### PR TITLE
[BE-001] Scaffold Bun Hono TypeScript backend

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,3 @@
+dist
+coverage
+*.log

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,13 @@
+# vinicius.dev Backend
+
+Bun + Hono + TypeScript backend scaffold for Wave 2.
+
+## Commands
+- `bun install`
+- `bun run dev`
+- `bun run typecheck`
+- `bun test`
+- `bun run build`
+
+## Scope
+This package starts as the BE-001 scaffold only. Domain modules, adapters, persistence, media, auth, admin, and chat behavior are introduced by later Wave 2 tasks.

--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -1,0 +1,29 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@vinicius-dev/backend",
+      "dependencies": {
+        "hono": "^4.6.17",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.1.14",
+        "typescript": "^5.7.2",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@vinicius-dev/backend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun --watch src/bootstrap/server.ts",
+    "start": "bun src/bootstrap/server.ts",
+    "build": "bun build src/bootstrap/server.ts --target bun --outdir dist",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "hono": "^4.6.17"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.1.14",
+    "typescript": "^5.7.2"
+  }
+}

--- a/backend/src/bootstrap/server.test.ts
+++ b/backend/src/bootstrap/server.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+
+import { createServer } from "./server";
+
+describe("backend server scaffold", () => {
+  it("responds to the health route", async () => {
+    const app = createServer();
+    const response = await app.request("/health");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      service: "vinicius.dev-backend",
+      status: "ok",
+    });
+  });
+});

--- a/backend/src/bootstrap/server.ts
+++ b/backend/src/bootstrap/server.ts
@@ -1,0 +1,29 @@
+import { Hono } from "hono";
+
+export const createServer = () => {
+  const app = new Hono();
+
+  app.get("/health", (c) =>
+    c.json({
+      service: "vinicius.dev-backend",
+      status: "ok",
+    }),
+  );
+
+  return app;
+};
+
+const app = createServer();
+
+if (import.meta.main) {
+  const port = Number(Bun.env.PORT ?? 3000);
+
+  Bun.serve({
+    fetch: app.fetch,
+    port,
+  });
+
+  console.info(`vinicius.dev backend listening on :${port}`);
+}
+
+export default app;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["bun"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
Scaffold the backend package for Wave 2 Cluster 1.

## Changes
- Adds `backend/package.json` with Bun scripts for dev, start, build, typecheck, and test.
- Adds Hono, TypeScript, and Bun type dependencies.
- Adds a minimal Hono health-check server under `backend/src/bootstrap/server.ts`.
- Adds a smoke test for the scaffold.
- Adds backend README, TypeScript config, and backend-local ignore file.

## Scope Boundaries
No product APIs, domain modules, Prisma, media storage, auth, admin, chat, Docker, CI workflow, or frontend runtime changes.

## Verification
- `cd backend && bun run typecheck`
- `cd backend && bun test`
- `cd backend && bun run build`
- `bun scripts/frontend-analyzer.ts --output=/tmp/vinicius-dev-frontend-analyzer-be001.md`

Closes #15