### PR TITLE
[BE-003] Add Hono /api HTTP adapter shell

### DIFF
--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -1,0 +1,72 @@
+import { Hono } from "hono";
+
+const serviceName = "vinicius.dev-backend";
+
+type NotImplementedResponse = {
+  family: string;
+  method: string;
+  route: string;
+  service: string;
+  status: "not_implemented";
+};
+
+const createNotImplementedFamily = (family: string) => {
+  const familyApp = new Hono();
+
+  familyApp.all("*", (c) =>
+    c.json<NotImplementedResponse>(
+      {
+        family,
+        method: c.req.method,
+        route: c.req.path,
+        service: serviceName,
+        status: "not_implemented",
+      },
+      501,
+    ),
+  );
+
+  return familyApp;
+};
+
+const mountPlaceholderFamily = (app: Hono, path: string, family: string) => {
+  app.route(path, createNotImplementedFamily(family));
+};
+
+export const createHonoHttpAdapter = () => {
+  const app = new Hono();
+
+  app.get("/api", (c) =>
+    c.json({
+      route: "/api",
+      service: serviceName,
+      status: "ok",
+      surface: "hono-http-adapter-shell",
+    }),
+  );
+
+  mountPlaceholderFamily(app, "/api/thoughts", "public content");
+  mountPlaceholderFamily(app, "/api/projects", "public content");
+  mountPlaceholderFamily(app, "/api/photos", "public content");
+  mountPlaceholderFamily(app, "/api/status-strip", "status strip");
+  mountPlaceholderFamily(app, "/api/chat", "chat");
+  mountPlaceholderFamily(app, "/api/admin", "admin");
+  mountPlaceholderFamily(app, "/api/auth", "auth");
+  mountPlaceholderFamily(app, "/api/rss", "rss");
+  mountPlaceholderFamily(app, "/api/sitemap", "sitemap");
+
+  app.get("/media/photos/:id/original", (c) =>
+    c.json<NotImplementedResponse>(
+      {
+        family: "photo media",
+        method: c.req.method,
+        route: c.req.path,
+        service: serviceName,
+        status: "not_implemented",
+      },
+      501,
+    ),
+  );
+
+  return app;
+};

--- a/backend/src/bootstrap/server.test.ts
+++ b/backend/src/bootstrap/server.test.ts
@@ -13,4 +13,42 @@ describe("backend server scaffold", () => {
       status: "ok",
     });
   });
+
+  it("mounts the /api shell and placeholder route families", async () => {
+    const app = createServer();
+
+    const shellResponse = await app.request("/api");
+    expect(shellResponse.status).toBe(200);
+    await expect(shellResponse.json()).resolves.toEqual({
+      route: "/api",
+      service: "vinicius.dev-backend",
+      status: "ok",
+      surface: "hono-http-adapter-shell",
+    });
+
+    const placeholderRoutes = [
+      ["/api/thoughts", "public content"],
+      ["/api/projects", "public content"],
+      ["/api/photos", "public content"],
+      ["/api/status-strip", "status strip"],
+      ["/api/chat", "chat"],
+      ["/api/admin", "admin"],
+      ["/api/auth", "auth"],
+      ["/api/rss", "rss"],
+      ["/api/sitemap", "sitemap"],
+      ["/media/photos/123/original", "photo media"],
+    ] as const;
+
+    for (const [path, family] of placeholderRoutes) {
+      const response = await app.request(path);
+
+      expect(response.status).toBe(501);
+      await expect(response.json()).resolves.toMatchObject({
+        family,
+        route: path,
+        service: "vinicius.dev-backend",
+        status: "not_implemented",
+      });
+    }
+  });
 });

--- a/backend/src/bootstrap/server.ts
+++ b/backend/src/bootstrap/server.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
 
+import { createHonoHttpAdapter } from "../adapters/inbound/http/hono/http-adapter";
+
 export const createServer = () => {
   const app = new Hono();
 
@@ -9,6 +11,8 @@ export const createServer = () => {
       status: "ok",
     }),
   );
+
+  app.route("/", createHonoHttpAdapter());
 
   return app;
 };


### PR DESCRIPTION
## Summary\nAdd the Hono HTTP adapter shell for the backend foundation.\n\n## Scope\n- mount frontend-facing routes under /api\n- add placeholder route families for public content, status strip, chat, admin, auth, RSS, and sitemap\n- add a placeholder public media route for /media/photos/:id/original\n- preserve /health in bootstrap\n\n## Verification\n- bun run typecheck\n- bun test\n- bun run build\n- bun scripts/frontend-analyzer.ts --output=/tmp/vinicius-dev-frontend-analyzer-be003.md