### PR TITLE
[BE-005] Add backend verification and boundary check scripts

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -8,6 +8,10 @@ Bun + Hono + TypeScript backend scaffold for Wave 2.
 - `bun run typecheck`
 - `bun test`
 - `bun run build`
+- `bun run verify`
+- `bun run verify:boundary`
+
+`bun run verify` runs the backend boundary check and the frontend analyzer in non-mutating mode, writing the analyzer output to `/tmp/vinicius-dev-frontend-analyzer-be005.md`.
 
 ## Scope
 This package starts as the BE-001 scaffold only. Domain modules, adapters, persistence, media, auth, admin, and chat behavior are introduced by later Wave 2 tasks.

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,9 @@
     "start": "bun src/bootstrap/server.ts",
     "build": "bun build src/bootstrap/server.ts --target bun --outdir dist",
     "typecheck": "tsc --noEmit",
-    "test": "bun test"
+    "test": "bun test",
+    "verify:boundary": "bun scripts/boundary-check.ts",
+    "verify": "bun scripts/verify.ts"
   },
   "dependencies": {
     "hono": "^4.6.17"

--- a/backend/scripts/boundary-check.test.ts
+++ b/backend/scripts/boundary-check.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { checkBoundaryViolations } from "./boundary-check";
+
+async function makeTempBackend(files: Record<string, string>): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vinicius-dev-be-boundary-"));
+  await fs.mkdir(path.join(root, "src", "modules"), { recursive: true });
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const absolutePath = path.join(root, relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, content, "utf8");
+  }
+
+  return root;
+}
+
+describe("backend boundary check", () => {
+  it("passes when no core modules exist yet", async () => {
+    const root = await makeTempBackend({
+      "src/bootstrap/server.ts": "export {};\n",
+    });
+
+    await expect(checkBoundaryViolations(root)).resolves.toEqual([]);
+  });
+
+  it("flags forbidden core-module imports", async () => {
+    const root = await makeTempBackend({
+      "src/modules/content/application/use-case.ts": [
+        'import { Hono } from "hono";',
+        'import { PrismaClient } from "@prisma/client";',
+        'import { readFile } from "node:fs/promises";',
+        'import { repo } from "@/adapters/outbound/persistence/prisma";',
+        "",
+      ].join("\n"),
+    });
+
+    await expect(checkBoundaryViolations(root)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ importPath: "hono", reason: "Hono framework" }),
+        expect.objectContaining({ importPath: "@prisma/client", reason: "Prisma" }),
+        expect.objectContaining({ importPath: "node:fs/promises", reason: "filesystem" }),
+        expect.objectContaining({ importPath: "@/adapters/outbound/persistence/prisma", reason: "provider adapter" }),
+      ]),
+    );
+  });
+});

--- a/backend/scripts/boundary-check.ts
+++ b/backend/scripts/boundary-check.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env bun
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+type BoundaryViolation = {
+  file: string;
+  importPath: string;
+  reason: string;
+};
+
+const BACKEND_ROOT = path.resolve(import.meta.dir, "..");
+const SOURCE_ROOT = path.join(BACKEND_ROOT, "src");
+const MODULES_ROOT = path.join(SOURCE_ROOT, "modules");
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx"]);
+
+function toPosix(value: string): string {
+  return value.replaceAll("\\", "/");
+}
+
+async function exists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function walk(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.name === "node_modules" || entry.name === "dist") continue;
+
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walk(fullPath)));
+      continue;
+    }
+
+    if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+async function readText(filePath: string): Promise<string> {
+  return fs.readFile(filePath, "utf8");
+}
+
+function extractImportSpecifiers(source: string): string[] {
+  const specifiers = new Set<string>();
+  const patterns = [
+    /(?:^|\n)\s*import(?:\s+type)?(?:[\s\S]*?\sfrom\s*)?["']([^"']+)["']/g,
+    /(?:^|\n)\s*export(?:\s+type)?(?:[\s\S]*?\sfrom\s*)?["']([^"']+)["']/g,
+    /import\s*\(\s*["']([^"']+)["']\s*\)/g,
+    /require\s*\(\s*["']([^"']+)["']\s*\)/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      specifiers.add(match[1]);
+    }
+  }
+
+  return [...specifiers];
+}
+
+function classifyImport(importPath: string, filePath: string): string | null {
+  const normalized = toPosix(importPath);
+  const importerDir = path.dirname(filePath);
+
+  if (
+    normalized === "hono" ||
+    normalized.startsWith("hono/") ||
+    normalized.includes("/hono/")
+  ) {
+    return "Hono framework";
+  }
+
+  if (
+    normalized === "@prisma/client" ||
+    normalized.startsWith("@prisma/client/") ||
+    normalized.includes("/prisma/") ||
+    normalized === "prisma"
+  ) {
+    return "Prisma";
+  }
+
+  if (
+    normalized === "fs" ||
+    normalized === "fs/promises" ||
+    normalized === "node:fs" ||
+    normalized === "node:fs/promises" ||
+    normalized.startsWith("node:fs/") ||
+    normalized.startsWith("fs/")
+  ) {
+    return "filesystem";
+  }
+
+  const adapterPatterns = [
+    /(^|\/)adapters(\/|$)/,
+    /(^|\/)bootstrap(\/|$)/,
+  ];
+
+  if (normalized.startsWith("@/")) {
+    const mapped = path.resolve(SOURCE_ROOT, normalized.slice(2));
+    const mappedRelative = toPosix(path.relative(SOURCE_ROOT, mapped));
+    if (adapterPatterns.some((pattern) => pattern.test(mappedRelative))) {
+      return "provider adapter";
+    }
+  }
+
+  if (normalized.startsWith(".")) {
+    const resolved = path.resolve(importerDir, normalized);
+    const resolvedRelative = toPosix(path.relative(SOURCE_ROOT, resolved));
+    if (adapterPatterns.some((pattern) => pattern.test(resolvedRelative))) {
+      return "provider adapter";
+    }
+  }
+
+  if (normalized.includes("/adapters/") || normalized.includes("/bootstrap/")) {
+    return "provider adapter";
+  }
+
+  return null;
+}
+
+export async function checkBoundaryViolations(rootDir = BACKEND_ROOT): Promise<BoundaryViolation[]> {
+  const modulesDir = path.join(rootDir, "src", "modules");
+  if (!(await exists(modulesDir))) return [];
+
+  const sourceFiles = (await walk(modulesDir)).filter((file) => !/\.(test|spec)\.[tj]sx?$/.test(file));
+  const violations: BoundaryViolation[] = [];
+
+  for (const filePath of sourceFiles) {
+    const source = await readText(filePath);
+    const imports = extractImportSpecifiers(source);
+
+    for (const importPath of imports) {
+      const reason = classifyImport(importPath, filePath);
+      if (!reason) continue;
+
+      violations.push({
+        file: toPosix(path.relative(rootDir, filePath)),
+        importPath,
+        reason,
+      });
+    }
+  }
+
+  return violations;
+}
+
+export async function main(): Promise<number> {
+  const violations = await checkBoundaryViolations();
+
+  if (violations.length === 0) {
+    console.log("Boundary check passed: no forbidden imports found in backend core modules.");
+    return 0;
+  }
+
+  console.error("Boundary check failed:");
+  for (const violation of violations) {
+    console.error(`- ${violation.file}: ${violation.importPath} (${violation.reason})`);
+  }
+
+  return 1;
+}
+
+if (import.meta.main) {
+  const exitCode = await main();
+  process.exitCode = exitCode;
+}

--- a/backend/scripts/verify.ts
+++ b/backend/scripts/verify.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env bun
+
+import path from "node:path";
+
+import { checkBoundaryViolations } from "./boundary-check";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "../..");
+const FRONTEND_ANALYZER = path.join(REPO_ROOT, "scripts", "frontend-analyzer.ts");
+const FRONTEND_ANALYZER_OUTPUT = "/tmp/vinicius-dev-frontend-analyzer-be005.md";
+
+async function runFrontendAnalyzer(): Promise<number> {
+  console.log(`Running frontend analyzer to ${FRONTEND_ANALYZER_OUTPUT}`);
+  const proc = Bun.spawn([
+    "bun",
+    FRONTEND_ANALYZER,
+    `--output=${FRONTEND_ANALYZER_OUTPUT}`,
+  ], {
+    cwd: REPO_ROOT,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+
+  return await proc.exited;
+}
+
+export async function main(): Promise<number> {
+  const violations = await checkBoundaryViolations();
+  if (violations.length > 0) {
+    console.error("Backend boundary check failed:");
+    for (const violation of violations) {
+      console.error(`- ${violation.file}: ${violation.importPath} (${violation.reason})`);
+    }
+    return 1;
+  }
+
+  console.log("Backend boundary check passed.");
+  const analyzerExitCode = await runFrontendAnalyzer();
+  if (analyzerExitCode !== 0) return analyzerExitCode;
+
+  console.log("Backend verification passed.");
+  return 0;
+}
+
+if (import.meta.main) {
+  const exitCode = await main();
+  process.exitCode = exitCode;
+}


### PR DESCRIPTION
## Summary
Add Bun-based backend verification scripts, a core-module boundary scanner, and backend-only analyzer validation that writes to `/tmp`.

## Checks
- `bun run typecheck`
- `bun test`
- `bun run build`
- `bun run verify`
- `bun run verify:boundary`
- `bun scripts/frontend-analyzer.ts --output=/tmp/vinicius-dev-frontend-analyzer-be005.md`

## Notes
The backend `verify` command runs the boundary check and the frontend analyzer in non-mutating mode.