### PR TITLE
[BE-004] Add backend config and bootstrap composition root

### DIFF
--- a/backend/src/bootstrap/config/bootstrap-config.test.ts
+++ b/backend/src/bootstrap/config/bootstrap-config.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+
+import { loadBootstrapConfig } from "./bootstrap-config";
+
+describe("bootstrap config", () => {
+  it("loads defaults for runtime placeholders", () => {
+    const config = loadBootstrapConfig({});
+
+    expect(config).toEqual({
+      auth: {
+        mfaCodeMaxAgeSeconds: 600,
+        roomPasswordSecret: "development-room-password-secret",
+        sessionCookieName: "vinicius.dev-session",
+        sessionMaxAgeSeconds: 604800,
+        sessionSecret: "development-session-secret",
+      },
+      cors: {
+        allowCredentials: true,
+        allowedOrigins: [],
+      },
+      media: {
+        chatRoot: "/var/lib/vinicius.dev/media/chat",
+        chatUploadAllowedMimeTypes: [
+          "image/jpeg",
+          "image/png",
+          "image/webp",
+        ],
+        chatUploadMaxBytes: 5 * 1024 * 1024,
+        chatUploadMaxFilesPerMessage: 1,
+        photosRoot: "/var/lib/vinicius.dev/media/photos",
+        publicUrlBase: "/media",
+      },
+      server: {
+        apiBasePath: "/api",
+        mediaPhotoOriginalPath: "/media/photos/:id/original",
+        nodeEnv: "development",
+        port: 3000,
+      },
+    });
+  });
+
+  it("applies environment overrides for runtime config", () => {
+    const config = loadBootstrapConfig({
+      AUTH_MFA_CODE_MAX_AGE_SECONDS: "120",
+      AUTH_ROOM_PASSWORD_SECRET: "room-secret",
+      AUTH_SESSION_COOKIE_NAME: "session-cookie",
+      AUTH_SESSION_MAX_AGE_SECONDS: "3600",
+      AUTH_SESSION_SECRET: "session-secret",
+      CHAT_UPLOAD_ALLOWED_MIME_TYPES: "image/jpeg,image/png",
+      CHAT_UPLOAD_MAX_BYTES: "1048576",
+      CHAT_UPLOAD_MAX_FILES_PER_MESSAGE: "1",
+      CORS_ALLOW_CREDENTIALS: "false",
+      CORS_ALLOWED_ORIGINS: "http://localhost:5173, https://example.com",
+      MEDIA_CHAT_ROOT: "/tmp/chat",
+      MEDIA_PHOTOS_ROOT: "/tmp/photos",
+      MEDIA_PUBLIC_URL_BASE: "https://media.example.com",
+      NODE_ENV: "production",
+      PORT: "4321",
+    });
+
+    expect(config.server.port).toBe(4321);
+    expect(config.server.nodeEnv).toBe("production");
+    expect(config.media.photosRoot).toBe("/tmp/photos");
+    expect(config.media.chatRoot).toBe("/tmp/chat");
+    expect(config.media.chatUploadMaxBytes).toBe(1048576);
+    expect(config.media.chatUploadAllowedMimeTypes).toEqual([
+      "image/jpeg",
+      "image/png",
+    ]);
+    expect(config.auth.sessionSecret).toBe("session-secret");
+    expect(config.auth.sessionCookieName).toBe("session-cookie");
+    expect(config.auth.sessionMaxAgeSeconds).toBe(3600);
+    expect(config.auth.mfaCodeMaxAgeSeconds).toBe(120);
+    expect(config.auth.roomPasswordSecret).toBe("room-secret");
+    expect(config.cors.allowCredentials).toBe(false);
+    expect(config.cors.allowedOrigins).toEqual([
+      "http://localhost:5173",
+      "https://example.com",
+    ]);
+    expect(config.media.publicUrlBase).toBe("https://media.example.com");
+  });
+});

--- a/backend/src/bootstrap/config/bootstrap-config.ts
+++ b/backend/src/bootstrap/config/bootstrap-config.ts
@@ -1,0 +1,180 @@
+export const API_BASE_PATH = "/api" as const;
+export const MEDIA_PHOTO_ORIGINAL_PATH = "/media/photos/:id/original" as const;
+
+const DEFAULT_PORT = 3000;
+const DEFAULT_NODE_ENV = "development";
+const DEFAULT_MEDIA_PHOTOS_ROOT = "/var/lib/vinicius.dev/media/photos";
+const DEFAULT_MEDIA_CHAT_ROOT = "/var/lib/vinicius.dev/media/chat";
+const DEFAULT_MEDIA_PUBLIC_URL_BASE = "/media";
+const DEFAULT_CHAT_UPLOAD_MAX_BYTES = 5 * 1024 * 1024;
+const DEFAULT_CHAT_UPLOAD_ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+];
+const DEFAULT_CHAT_UPLOAD_MAX_FILES_PER_MESSAGE = 1;
+const DEFAULT_SESSION_SECRET = "development-session-secret";
+const DEFAULT_SESSION_COOKIE_NAME = "vinicius.dev-session";
+const DEFAULT_SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7;
+const DEFAULT_MFA_CODE_MAX_AGE_SECONDS = 60 * 10;
+const DEFAULT_ROOM_PASSWORD_SECRET = "development-room-password-secret";
+
+export type NodeEnv = "development" | "test" | "production";
+
+export type BootstrapConfig = {
+  auth: {
+    mfaCodeMaxAgeSeconds: number;
+    roomPasswordSecret: string;
+    sessionCookieName: string;
+    sessionMaxAgeSeconds: number;
+    sessionSecret: string;
+  };
+  cors: {
+    allowCredentials: boolean;
+    allowedOrigins: string[];
+  };
+  media: {
+    chatRoot: string;
+    chatUploadAllowedMimeTypes: string[];
+    chatUploadMaxBytes: number;
+    chatUploadMaxFilesPerMessage: number;
+    photosRoot: string;
+    publicUrlBase: string;
+  };
+  server: {
+    apiBasePath: typeof API_BASE_PATH;
+    mediaPhotoOriginalPath: typeof MEDIA_PHOTO_ORIGINAL_PATH;
+    nodeEnv: NodeEnv;
+    port: number;
+  };
+};
+
+type BootstrapEnv = Readonly<Record<string, string | undefined>>;
+
+const parsePort = (value: string | undefined) => {
+  if (value === undefined || value === "") {
+    return DEFAULT_PORT;
+  }
+
+  const port = Number(value);
+
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid PORT value: ${value}`);
+  }
+
+  return port;
+};
+
+const parseNodeEnv = (value: string | undefined): NodeEnv => {
+  if (value === undefined || value === "") {
+    return DEFAULT_NODE_ENV;
+  }
+
+  if (value === "development" || value === "test" || value === "production") {
+    return value;
+  }
+
+  throw new Error(`Invalid NODE_ENV value: ${value}`);
+};
+
+const parseInteger = (value: string | undefined, fallback: number, name: string) => {
+  if (value === undefined || value === "") {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid ${name} value: ${value}`);
+  }
+
+  return parsed;
+};
+
+const parseBoolean = (value: string | undefined, fallback: boolean) => {
+  if (value === undefined || value === "") {
+    return fallback;
+  }
+
+  if (value === "true") {
+    return true;
+  }
+
+  if (value === "false") {
+    return false;
+  }
+
+  throw new Error(`Invalid boolean value: ${value}`);
+};
+
+const parseList = (value: string | undefined, fallback: string[]) => {
+  if (value === undefined || value.trim() === "") {
+    return fallback;
+  }
+
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+};
+
+const parseString = (value: string | undefined, fallback: string) =>
+  value === undefined || value === "" ? fallback : value;
+
+export const loadBootstrapConfig = (
+  env: BootstrapEnv = Bun.env,
+): BootstrapConfig => ({
+  auth: {
+    mfaCodeMaxAgeSeconds: parseInteger(
+      env.AUTH_MFA_CODE_MAX_AGE_SECONDS,
+      DEFAULT_MFA_CODE_MAX_AGE_SECONDS,
+      "AUTH_MFA_CODE_MAX_AGE_SECONDS",
+    ),
+    roomPasswordSecret: parseString(
+      env.AUTH_ROOM_PASSWORD_SECRET,
+      DEFAULT_ROOM_PASSWORD_SECRET,
+    ),
+    sessionCookieName: parseString(
+      env.AUTH_SESSION_COOKIE_NAME,
+      DEFAULT_SESSION_COOKIE_NAME,
+    ),
+    sessionMaxAgeSeconds: parseInteger(
+      env.AUTH_SESSION_MAX_AGE_SECONDS,
+      DEFAULT_SESSION_MAX_AGE_SECONDS,
+      "AUTH_SESSION_MAX_AGE_SECONDS",
+    ),
+    sessionSecret: parseString(env.AUTH_SESSION_SECRET, DEFAULT_SESSION_SECRET),
+  },
+  cors: {
+    allowCredentials: parseBoolean(env.CORS_ALLOW_CREDENTIALS, true),
+    allowedOrigins: parseList(env.CORS_ALLOWED_ORIGINS, []),
+  },
+  media: {
+    chatRoot: parseString(env.MEDIA_CHAT_ROOT, DEFAULT_MEDIA_CHAT_ROOT),
+    chatUploadAllowedMimeTypes: parseList(
+      env.CHAT_UPLOAD_ALLOWED_MIME_TYPES,
+      DEFAULT_CHAT_UPLOAD_ALLOWED_MIME_TYPES,
+    ),
+    chatUploadMaxBytes: parseInteger(
+      env.CHAT_UPLOAD_MAX_BYTES,
+      DEFAULT_CHAT_UPLOAD_MAX_BYTES,
+      "CHAT_UPLOAD_MAX_BYTES",
+    ),
+    chatUploadMaxFilesPerMessage: parseInteger(
+      env.CHAT_UPLOAD_MAX_FILES_PER_MESSAGE,
+      DEFAULT_CHAT_UPLOAD_MAX_FILES_PER_MESSAGE,
+      "CHAT_UPLOAD_MAX_FILES_PER_MESSAGE",
+    ),
+    photosRoot: parseString(env.MEDIA_PHOTOS_ROOT, DEFAULT_MEDIA_PHOTOS_ROOT),
+    publicUrlBase: parseString(
+      env.MEDIA_PUBLIC_URL_BASE,
+      DEFAULT_MEDIA_PUBLIC_URL_BASE,
+    ),
+  },
+  server: {
+    apiBasePath: API_BASE_PATH,
+    mediaPhotoOriginalPath: MEDIA_PHOTO_ORIGINAL_PATH,
+    nodeEnv: parseNodeEnv(env.NODE_ENV),
+    port: parsePort(env.PORT),
+  },
+});

--- a/backend/src/bootstrap/config/index.ts
+++ b/backend/src/bootstrap/config/index.ts
@@ -1,0 +1,7 @@
+export {
+  API_BASE_PATH,
+  MEDIA_PHOTO_ORIGINAL_PATH,
+  loadBootstrapConfig,
+  type BootstrapConfig,
+  type NodeEnv,
+} from "./bootstrap-config";

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -1,0 +1,13 @@
+import { loadBootstrapConfig, type BootstrapConfig } from "../config";
+
+export type BootstrapContainer = Readonly<{
+  config: BootstrapConfig;
+}>;
+
+type BootstrapEnv = Readonly<Record<string, string | undefined>>;
+
+export const createContainer = (
+  env: BootstrapEnv = Bun.env,
+): BootstrapContainer => ({
+  config: loadBootstrapConfig(env),
+});

--- a/backend/src/bootstrap/container/index.ts
+++ b/backend/src/bootstrap/container/index.ts
@@ -1,0 +1,1 @@
+export { createContainer, type BootstrapContainer } from "./create-container";

--- a/backend/src/bootstrap/server.ts
+++ b/backend/src/bootstrap/server.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
 
+import { createContainer } from "./container";
+
 export const createServer = () => {
   const app = new Hono();
 
@@ -13,17 +15,16 @@ export const createServer = () => {
   return app;
 };
 
+const container = createContainer();
 const app = createServer();
 
 if (import.meta.main) {
-  const port = Number(Bun.env.PORT ?? 3000);
-
   Bun.serve({
     fetch: app.fetch,
-    port,
+    port: container.config.server.port,
   });
 
-  console.info(`vinicius.dev backend listening on :${port}`);
+  console.info(`vinicius.dev backend listening on :${container.config.server.port}`);
 }
 
 export default app;


### PR DESCRIPTION
## Summary\n- Add bootstrap config parsing for server, media, auth/session, and CORS placeholders.\n- Add a minimal bootstrap composition container that returns config.\n- Wire the runtime entrypoint to start from configured bootstrap config.\n\n## Checks\n- bun run typecheck\n- bun test\n- bun run build\n- bun scripts/frontend-analyzer.ts --output=/tmp/vinicius-dev-frontend-analyzer-be004.md\n\n## Notes\n- Scope stays within backend/src/bootstrap/config/**, backend/src/bootstrap/container/**, and minimal bootstrap/server.ts wiring.