### PR TITLE
[SPEC-021] Define Wave 2 persistence cluster

### DIFF
--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -69,11 +69,12 @@
 - Integrated verification: backend typecheck, tests, build, and `bun run verify` passed on `develop`.
 
 ### Wave 2 Cluster 2 Persistence Foundation
-- Status: next cluster to define.
+- Status: ready for issue creation and implementation.
 - Primary specs: `SPEC-007`, `SPEC-006`, `SPEC-011`, `SPEC-016`, `SPEC-018`.
 - Scope: Prisma/Postgres setup, migration baseline, repository adapter patterns, schema for approved first-class entities, and seed strategy.
 - Non-scope: public endpoint behavior, media binary storage, admin auth flows, chat room behavior, Docker/Caddy deployment, and production CI workflows.
-- Required ordering: task definition must happen before implementation; split one issue, one branch, and one acceptance source per persistence task.
+- Tasks: `DATA-001`, `DATA-002`, `DATA-003`, `DATA-004`, and `DATA-005`.
+- Required ordering: `DATA-001` first; `DATA-002` after `DATA-001`; `DATA-003` after `DATA-002`; `DATA-004` after `DATA-002`; `DATA-005` after `DATA-002` and `DATA-003`.
 
 ### Frontend Migration Wave 1
 - Status: complete after FE-010 analyzer reconciliation.

--- a/docs/specs/wave-2-task-clusters.md
+++ b/docs/specs/wave-2-task-clusters.md
@@ -54,21 +54,56 @@ Complete. `BE-001`, `BE-002`, `BE-003`, `BE-004`, and `BE-005` were implemented,
 - Production GitHub Actions workflow YAML.
 
 ## Future Clusters
-- Cluster 2 persistence splits by Prisma setup, repository adapter patterns, data model migrations, and seed strategy. This is the next cluster to define.
 - Cluster 3 public content splits by Thoughts, Projects, Photos, Status Strip, RSS, and sitemap.
 - Cluster 4 media splits by public photo delivery, filesystem storage adapter, chat upload validation/storage, and moderation retention.
 - Cluster 5 admin splits by auth/MFA/session, admin dashboard contracts, content CRUD, curation, and status strip editing.
 - Cluster 6 chat splits by room gate, handle/session state, message archive, participant state, image attachment flow, moderation commands, and audit records.
 - Cluster 7 infra/CI/verification splits by Docker service layout, Caddy routing, env/volume policy, GitHub Actions validation, deploy workflow, and cross-layer tests.
 
+## Cluster 2: Persistence Foundation
+### Goal
+Create the Prisma/Postgres persistence foundation and schema baseline needed before public content, media, admin, or chat behavior can use durable state.
+
+### Status
+Ready for issue creation and implementation.
+
+### Tasks
+| Task ID | Title | Layer | Base Branch | Branch Name | Merge Target | Source Specs | Acceptance Source |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| DATA-001 | Add Prisma Postgres tooling baseline | data | develop | data/DATA-001-prisma-postgres-baseline | develop | SPEC-007, SPEC-016, SPEC-018 | data-model.md, project-structure.md, ci-cd.md |
+| DATA-002 | Model public content and status strip schema | data | develop | data/DATA-002-public-content-status-schema | develop | SPEC-006, SPEC-007, SPEC-011 | data-model.md, backend-architecture.md, verification.md |
+| DATA-003 | Model auth chat media and audit schema | data | develop | data/DATA-003-auth-chat-media-audit-schema | develop | SPEC-007, SPEC-008, SPEC-009, SPEC-011 | data-model.md, media-storage.md, admin-cms.md, verification.md |
+| DATA-004 | Add repository port and Prisma adapter patterns | data | develop | data/DATA-004-repository-prisma-adapter-patterns | develop | SPEC-006, SPEC-007, SPEC-016 | backend-architecture.md, data-model.md, project-structure.md |
+| DATA-005 | Add seed and migration verification workflow | data | develop | data/DATA-005-seed-migration-verification | develop | SPEC-007, SPEC-011, SPEC-018 | data-model.md, verification.md, ci-cd.md |
+
+### Dependency Rules
+- `DATA-001` runs first.
+- `DATA-002` starts only after `DATA-001` lands on `develop`.
+- `DATA-003` starts only after `DATA-002` lands on `develop` because both own the Prisma schema.
+- `DATA-004` starts only after `DATA-002` and may be finalized after `DATA-003` if adapter tests need auth/chat/media models.
+- `DATA-005` starts only after `DATA-002` and `DATA-003` land on `develop`.
+- No Cluster 3 public content API tasks start until Cluster 2 is merged and validated.
+
+### Non-Scope
+- Public HTTP endpoint behavior.
+- Content CRUD use cases.
+- Media binary storage and file serving.
+- Admin authentication/session behavior.
+- Chat room join/send/moderation behavior.
+- Docker/Caddy deployment descriptors.
+- Production GitHub Actions workflow YAML.
+
 ## Acceptance Checklist
 - [ ] Cluster order follows the approved Wave 2 dependency sequence.
 - [ ] Cluster 1 tasks each have one task ID, branch, issue, Project item, and acceptance source.
 - [ ] Cluster 1 does not include persistence, media, admin, chat, infra deployment, or production CI implementation.
 - [ ] Backend foundation tasks cite approved specs and branch rules.
+- [ ] Cluster 2 tasks each have one task ID, branch, issue, Project item, and acceptance source.
+- [ ] Cluster 2 keeps Prisma schema edits sequential to avoid merge conflicts.
 - [ ] Future clusters remain blocked until their dependencies land.
 
 ## Git Branch Implications
 - Cluster definition changes use `spec/` branches.
 - Cluster 1 implementation uses `backend/` branches.
+- Cluster 2 implementation uses `data/` branches.
 - Future infra-only work uses `infra/` branches and future verification-only work may use `qa/` branches if the harness adopts that prefix; until then, use the closest approved prefix from `git-workflow.md`.


### PR DESCRIPTION
## Summary
Define Wave 2 Cluster 2 persistence foundation.

## Changes
- Adds DATA-001 through DATA-005 to `docs/specs/wave-2-task-clusters.md`.
- Updates `docs/specs/tracker.md` to mark Cluster 2 ready for task creation and implementation.
- Documents dependency order and non-scope to keep Prisma schema edits sequential and avoid product/API drift.

## Verification
- `git diff --check`