### PR TITLE
[DATA-004] Add repository port and Prisma adapter patterns

### DIFF
--- a/backend/src/adapters/outbound/persistence/index.ts
+++ b/backend/src/adapters/outbound/persistence/index.ts
@@ -1,0 +1,1 @@
+export * from "./prisma";

--- a/backend/src/adapters/outbound/persistence/prisma/admin-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/admin-repository.ts
@@ -1,0 +1,21 @@
+import type {
+  AdminMfaChallengeRepositoryRow,
+  AdminRepositoryPort,
+  AdminSessionRepositoryRow,
+  AdminUserRepositoryRow,
+} from "@/modules/admin/ports/outbound";
+
+import type { PrismaDatabaseClient } from "./prisma-client";
+
+const notImplemented = <T>(method: string): Promise<T> => {
+  return Promise.reject(new Error(`Prisma admin repository method not implemented: ${method}`));
+};
+
+export const createPrismaAdminRepository = (_client: PrismaDatabaseClient): AdminRepositoryPort => ({
+  findAdminUserByEmail: (_email: string): Promise<AdminUserRepositoryRow | null> =>
+    notImplemented("findAdminUserByEmail"),
+  findAdminSessionByTokenHash: (_tokenHash: string): Promise<AdminSessionRepositoryRow | null> =>
+    notImplemented("findAdminSessionByTokenHash"),
+  findMfaChallengeById: (_challengeId: string): Promise<AdminMfaChallengeRepositoryRow | null> =>
+    notImplemented("findMfaChallengeById"),
+});

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
@@ -1,0 +1,25 @@
+import type {
+  ChatHandleRepositoryRow,
+  ChatMessageListQuery,
+  ChatMessageRepositoryRow,
+  ChatRepositoryPort,
+  ChatRoomRepositoryRow,
+  ChatUploadRepositoryRow,
+} from "@/modules/chat/ports/outbound";
+
+import type { PrismaDatabaseClient } from "./prisma-client";
+
+const notImplemented = <T>(method: string): Promise<T> => {
+  return Promise.reject(new Error(`Prisma chat repository method not implemented: ${method}`));
+};
+
+export const createPrismaChatRepository = (_client: PrismaDatabaseClient): ChatRepositoryPort => ({
+  findRoomBySlug: (_query): Promise<ChatRoomRepositoryRow | null> =>
+    notImplemented("findRoomBySlug"),
+  findHandleByRoomIdAndNormalizedHandle: (_roomId, _normalizedHandle): Promise<ChatHandleRepositoryRow | null> =>
+    notImplemented("findHandleByRoomIdAndNormalizedHandle"),
+  listMessages: (_query: ChatMessageListQuery): Promise<readonly ChatMessageRepositoryRow[]> =>
+    notImplemented("listMessages"),
+  findUploadById: (_uploadId: string): Promise<ChatUploadRepositoryRow | null> =>
+    notImplemented("findUploadById"),
+});

--- a/backend/src/adapters/outbound/persistence/prisma/content-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/content-repository.ts
@@ -1,0 +1,27 @@
+import type {
+  ContentRepositoryPort,
+  PhotoListQuery,
+  PhotoRepositoryRow,
+  ProjectListQuery,
+  ProjectRepositoryRow,
+  StatusStripEntryRepositoryRow,
+  ThoughtListQuery,
+  ThoughtRepositoryRow,
+} from "@/modules/content/ports/outbound";
+
+import type { PrismaDatabaseClient } from "./prisma-client";
+
+const notImplemented = <T>(method: string): Promise<T> => {
+  return Promise.reject(new Error(`Prisma content repository method not implemented: ${method}`));
+};
+
+export const createPrismaContentRepository = (_client: PrismaDatabaseClient): ContentRepositoryPort => ({
+  findPublishedThoughts: (_query: ThoughtListQuery): Promise<readonly ThoughtRepositoryRow[]> =>
+    notImplemented("findPublishedThoughts"),
+  findPublishedProjects: (_query: ProjectListQuery): Promise<readonly ProjectRepositoryRow[]> =>
+    notImplemented("findPublishedProjects"),
+  findPublishedPhotos: (_query: PhotoListQuery): Promise<readonly PhotoRepositoryRow[]> =>
+    notImplemented("findPublishedPhotos"),
+  listStatusStripEntries: (): Promise<readonly StatusStripEntryRepositoryRow[]> =>
+    notImplemented("listStatusStripEntries"),
+});

--- a/backend/src/adapters/outbound/persistence/prisma/create-prisma-persistence-adapter.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/create-prisma-persistence-adapter.ts
@@ -1,0 +1,26 @@
+import type { AdminRepositoryPort } from "@/modules/admin/ports/outbound";
+import type { ChatRepositoryPort } from "@/modules/chat/ports/outbound";
+import type { ContentRepositoryPort } from "@/modules/content/ports/outbound";
+import type { MediaRepositoryPort } from "@/modules/media/ports/outbound";
+
+import { createPrismaAdminRepository } from "./admin-repository";
+import { createPrismaChatRepository } from "./chat-repository";
+import { createPrismaClient, type PrismaDatabaseClient } from "./prisma-client";
+import { createPrismaContentRepository } from "./content-repository";
+import { createPrismaMediaRepository } from "./media-repository";
+
+export type PrismaPersistenceAdapter = Readonly<{
+  content: ContentRepositoryPort;
+  chat: ChatRepositoryPort;
+  admin: AdminRepositoryPort;
+  media: MediaRepositoryPort;
+}>;
+
+export const createPrismaPersistenceAdapter = (
+  client: PrismaDatabaseClient = createPrismaClient(),
+): PrismaPersistenceAdapter => ({
+  content: createPrismaContentRepository(client),
+  chat: createPrismaChatRepository(client),
+  admin: createPrismaAdminRepository(client),
+  media: createPrismaMediaRepository(client),
+});

--- a/backend/src/adapters/outbound/persistence/prisma/index.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/index.ts
@@ -1,0 +1,6 @@
+export { createPrismaAdminRepository } from "./admin-repository";
+export { createPrismaChatRepository } from "./chat-repository";
+export { createPrismaClient, type PrismaDatabaseClient } from "./prisma-client";
+export { createPrismaContentRepository } from "./content-repository";
+export { createPrismaMediaRepository } from "./media-repository";
+export { createPrismaPersistenceAdapter, type PrismaPersistenceAdapter } from "./create-prisma-persistence-adapter";

--- a/backend/src/adapters/outbound/persistence/prisma/media-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/media-repository.ts
@@ -1,0 +1,18 @@
+import type {
+  ChatUploadMediaRepositoryRow,
+  MediaRepositoryPort,
+  PhotoMediaRepositoryRow,
+} from "@/modules/media/ports/outbound";
+
+import type { PrismaDatabaseClient } from "./prisma-client";
+
+const notImplemented = <T>(method: string): Promise<T> => {
+  return Promise.reject(new Error(`Prisma media repository method not implemented: ${method}`));
+};
+
+export const createPrismaMediaRepository = (_client: PrismaDatabaseClient): MediaRepositoryPort => ({
+  findPhotoMediaById: (_photoId: string): Promise<PhotoMediaRepositoryRow | null> =>
+    notImplemented("findPhotoMediaById"),
+  findChatUploadMediaById: (_uploadId: string): Promise<ChatUploadMediaRepositoryRow | null> =>
+    notImplemented("findChatUploadMediaById"),
+});

--- a/backend/src/adapters/outbound/persistence/prisma/prisma-client.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/prisma-client.ts
@@ -1,0 +1,5 @@
+import type { PrismaClient } from "../../../../../generated/prisma/client";
+
+export const createPrismaClient = (): PrismaDatabaseClient => ({} as PrismaDatabaseClient);
+
+export type PrismaDatabaseClient = PrismaClient;

--- a/backend/src/adapters/outbound/persistence/prisma/prisma-persistence-adapter.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/prisma-persistence-adapter.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+
+import { createPrismaPersistenceAdapter } from "./create-prisma-persistence-adapter";
+import { createPrismaClient } from "./prisma-client";
+
+describe("prisma persistence adapter", () => {
+  it("exposes module repository seams without wiring behavior", () => {
+    const adapter = createPrismaPersistenceAdapter(createPrismaClient());
+
+    expect(Object.keys(adapter).sort()).toEqual(["admin", "chat", "content", "media"]);
+    expect(typeof adapter.content.findPublishedThoughts).toBe("function");
+    expect(typeof adapter.chat.listMessages).toBe("function");
+    expect(typeof adapter.admin.findAdminUserByEmail).toBe("function");
+    expect(typeof adapter.media.findPhotoMediaById).toBe("function");
+  });
+});

--- a/backend/src/modules/admin/ports/outbound/index.ts
+++ b/backend/src/modules/admin/ports/outbound/index.ts
@@ -1,1 +1,42 @@
-export {};
+export type AdminUserRepositoryRow = Readonly<{
+  id: string;
+  email: string;
+  passwordHash: string;
+  passwordHashAlgorithm: string;
+  passwordHashParams: unknown | null;
+  createdAt: Date;
+  updatedAt: Date;
+}>;
+
+export type AdminSessionRepositoryRow = Readonly<{
+  id: string;
+  adminUserId: string;
+  tokenHash: string;
+  status: "active" | "revoked" | "expired";
+  issuedAt: Date;
+  expiresAt: Date;
+  revokedAt: Date | null;
+  lastSeenAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}>;
+
+export type AdminMfaChallengeRepositoryRow = Readonly<{
+  id: string;
+  adminUserId: string;
+  codeHash: string;
+  status: "pending" | "verified" | "expired" | "canceled";
+  sentAt: Date;
+  expiresAt: Date;
+  verifiedAt: Date | null;
+  canceledAt: Date | null;
+  attempts: number;
+  createdAt: Date;
+  updatedAt: Date;
+}>;
+
+export interface AdminRepositoryPort {
+  findAdminUserByEmail(email: string): Promise<AdminUserRepositoryRow | null>;
+  findAdminSessionByTokenHash(tokenHash: string): Promise<AdminSessionRepositoryRow | null>;
+  findMfaChallengeById(challengeId: string): Promise<AdminMfaChallengeRepositoryRow | null>;
+}

--- a/backend/src/modules/chat/ports/outbound/index.ts
+++ b/backend/src/modules/chat/ports/outbound/index.ts
@@ -1,1 +1,67 @@
-export {};
+export type ChatRoomRepositoryRow = Readonly<{
+  id: string;
+  slug: string;
+  passwordVersion: number;
+  passwordRotatedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}>;
+
+export type ChatHandleRepositoryRow = Readonly<{
+  id: string;
+  roomId: string;
+  handle: string;
+  normalizedHandle: string;
+  status: "active" | "banned";
+  createdAt: Date;
+  updatedAt: Date;
+}>;
+
+export type ChatMessageRepositoryRow = Readonly<{
+  id: string;
+  roomId: string;
+  roomSessionId: string;
+  authorHandleId: string;
+  body: string;
+  sentAt: Date;
+  tone: "cyan" | "pink" | "system" | null;
+  moderationState: "visible" | "hidden" | "deleted";
+  hiddenAt: Date | null;
+  deletedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}>;
+
+export type ChatUploadRepositoryRow = Readonly<{
+  id: string;
+  roomId: string;
+  displayFilename: string;
+  mimeType: "image/jpeg" | "image/png" | "image/webp";
+  byteSize: number;
+  kind: "image";
+  storageKey: string;
+  relatedMessageId: string | null;
+  moderationState: "visible" | "hidden" | "deleted";
+  hiddenAt: Date | null;
+  deletedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}>;
+
+export type ChatRoomQuery = Readonly<{
+  slug: string;
+}>;
+
+export type ChatMessageListQuery = Readonly<{
+  roomId: string;
+  roomSessionId?: string;
+  cursor?: string;
+  limit?: number;
+}>;
+
+export interface ChatRepositoryPort {
+  findRoomBySlug(query: ChatRoomQuery): Promise<ChatRoomRepositoryRow | null>;
+  findHandleByRoomIdAndNormalizedHandle(roomId: string, normalizedHandle: string): Promise<ChatHandleRepositoryRow | null>;
+  listMessages(query: ChatMessageListQuery): Promise<readonly ChatMessageRepositoryRow[]>;
+  findUploadById(uploadId: string): Promise<ChatUploadRepositoryRow | null>;
+}

--- a/backend/src/modules/chat/ports/outbound/index.ts
+++ b/backend/src/modules/chat/ports/outbound/index.ts
@@ -40,7 +40,10 @@ export type ChatUploadRepositoryRow = Readonly<{
   byteSize: number;
   kind: "image";
   storageKey: string;
-  relatedMessageId: string | null;
+  storagePath: string;
+  uploaderHandleId: string;
+  uploaderSessionId: string | null;
+  messageId: string | null;
   moderationState: "visible" | "hidden" | "deleted";
   hiddenAt: Date | null;
   deletedAt: Date | null;

--- a/backend/src/modules/content/ports/outbound/index.ts
+++ b/backend/src/modules/content/ports/outbound/index.ts
@@ -1,1 +1,89 @@
-export {};
+export type ThoughtRepositoryRow = Readonly<{
+  id: string;
+  title: string;
+  slug: string;
+  type: "essay" | "note";
+  status: "draft" | "published";
+  publishedAt: Date | null;
+  readingTime: number;
+  tags: readonly string[];
+  excerpt: string | null;
+  bodyPreview: string | null;
+  featured: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}>;
+
+export type ProjectRepositoryRow = Readonly<{
+  id: string;
+  channel: string;
+  title: string;
+  slug: string;
+  year: number;
+  status: "live" | "archived" | "in-progress";
+  description: string | null;
+  tags: readonly string[];
+  githubUrl: string | null;
+  siteUrl: string | null;
+  thumbnailHue: number | null;
+  thumbnailKind: string | null;
+  featured: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}>;
+
+export type PhotoRepositoryRow = Readonly<{
+  id: string;
+  frame: string;
+  title: string;
+  date: Date;
+  location: string | null;
+  tags: readonly string[];
+  tone: "amber" | "cyan" | "mono" | "sunset" | "violet";
+  caption: string | null;
+  featured: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}>;
+
+export type StatusStripEntryRepositoryRow = Readonly<{
+  id: string;
+  label: string;
+  value: string;
+  accent: "amber" | "cyan" | "pink" | null;
+  displayOrder: number;
+  createdAt: Date;
+  updatedAt: Date;
+}>;
+
+export type ThoughtListQuery = Readonly<{
+  cursor?: string;
+  limit?: number;
+  type?: "essay" | "note";
+  tags?: readonly string[];
+  search?: string;
+}>;
+
+export type ProjectListQuery = Readonly<{
+  page?: number;
+  pageSize?: number;
+  status?: "live" | "archived" | "in-progress";
+  tags?: readonly string[];
+  search?: string;
+  sort?: "recent" | "alpha" | "channel";
+}>;
+
+export type PhotoListQuery = Readonly<{
+  page?: number;
+  pageSize?: number;
+  year?: number;
+  location?: string;
+  search?: string;
+}>;
+
+export interface ContentRepositoryPort {
+  findPublishedThoughts(query: ThoughtListQuery): Promise<readonly ThoughtRepositoryRow[]>;
+  findPublishedProjects(query: ProjectListQuery): Promise<readonly ProjectRepositoryRow[]>;
+  findPublishedPhotos(query: PhotoListQuery): Promise<readonly PhotoRepositoryRow[]>;
+  listStatusStripEntries(): Promise<readonly StatusStripEntryRepositoryRow[]>;
+}

--- a/backend/src/modules/content/ports/outbound/index.ts
+++ b/backend/src/modules/content/ports/outbound/index.ts
@@ -5,10 +5,10 @@ export type ThoughtRepositoryRow = Readonly<{
   type: "essay" | "note";
   status: "draft" | "published";
   publishedAt: Date | null;
-  readingTime: number;
+  readingTime: number | null;
   tags: readonly string[];
-  excerpt: string | null;
-  bodyPreview: string | null;
+  excerpt: string;
+  bodyPreview: string;
   featured: boolean;
   createdAt: Date;
   updatedAt: Date;
@@ -21,12 +21,12 @@ export type ProjectRepositoryRow = Readonly<{
   slug: string;
   year: number;
   status: "live" | "archived" | "in-progress";
-  description: string | null;
+  description: string;
   tags: readonly string[];
   githubUrl: string | null;
   siteUrl: string | null;
-  thumbnailHue: number | null;
-  thumbnailKind: string | null;
+  thumbnailHue: number;
+  thumbnailKind: string;
   featured: boolean;
   createdAt: Date;
   updatedAt: Date;
@@ -37,7 +37,7 @@ export type PhotoRepositoryRow = Readonly<{
   frame: string;
   title: string;
   date: Date;
-  location: string | null;
+  location: string;
   tags: readonly string[];
   tone: "amber" | "cyan" | "mono" | "sunset" | "violet";
   caption: string | null;

--- a/backend/src/modules/media/ports/outbound/index.ts
+++ b/backend/src/modules/media/ports/outbound/index.ts
@@ -1,7 +1,6 @@
 export type PhotoMediaRepositoryRow = Readonly<{
   id: string;
   title: string;
-  slug: string;
   originalReferencePolicy: "backend_media_route" | "filesystem_reference";
   originalReference: string;
   createdAt: Date;

--- a/backend/src/modules/media/ports/outbound/index.ts
+++ b/backend/src/modules/media/ports/outbound/index.ts
@@ -1,1 +1,24 @@
-export {};
+export type PhotoMediaRepositoryRow = Readonly<{
+  id: string;
+  title: string;
+  slug: string;
+  originalReferencePolicy: "backend_media_route" | "filesystem_reference";
+  originalReference: string;
+  createdAt: Date;
+  updatedAt: Date;
+}>;
+
+export type ChatUploadMediaRepositoryRow = Readonly<{
+  id: string;
+  displayFilename: string;
+  mimeType: "image/jpeg" | "image/png" | "image/webp";
+  storageKey: string;
+  byteSize: number;
+  createdAt: Date;
+  updatedAt: Date;
+}>;
+
+export interface MediaRepositoryPort {
+  findPhotoMediaById(photoId: string): Promise<PhotoMediaRepositoryRow | null>;
+  findChatUploadMediaById(uploadId: string): Promise<ChatUploadMediaRepositoryRow | null>;
+}


### PR DESCRIPTION
## Summary
Add DTO-safe outbound repository ports for content/status strip, chat, admin, and media, plus a skeletal Prisma persistence adapter factory under the outbound persistence boundary.

## Validation
- bun run prisma:validate
- bun run prisma:generate
- bun run typecheck
- bun test
- bun run build
- bun run verify
- bun scripts/frontend-analyzer.ts --output=/tmp/vinicius-dev-frontend-analyzer-data004.md
