### PR TITLE
[BE-006] Implement Thoughts public list detail API

### DIFF
--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -1,5 +1,8 @@
 import { Hono } from "hono";
 
+import { InvalidThoughtCursorError } from "@/modules/content/application";
+import type { BootstrapContainer } from "@/bootstrap/container";
+
 const serviceName = "vinicius.dev-backend";
 
 type NotImplementedResponse = {
@@ -33,7 +36,124 @@ const mountPlaceholderFamily = (app: Hono, path: string, family: string) => {
   app.route(path, createNotImplementedFamily(family));
 };
 
-export const createHonoHttpAdapter = () => {
+const parsePositiveInteger = (value: string | undefined): number | undefined => {
+  if (typeof value === "undefined") {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return undefined;
+  }
+
+  return parsed;
+};
+
+const parseThoughtQuery = (query: Record<string, string | undefined>) => {
+  const type = query.type;
+
+  if (type && type !== "essay" && type !== "note") {
+    return {
+      error: {
+        error: "invalid_query",
+        field: "type",
+      },
+    } as const;
+  }
+
+  const limit = parsePositiveInteger(query.limit);
+
+  if (typeof query.limit !== "undefined" && typeof limit === "undefined") {
+    return {
+      error: {
+        error: "invalid_query",
+        field: "limit",
+      },
+    } as const;
+  }
+
+  const tags = [query.tag, query.tags]
+    .filter((value): value is string => typeof value === "string")
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  const normalizedType: "essay" | "note" | undefined =
+    type === "essay" || type === "note" ? type : undefined;
+
+  return {
+    value: {
+      cursor: query.cursor,
+      limit,
+      search: query.search,
+      tags,
+      type: normalizedType,
+    },
+  } as const;
+};
+
+const createThoughtsFamily = (container: BootstrapContainer) => {
+  const thoughtsApp = new Hono();
+
+  thoughtsApp.get("/", async (c) => {
+    const parsed = parseThoughtQuery(c.req.query());
+
+    if ("error" in parsed) {
+      return c.json(parsed.error, 400);
+    }
+
+    try {
+      const response = await container.content.listPublishedThoughts.execute(parsed.value);
+
+      return c.json(response);
+    } catch (error) {
+      if (error instanceof InvalidThoughtCursorError) {
+        return c.json(
+          {
+            error: "invalid_query",
+            field: "cursor",
+          },
+          400,
+        );
+      }
+
+      throw error;
+    }
+  });
+
+  thoughtsApp.get("/:slug", async (c) => {
+    const slug = c.req.param("slug")?.trim();
+
+    if (!slug) {
+      return c.json(
+        {
+          error: "invalid_path",
+          field: "slug",
+        },
+        400,
+      );
+    }
+
+    const thought = await container.content.getPublishedThoughtBySlug.execute({ slug });
+
+    if (!thought) {
+      return c.json(
+        {
+          error: "not_found",
+          resource: "thought",
+        },
+        404,
+      );
+    }
+
+    return c.json({ item: thought });
+  });
+
+  return thoughtsApp;
+};
+
+export const createHonoHttpAdapter = (container: BootstrapContainer) => {
   const app = new Hono();
 
   app.get("/api", (c) =>
@@ -45,7 +165,7 @@ export const createHonoHttpAdapter = () => {
     }),
   );
 
-  mountPlaceholderFamily(app, "/api/thoughts", "public content");
+  app.route("/api/thoughts", createThoughtsFamily(container));
   mountPlaceholderFamily(app, "/api/projects", "public content");
   mountPlaceholderFamily(app, "/api/photos", "public content");
   mountPlaceholderFamily(app, "/api/status-strip", "status strip");

--- a/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "bun:test";
+
+import type { BootstrapContainer } from "@/bootstrap/container";
+
+import { createHonoHttpAdapter } from "./http-adapter";
+
+const createTestContainer = (): BootstrapContainer => ({
+  config: {
+    auth: {
+      mfaCodeMaxAgeSeconds: 600,
+      roomPasswordSecret: "test-room-secret",
+      sessionCookieName: "vinicius.dev-session",
+      sessionMaxAgeSeconds: 604800,
+      sessionSecret: "test-session-secret",
+    },
+    cors: {
+      allowCredentials: true,
+      allowedOrigins: [],
+    },
+    media: {
+      chatRoot: "/tmp/chat",
+      chatUploadAllowedMimeTypes: ["image/jpeg", "image/png", "image/webp"],
+      chatUploadMaxBytes: 5 * 1024 * 1024,
+      chatUploadMaxFilesPerMessage: 1,
+      photosRoot: "/tmp/photos",
+      publicUrlBase: "/media",
+    },
+    server: {
+      apiBasePath: "/api",
+      mediaPhotoOriginalPath: "/media/photos/:id/original",
+      nodeEnv: "test",
+      port: 4000,
+    },
+  },
+  content: {
+    getPublishedThoughtBySlug: {
+      execute: async ({ slug }) =>
+        slug === "night-cable-interfaces"
+          ? {
+              body: "A homepage does not need to convert anyone.",
+              bodyPreview: "A homepage does not need to convert anyone.",
+              excerpt: "The best personal websites feel less like products.",
+              id: "thought_1",
+              publishedAt: "2026-03-28",
+              readingTime: "7 min",
+              slug,
+              source: "notes/night-cable-interfaces.md",
+              status: "published",
+              tags: ["interface", "nostalgia"],
+              title: "Night Cable Interfaces",
+              type: "essay",
+            }
+          : null,
+    },
+    listPublishedThoughts: {
+      execute: async ({ cursor, limit, search, tags, type }) => ({
+        items: [
+          {
+            bodyPreview: `cursor=${cursor ?? "none"} search=${search ?? "none"} tags=${tags?.join("|") ?? "none"} limit=${limit ?? 0}`,
+            excerpt: "The best personal websites feel less like products.",
+            id: "thought_1",
+            publishedAt: "2026-03-28",
+            readingTime: "7 min",
+            slug: "night-cable-interfaces",
+            status: "published",
+            tags: ["interface", "nostalgia"],
+            title: type === "note" ? "Adjusted Type" : "Night Cable Interfaces",
+            type: type ?? "essay",
+          },
+        ],
+        pageInfo: {
+          nextCursor: null,
+        },
+      }),
+    },
+  },
+});
+
+describe("thoughts routes", () => {
+  it("maps validated list queries to the Thoughts use case", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request(
+      "/api/thoughts?type=note&tag=ops&tags=web,craft&search=retro&limit=3&cursor=abc123",
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      items: [
+        {
+          bodyPreview: "cursor=abc123 search=retro tags=ops|web|craft limit=3",
+          excerpt: "The best personal websites feel less like products.",
+          id: "thought_1",
+          publishedAt: "2026-03-28",
+          readingTime: "7 min",
+          slug: "night-cable-interfaces",
+          status: "published",
+          tags: ["interface", "nostalgia"],
+          title: "Adjusted Type",
+          type: "note",
+        },
+      ],
+      pageInfo: {
+        nextCursor: null,
+      },
+    });
+  });
+
+  it("rejects invalid list queries before reaching the core", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/api/thoughts?limit=0&type=invalid");
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_query",
+      field: "type",
+    });
+  });
+
+  it("returns a published thought detail by slug", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/api/thoughts/night-cable-interfaces");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      item: {
+        body: "A homepage does not need to convert anyone.",
+        bodyPreview: "A homepage does not need to convert anyone.",
+        excerpt: "The best personal websites feel less like products.",
+        id: "thought_1",
+        publishedAt: "2026-03-28",
+        readingTime: "7 min",
+        slug: "night-cable-interfaces",
+        source: "notes/night-cable-interfaces.md",
+        status: "published",
+        tags: ["interface", "nostalgia"],
+        title: "Night Cable Interfaces",
+        type: "essay",
+      },
+    });
+  });
+
+  it("returns not found for an unknown thought slug", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/api/thoughts/unknown-thought");
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "not_found",
+      resource: "thought",
+    });
+  });
+});

--- a/backend/src/adapters/outbound/persistence/prisma/content-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/content-repository.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "bun:test";
+
+import { createPrismaContentRepository } from "./content-repository";
+import type { PrismaDatabaseClient } from "./prisma-client";
+
+describe("prisma content repository", () => {
+  it("maps published thought rows and produces a cursor for the next page", async () => {
+    const findMany = async () => [
+      {
+        bodyPreview: "First preview",
+        createdAt: new Date("2026-03-28T00:00:00.000Z"),
+        excerpt: "First excerpt",
+        featured: true,
+        id: "thought_2",
+        publishedAt: new Date("2026-03-28T00:00:00.000Z"),
+        readingTime: 7,
+        slug: "night-cable-interfaces",
+        status: "published" as const,
+        tags: ["interface", "nostalgia"],
+        title: "Night Cable Interfaces",
+        type: "essay" as const,
+        updatedAt: new Date("2026-03-28T00:00:00.000Z"),
+      },
+      {
+        bodyPreview: "Second preview",
+        createdAt: new Date("2026-03-16T00:00:00.000Z"),
+        excerpt: "Second excerpt",
+        featured: false,
+        id: "thought_1",
+        publishedAt: new Date("2026-03-16T00:00:00.000Z"),
+        readingTime: 3,
+        slug: "runbook-for-small-tools",
+        status: "published" as const,
+        tags: ["tools", "ops"],
+        title: "Runbook for Small Tools",
+        type: "note" as const,
+        updatedAt: new Date("2026-03-16T00:00:00.000Z"),
+      },
+    ];
+
+    const repository = createPrismaContentRepository({
+      thought: {
+        findMany,
+        findFirst: async () => null,
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    const page = await repository.findPublishedThoughts({
+      limit: 1,
+    });
+
+    expect(page.items).toEqual([
+      {
+        bodyPreview: "First preview",
+        createdAt: new Date("2026-03-28T00:00:00.000Z"),
+        excerpt: "First excerpt",
+        featured: true,
+        id: "thought_2",
+        publishedAt: new Date("2026-03-28T00:00:00.000Z"),
+        readingTime: 7,
+        slug: "night-cable-interfaces",
+        status: "published",
+        tags: ["interface", "nostalgia"],
+        title: "Night Cable Interfaces",
+        type: "essay",
+        updatedAt: new Date("2026-03-28T00:00:00.000Z"),
+      },
+    ]);
+    expect(page.nextCursor).toEqual({
+      id: "thought_1",
+      publishedAt: new Date("2026-03-16T00:00:00.000Z"),
+    });
+  });
+
+  it("maps a published thought detail row without leaking Prisma types", async () => {
+    const repository = createPrismaContentRepository({
+      thought: {
+        findMany: async () => [],
+        findFirst: async () => ({
+          body: "A homepage does not need to convert anyone.",
+          bodyPreview: "A homepage does not need to convert anyone.",
+          createdAt: new Date("2026-03-28T00:00:00.000Z"),
+          excerpt: "The best personal websites feel less like products.",
+          featured: true,
+          id: "thought_2",
+          publishedAt: new Date("2026-03-28T00:00:00.000Z"),
+          readingTime: 7,
+          slug: "night-cable-interfaces",
+          source: "notes/night-cable-interfaces.md",
+          status: "published" as const,
+          tags: ["interface", "nostalgia"],
+          title: "Night Cable Interfaces",
+          type: "essay" as const,
+          updatedAt: new Date("2026-03-28T00:00:00.000Z"),
+        }),
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    const thought = await repository.findPublishedThoughtBySlug("night-cable-interfaces");
+
+    expect(thought).toEqual({
+      body: "A homepage does not need to convert anyone.",
+      bodyPreview: "A homepage does not need to convert anyone.",
+      createdAt: new Date("2026-03-28T00:00:00.000Z"),
+      excerpt: "The best personal websites feel less like products.",
+      featured: true,
+      id: "thought_2",
+      publishedAt: new Date("2026-03-28T00:00:00.000Z"),
+      readingTime: 7,
+      slug: "night-cable-interfaces",
+      source: "notes/night-cable-interfaces.md",
+      status: "published",
+      tags: ["interface", "nostalgia"],
+      title: "Night Cable Interfaces",
+      type: "essay",
+      updatedAt: new Date("2026-03-28T00:00:00.000Z"),
+    });
+  });
+});

--- a/backend/src/adapters/outbound/persistence/prisma/content-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/content-repository.ts
@@ -5,9 +5,12 @@ import type {
   ProjectListQuery,
   ProjectRepositoryRow,
   StatusStripEntryRepositoryRow,
+  ThoughtDetailRepositoryRow,
   ThoughtListQuery,
+  ThoughtListPage,
   ThoughtRepositoryRow,
 } from "@/modules/content/ports/outbound";
+import { Prisma, ThoughtStatus } from "../../../../../generated/prisma/client";
 
 import type { PrismaDatabaseClient } from "./prisma-client";
 
@@ -15,9 +18,196 @@ const notImplemented = <T>(method: string): Promise<T> => {
   return Promise.reject(new Error(`Prisma content repository method not implemented: ${method}`));
 };
 
-export const createPrismaContentRepository = (_client: PrismaDatabaseClient): ContentRepositoryPort => ({
-  findPublishedThoughts: (_query: ThoughtListQuery): Promise<readonly ThoughtRepositoryRow[]> =>
-    notImplemented("findPublishedThoughts"),
+const mapThoughtRow = (row: {
+  bodyPreview: string;
+  createdAt: Date;
+  excerpt: string;
+  featured: boolean;
+  id: string;
+  publishedAt: Date | null;
+  readingTime: number | null;
+  slug: string;
+  status: "draft" | "published";
+  tags: string[];
+  title: string;
+  type: "essay" | "note";
+  updatedAt: Date;
+}): ThoughtRepositoryRow => ({
+  bodyPreview: row.bodyPreview,
+  createdAt: row.createdAt,
+  excerpt: row.excerpt,
+  featured: row.featured,
+  id: row.id,
+  publishedAt: row.publishedAt,
+  readingTime: row.readingTime,
+  slug: row.slug,
+  status: row.status,
+  tags: [...row.tags],
+  title: row.title,
+  type: row.type,
+  updatedAt: row.updatedAt,
+});
+
+const mapThoughtDetailRow = (row: {
+  body: string;
+  bodyPreview: string;
+  createdAt: Date;
+  excerpt: string;
+  featured: boolean;
+  id: string;
+  publishedAt: Date | null;
+  readingTime: number | null;
+  slug: string;
+  source: string | null;
+  status: "draft" | "published";
+  tags: string[];
+  title: string;
+  type: "essay" | "note";
+  updatedAt: Date;
+}): ThoughtDetailRepositoryRow => ({
+  ...mapThoughtRow(row),
+  body: row.body,
+  source: row.source,
+});
+
+const applyThoughtSearch = <
+  TRow extends {
+    bodyPreview: string;
+    excerpt: string;
+    tags: string[];
+    title: string;
+  },
+>(
+  rows: readonly TRow[],
+  search?: string,
+) => {
+  const normalizedSearch = search?.trim().toLowerCase();
+
+  if (!normalizedSearch) {
+    return rows;
+  }
+
+  return rows.filter((row) => {
+    return (
+      row.title.toLowerCase().includes(normalizedSearch) ||
+      row.excerpt.toLowerCase().includes(normalizedSearch) ||
+      row.bodyPreview.toLowerCase().includes(normalizedSearch) ||
+      row.tags.some((tag) => tag.toLowerCase().includes(normalizedSearch))
+    );
+  });
+};
+
+const buildThoughtCursorWhere = (query: ThoughtListQuery): Prisma.ThoughtWhereInput | undefined => {
+  if (!query.cursor) {
+    return undefined;
+  }
+
+  return {
+    OR: [
+      {
+        publishedAt: {
+          lt: query.cursor.publishedAt,
+        },
+      },
+      {
+        id: {
+          lt: query.cursor.id,
+        },
+        publishedAt: query.cursor.publishedAt,
+      },
+    ],
+  };
+};
+
+const buildThoughtBaseWhere = (query: ThoughtListQuery): Prisma.ThoughtWhereInput => ({
+  ...buildThoughtCursorWhere(query),
+  ...(query.tags?.length
+    ? {
+        tags: {
+          hasEvery: [...query.tags],
+        },
+      }
+    : {}),
+  ...(query.type
+    ? {
+        type: query.type,
+      }
+    : {}),
+  publishedAt: {
+    not: null,
+  },
+  status: ThoughtStatus.published,
+});
+
+export const createPrismaContentRepository = (client: PrismaDatabaseClient): ContentRepositoryPort => ({
+  findPublishedThoughts: async (query: ThoughtListQuery): Promise<ThoughtListPage> => {
+    const limit = query.limit ?? 6;
+    const rows = await client.thought.findMany({
+      orderBy: [{ publishedAt: "desc" }, { id: "desc" }],
+      select: {
+        bodyPreview: true,
+        createdAt: true,
+        excerpt: true,
+        featured: true,
+        id: true,
+        publishedAt: true,
+        readingTime: true,
+        slug: true,
+        status: true,
+        tags: true,
+        title: true,
+        type: true,
+        updatedAt: true,
+      },
+      take: query.search ? undefined : limit + 1,
+      where: buildThoughtBaseWhere(query),
+    });
+
+    const filteredRows = applyThoughtSearch(rows, query.search);
+    const pageRows = filteredRows.slice(0, limit).map(mapThoughtRow);
+    const nextRow = filteredRows.at(limit);
+
+    return {
+      items: pageRows,
+      nextCursor:
+        nextRow && nextRow.publishedAt
+          ? {
+              id: nextRow.id,
+              publishedAt: nextRow.publishedAt,
+            }
+          : null,
+    };
+  },
+  findPublishedThoughtBySlug: async (slug: string): Promise<ThoughtDetailRepositoryRow | null> => {
+    const row = await client.thought.findFirst({
+      select: {
+        body: true,
+        bodyPreview: true,
+        createdAt: true,
+        excerpt: true,
+        featured: true,
+        id: true,
+        publishedAt: true,
+        readingTime: true,
+        slug: true,
+        source: true,
+        status: true,
+        tags: true,
+        title: true,
+        type: true,
+        updatedAt: true,
+      },
+      where: {
+        OR: [{ id: slug }, { slug }],
+        publishedAt: {
+          not: null,
+        },
+        status: ThoughtStatus.published,
+      },
+    });
+
+    return row ? mapThoughtDetailRow(row) : null;
+  },
   findPublishedProjects: (_query: ProjectListQuery): Promise<readonly ProjectRepositoryRow[]> =>
     notImplemented("findPublishedProjects"),
   findPublishedPhotos: (_query: PhotoListQuery): Promise<readonly PhotoRepositoryRow[]> =>

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -1,13 +1,37 @@
+import { createPrismaPersistenceAdapter } from "@/adapters/outbound/persistence";
+import {
+  createGetPublishedThoughtBySlugUseCase,
+  createListPublishedThoughtsUseCase,
+} from "@/modules/content/application";
+import type {
+  GetPublishedThoughtBySlugPort,
+  ListPublishedThoughtsPort,
+} from "@/modules/content/ports/inbound";
+
 import { loadBootstrapConfig, type BootstrapConfig } from "../config";
 
 export type BootstrapContainer = Readonly<{
   config: BootstrapConfig;
+  content: Readonly<{
+    getPublishedThoughtBySlug: GetPublishedThoughtBySlugPort;
+    listPublishedThoughts: ListPublishedThoughtsPort;
+  }>;
 }>;
 
 type BootstrapEnv = Readonly<Record<string, string | undefined>>;
 
-export const createContainer = (
-  env: BootstrapEnv = Bun.env,
-): BootstrapContainer => ({
-  config: loadBootstrapConfig(env),
-});
+export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer => {
+  const persistence = createPrismaPersistenceAdapter();
+
+  return {
+    config: loadBootstrapConfig(env),
+    content: {
+      getPublishedThoughtBySlug: createGetPublishedThoughtBySlugUseCase({
+        repository: persistence.content,
+      }),
+      listPublishedThoughts: createListPublishedThoughtsUseCase({
+        repository: persistence.content,
+      }),
+    },
+  };
+};

--- a/backend/src/bootstrap/server.test.ts
+++ b/backend/src/bootstrap/server.test.ts
@@ -1,10 +1,83 @@
 import { describe, expect, it } from "bun:test";
 
+import type { BootstrapContainer } from "./container";
 import { createServer } from "./server";
+
+const createTestContainer = (): BootstrapContainer => ({
+  config: {
+    auth: {
+      mfaCodeMaxAgeSeconds: 600,
+      roomPasswordSecret: "test-room-secret",
+      sessionCookieName: "vinicius.dev-session",
+      sessionMaxAgeSeconds: 604800,
+      sessionSecret: "test-session-secret",
+    },
+    cors: {
+      allowCredentials: true,
+      allowedOrigins: [],
+    },
+    media: {
+      chatRoot: "/tmp/chat",
+      chatUploadAllowedMimeTypes: ["image/jpeg", "image/png", "image/webp"],
+      chatUploadMaxBytes: 5 * 1024 * 1024,
+      chatUploadMaxFilesPerMessage: 1,
+      photosRoot: "/tmp/photos",
+      publicUrlBase: "/media",
+    },
+    server: {
+      apiBasePath: "/api",
+      mediaPhotoOriginalPath: "/media/photos/:id/original",
+      nodeEnv: "test",
+      port: 4000,
+    },
+  },
+  content: {
+    getPublishedThoughtBySlug: {
+      execute: async ({ slug }) =>
+        slug === "night-cable-interfaces"
+          ? {
+              body: "A homepage does not need to convert anyone.",
+              bodyPreview: "A homepage does not need to convert anyone.",
+              excerpt: "The best personal websites feel less like products.",
+              id: "thought_1",
+              publishedAt: "2026-03-28",
+              readingTime: "7 min",
+              slug,
+              source: null,
+              status: "published",
+              tags: ["interface", "nostalgia"],
+              title: "Night Cable Interfaces",
+              type: "essay",
+            }
+          : null,
+    },
+    listPublishedThoughts: {
+      execute: async () => ({
+        items: [
+          {
+            bodyPreview: "A homepage does not need to convert anyone.",
+            excerpt: "The best personal websites feel less like products.",
+            id: "thought_1",
+            publishedAt: "2026-03-28",
+            readingTime: "7 min",
+            slug: "night-cable-interfaces",
+            status: "published",
+            tags: ["interface", "nostalgia"],
+            title: "Night Cable Interfaces",
+            type: "essay",
+          },
+        ],
+        pageInfo: {
+          nextCursor: null,
+        },
+      }),
+    },
+  },
+});
 
 describe("backend server scaffold", () => {
   it("responds to the health route", async () => {
-    const app = createServer();
+    const app = createServer(createTestContainer());
     const response = await app.request("/health");
 
     expect(response.status).toBe(200);
@@ -15,7 +88,7 @@ describe("backend server scaffold", () => {
   });
 
   it("mounts the /api shell and placeholder route families", async () => {
-    const app = createServer();
+    const app = createServer(createTestContainer());
 
     const shellResponse = await app.request("/api");
     expect(shellResponse.status).toBe(200);
@@ -26,8 +99,29 @@ describe("backend server scaffold", () => {
       surface: "hono-http-adapter-shell",
     });
 
+    const thoughtsResponse = await app.request("/api/thoughts");
+    expect(thoughtsResponse.status).toBe(200);
+    await expect(thoughtsResponse.json()).resolves.toEqual({
+      items: [
+        {
+          bodyPreview: "A homepage does not need to convert anyone.",
+          excerpt: "The best personal websites feel less like products.",
+          id: "thought_1",
+          publishedAt: "2026-03-28",
+          readingTime: "7 min",
+          slug: "night-cable-interfaces",
+          status: "published",
+          tags: ["interface", "nostalgia"],
+          title: "Night Cable Interfaces",
+          type: "essay",
+        },
+      ],
+      pageInfo: {
+        nextCursor: null,
+      },
+    });
+
     const placeholderRoutes = [
-      ["/api/thoughts", "public content"],
       ["/api/projects", "public content"],
       ["/api/photos", "public content"],
       ["/api/status-strip", "status strip"],

--- a/backend/src/bootstrap/server.ts
+++ b/backend/src/bootstrap/server.ts
@@ -1,9 +1,9 @@
 import { Hono } from "hono";
 
 import { createHonoHttpAdapter } from "../adapters/inbound/http/hono/http-adapter";
-import { createContainer } from "./container";
+import { createContainer, type BootstrapContainer } from "./container";
 
-export const createServer = () => {
+export const createServer = (container: BootstrapContainer = createContainer()) => {
   const app = new Hono();
 
   app.get("/health", (c) =>
@@ -13,15 +13,15 @@ export const createServer = () => {
     }),
   );
 
-  app.route("/", createHonoHttpAdapter());
+  app.route("/", createHonoHttpAdapter(container));
 
   return app;
 };
 
-const container = createContainer();
-const app = createServer();
-
 if (import.meta.main) {
+  const container = createContainer();
+  const app = createServer(container);
+
   Bun.serve({
     fetch: app.fetch,
     port: container.config.server.port,
@@ -30,4 +30,4 @@ if (import.meta.main) {
   console.info(`vinicius.dev backend listening on :${container.config.server.port}`);
 }
 
-export default app;
+export default createServer;

--- a/backend/src/modules/content/application/index.ts
+++ b/backend/src/modules/content/application/index.ts
@@ -1,1 +1,140 @@
-export {};
+import type {
+  ContentRepositoryPort,
+  ThoughtCursor,
+  ThoughtDetailRepositoryRow,
+  ThoughtRepositoryRow,
+} from "@/modules/content/ports/outbound";
+
+import type {
+  GetPublishedThoughtBySlugPort,
+  ListPublishedThoughtsInput,
+  ListPublishedThoughtsOutput,
+  ListPublishedThoughtsPort,
+  PublishedThoughtDetail,
+  PublishedThoughtSummary,
+} from "../ports/inbound";
+
+const DEFAULT_THOUGHTS_PAGE_SIZE = 6;
+const MAX_THOUGHTS_PAGE_SIZE = 24;
+
+export class InvalidThoughtCursorError extends Error {
+  constructor() {
+    super("Thought cursor is invalid.");
+    this.name = "InvalidThoughtCursorError";
+  }
+}
+
+const formatPublishedDate = (value: Date | null): string => {
+  if (!value) {
+    return "";
+  }
+
+  return value.toISOString().slice(0, 10);
+};
+
+const formatReadingTime = (value: number | null): string | null => {
+  if (value === null) {
+    return null;
+  }
+
+  return `${value} min`;
+};
+
+const mapThoughtSummary = (row: ThoughtRepositoryRow): PublishedThoughtSummary => ({
+  id: row.id,
+  title: row.title,
+  slug: row.slug,
+  type: row.type,
+  status: "published",
+  publishedAt: formatPublishedDate(row.publishedAt),
+  readingTime: formatReadingTime(row.readingTime),
+  tags: [...row.tags],
+  excerpt: row.excerpt,
+  bodyPreview: row.bodyPreview,
+});
+
+const mapThoughtDetail = (row: ThoughtDetailRepositoryRow): PublishedThoughtDetail => ({
+  ...mapThoughtSummary(row),
+  body: row.body,
+  source: row.source,
+});
+
+const normalizeLimit = (value?: number): number => {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return DEFAULT_THOUGHTS_PAGE_SIZE;
+  }
+
+  return Math.min(Math.max(Math.trunc(value), 1), MAX_THOUGHTS_PAGE_SIZE);
+};
+
+const encodeThoughtCursor = (cursor: ThoughtCursor): string => {
+  return Buffer.from(
+    JSON.stringify({
+      id: cursor.id,
+      publishedAt: cursor.publishedAt.toISOString(),
+    }),
+    "utf8",
+  ).toString("base64url");
+};
+
+const decodeThoughtCursor = (input: string): ThoughtCursor => {
+  try {
+    const parsed = JSON.parse(Buffer.from(input, "base64url").toString("utf8")) as {
+      id?: unknown;
+      publishedAt?: unknown;
+    };
+
+    if (typeof parsed.id !== "string" || typeof parsed.publishedAt !== "string") {
+      throw new InvalidThoughtCursorError();
+    }
+
+    const publishedAt = new Date(parsed.publishedAt);
+
+    if (Number.isNaN(publishedAt.getTime())) {
+      throw new InvalidThoughtCursorError();
+    }
+
+    return {
+      id: parsed.id,
+      publishedAt,
+    };
+  } catch (_error) {
+    throw new InvalidThoughtCursorError();
+  }
+};
+
+export type ContentApplicationDependencies = Readonly<{
+  repository: ContentRepositoryPort;
+}>;
+
+export const createListPublishedThoughtsUseCase = ({
+  repository,
+}: ContentApplicationDependencies): ListPublishedThoughtsPort => ({
+  execute: async (input: ListPublishedThoughtsInput): Promise<ListPublishedThoughtsOutput> => {
+    const limit = normalizeLimit(input.limit);
+    const result = await repository.findPublishedThoughts({
+      cursor: input.cursor ? decodeThoughtCursor(input.cursor) : undefined,
+      limit,
+      search: input.search?.trim() || undefined,
+      tags: input.tags?.filter(Boolean),
+      type: input.type,
+    });
+
+    return {
+      items: result.items.map(mapThoughtSummary),
+      pageInfo: {
+        nextCursor: result.nextCursor ? encodeThoughtCursor(result.nextCursor) : null,
+      },
+    };
+  },
+});
+
+export const createGetPublishedThoughtBySlugUseCase = ({
+  repository,
+}: ContentApplicationDependencies): GetPublishedThoughtBySlugPort => ({
+  execute: async ({ slug }) => {
+    const thought = await repository.findPublishedThoughtBySlug(slug);
+
+    return thought ? mapThoughtDetail(thought) : null;
+  },
+});

--- a/backend/src/modules/content/ports/inbound/index.ts
+++ b/backend/src/modules/content/ports/inbound/index.ts
@@ -1,1 +1,45 @@
-export {};
+import type { UseCase } from "@/modules/shared/application/use-case";
+
+export type PublishedThoughtSummary = Readonly<{
+  id: string;
+  title: string;
+  slug: string;
+  type: "essay" | "note";
+  status: "published";
+  publishedAt: string;
+  readingTime: string | null;
+  tags: readonly string[];
+  excerpt: string;
+  bodyPreview: string;
+}>;
+
+export type PublishedThoughtDetail = PublishedThoughtSummary &
+  Readonly<{
+    body: string;
+    source: string | null;
+  }>;
+
+export type ListPublishedThoughtsInput = Readonly<{
+  cursor?: string;
+  limit?: number;
+  type?: "essay" | "note";
+  tags?: readonly string[];
+  search?: string;
+}>;
+
+export type ListPublishedThoughtsOutput = Readonly<{
+  items: readonly PublishedThoughtSummary[];
+  pageInfo: Readonly<{
+    nextCursor: string | null;
+  }>;
+}>;
+
+export type GetPublishedThoughtBySlugInput = Readonly<{
+  slug: string;
+}>;
+
+export interface ListPublishedThoughtsPort
+  extends UseCase<ListPublishedThoughtsInput, ListPublishedThoughtsOutput> {}
+
+export interface GetPublishedThoughtBySlugPort
+  extends UseCase<GetPublishedThoughtBySlugInput, PublishedThoughtDetail | null> {}

--- a/backend/src/modules/content/ports/outbound/index.ts
+++ b/backend/src/modules/content/ports/outbound/index.ts
@@ -1,3 +1,8 @@
+export type ThoughtCursor = Readonly<{
+  publishedAt: Date;
+  id: string;
+}>;
+
 export type ThoughtRepositoryRow = Readonly<{
   id: string;
   title: string;
@@ -12,6 +17,17 @@ export type ThoughtRepositoryRow = Readonly<{
   featured: boolean;
   createdAt: Date;
   updatedAt: Date;
+}>;
+
+export type ThoughtDetailRepositoryRow = ThoughtRepositoryRow &
+  Readonly<{
+    body: string;
+    source: string | null;
+  }>;
+
+export type ThoughtListPage = Readonly<{
+  items: readonly ThoughtRepositoryRow[];
+  nextCursor: ThoughtCursor | null;
 }>;
 
 export type ProjectRepositoryRow = Readonly<{
@@ -57,7 +73,7 @@ export type StatusStripEntryRepositoryRow = Readonly<{
 }>;
 
 export type ThoughtListQuery = Readonly<{
-  cursor?: string;
+  cursor?: ThoughtCursor;
   limit?: number;
   type?: "essay" | "note";
   tags?: readonly string[];
@@ -82,7 +98,8 @@ export type PhotoListQuery = Readonly<{
 }>;
 
 export interface ContentRepositoryPort {
-  findPublishedThoughts(query: ThoughtListQuery): Promise<readonly ThoughtRepositoryRow[]>;
+  findPublishedThoughts(query: ThoughtListQuery): Promise<ThoughtListPage>;
+  findPublishedThoughtBySlug(slug: string): Promise<ThoughtDetailRepositoryRow | null>;
   findPublishedProjects(query: ProjectListQuery): Promise<readonly ProjectRepositoryRow[]>;
   findPublishedPhotos(query: PhotoListQuery): Promise<readonly PhotoRepositoryRow[]>;
   listStatusStripEntries(): Promise<readonly StatusStripEntryRepositoryRow[]>;


### PR DESCRIPTION
## Summary\n- implement the public Thoughts list/detail API under \n- add server-side filter parsing, cursor pagination, DTO mapping, and detail lookup\n- add focused route and repository tests for the Thoughts slice\n\n## Testing\n- bun test\n- bun run typecheck\n- bun run build\n- bun run verify\n\nCloses #39