### PR TITLE
[BE-007] Implement Projects public list detail API

### DIFF
--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -153,6 +153,122 @@ const createThoughtsFamily = (container: BootstrapContainer) => {
   return thoughtsApp;
 };
 
+const parseProjectsQuery = (query: Record<string, string | undefined>) => {
+  const status = query.status;
+
+  if (status && status !== "live" && status !== "archived" && status !== "in-progress") {
+    return {
+      error: {
+        error: "invalid_query",
+        field: "status",
+      },
+    } as const;
+  }
+
+  const sort = query.sort;
+
+  if (sort && sort !== "recent" && sort !== "alpha" && sort !== "channel") {
+    return {
+      error: {
+        error: "invalid_query",
+        field: "sort",
+      },
+    } as const;
+  }
+
+  const page = parsePositiveInteger(query.page);
+
+  if (typeof query.page !== "undefined" && typeof page === "undefined") {
+    return {
+      error: {
+        error: "invalid_query",
+        field: "page",
+      },
+    } as const;
+  }
+
+  const pageSize = parsePositiveInteger(query.pageSize);
+
+  if (typeof query.pageSize !== "undefined" && typeof pageSize === "undefined") {
+    return {
+      error: {
+        error: "invalid_query",
+        field: "pageSize",
+      },
+    } as const;
+  }
+
+  const tags = [query.tag, query.tags]
+    .filter((value): value is string => typeof value === "string")
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  const normalizedStatus: "live" | "archived" | "in-progress" | undefined =
+    status === "live" || status === "archived" || status === "in-progress"
+      ? status
+      : undefined;
+  const normalizedSort: "recent" | "alpha" | "channel" | undefined =
+    sort === "recent" || sort === "alpha" || sort === "channel" ? sort : undefined;
+
+  return {
+    value: {
+      page,
+      pageSize,
+      search: query.search,
+      sort: normalizedSort,
+      status: normalizedStatus,
+      tags,
+    },
+  } as const;
+};
+
+const createProjectsFamily = (container: BootstrapContainer) => {
+  const projectsApp = new Hono();
+
+  projectsApp.get("/", async (c) => {
+    const parsed = parseProjectsQuery(c.req.query());
+
+    if ("error" in parsed) {
+      return c.json(parsed.error, 400);
+    }
+
+    const response = await container.content.listPublishedProjects.execute(parsed.value);
+
+    return c.json(response);
+  });
+
+  projectsApp.get("/:slug", async (c) => {
+    const slug = c.req.param("slug")?.trim();
+
+    if (!slug) {
+      return c.json(
+        {
+          error: "invalid_path",
+          field: "slug",
+        },
+        400,
+      );
+    }
+
+    const project = await container.content.getPublishedProjectBySlug.execute({ slug });
+
+    if (!project) {
+      return c.json(
+        {
+          error: "not_found",
+          resource: "project",
+        },
+        404,
+      );
+    }
+
+    return c.json({ item: project });
+  });
+
+  return projectsApp;
+};
+
 export const createHonoHttpAdapter = (container: BootstrapContainer) => {
   const app = new Hono();
 
@@ -166,7 +282,7 @@ export const createHonoHttpAdapter = (container: BootstrapContainer) => {
   );
 
   app.route("/api/thoughts", createThoughtsFamily(container));
-  mountPlaceholderFamily(app, "/api/projects", "public content");
+  app.route("/api/projects", createProjectsFamily(container));
   mountPlaceholderFamily(app, "/api/photos", "public content");
   mountPlaceholderFamily(app, "/api/status-strip", "status strip");
   mountPlaceholderFamily(app, "/api/chat", "chat");

--- a/backend/src/adapters/inbound/http/hono/projects-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/projects-routes.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "bun:test";
+
+import type { BootstrapContainer } from "@/bootstrap/container";
+
+import { createHonoHttpAdapter } from "./http-adapter";
+
+const createTestContainer = (): BootstrapContainer => ({
+  config: {
+    auth: {
+      mfaCodeMaxAgeSeconds: 600,
+      roomPasswordSecret: "test-room-secret",
+      sessionCookieName: "vinicius.dev-session",
+      sessionMaxAgeSeconds: 604800,
+      sessionSecret: "test-session-secret",
+    },
+    cors: {
+      allowCredentials: true,
+      allowedOrigins: [],
+    },
+    media: {
+      chatRoot: "/tmp/chat",
+      chatUploadAllowedMimeTypes: ["image/jpeg", "image/png", "image/webp"],
+      chatUploadMaxBytes: 5 * 1024 * 1024,
+      chatUploadMaxFilesPerMessage: 1,
+      photosRoot: "/tmp/photos",
+      publicUrlBase: "/media",
+    },
+    server: {
+      apiBasePath: "/api",
+      mediaPhotoOriginalPath: "/media/photos/:id/original",
+      nodeEnv: "test",
+      port: 4000,
+    },
+  },
+  content: {
+    getPublishedProjectBySlug: {
+      execute: async ({ slug }) =>
+        slug === "crt-shader-kit"
+          ? {
+              body: "Shader notes",
+              channel: "07",
+              description: "a tiny webgl shader kit",
+              id: "project_1",
+              links: {
+                github: "#",
+                site: "#",
+              },
+              slug,
+              source: "projects/crt-shader-kit.md",
+              status: "live",
+              tags: ["webgl", "glsl"],
+              thumbnail: {
+                hue: "cyan",
+                kind: "grid",
+              },
+              title: "crt.shader",
+              year: 2025,
+            }
+          : null,
+    },
+    getPublishedThoughtBySlug: {
+      execute: async () => null,
+    },
+    listPublishedProjects: {
+      execute: async ({ page, pageSize, search, sort, status, tags }) => ({
+        items: [
+          {
+            channel: "07",
+            description: `search=${search ?? "none"} tags=${tags?.join("|") ?? "none"} page=${page ?? 0} size=${pageSize ?? 0}`,
+            id: "project_1",
+            links: {
+              github: "#",
+              site: "#",
+            },
+            slug: "crt-shader-kit",
+            status: status ?? "live",
+            tags: ["webgl", "glsl"],
+            thumbnail: {
+              hue: sort === "alpha" ? "pink" : "cyan",
+              kind: "grid",
+            },
+            title: "crt.shader",
+            year: 2025,
+          },
+        ],
+        pageInfo: {
+          page: page ?? 1,
+          pageSize: pageSize ?? 12,
+          totalItems: 1,
+          totalPages: 1,
+        },
+      }),
+    },
+    listPublishedThoughts: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          nextCursor: null,
+        },
+      }),
+    },
+  },
+});
+
+describe("projects routes", () => {
+  it("maps validated list queries to the Projects use case", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request(
+      "/api/projects?status=live&tag=typescript&tags=react,bun&search=shader&sort=alpha&page=2&pageSize=5",
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      items: [
+        {
+          channel: "07",
+          description: "search=shader tags=typescript|react|bun page=2 size=5",
+          id: "project_1",
+          links: {
+            github: "#",
+            site: "#",
+          },
+          slug: "crt-shader-kit",
+          status: "live",
+          tags: ["webgl", "glsl"],
+          thumbnail: {
+            hue: "pink",
+            kind: "grid",
+          },
+          title: "crt.shader",
+          year: 2025,
+        },
+      ],
+      pageInfo: {
+        page: 2,
+        pageSize: 5,
+        totalItems: 1,
+        totalPages: 1,
+      },
+    });
+  });
+
+  it("rejects invalid project list queries before reaching the core", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/api/projects?status=nope&sort=weird");
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_query",
+      field: "status",
+    });
+  });
+
+  it("returns a project detail by slug", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/api/projects/crt-shader-kit");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      item: {
+        body: "Shader notes",
+        channel: "07",
+        description: "a tiny webgl shader kit",
+        id: "project_1",
+        links: {
+          github: "#",
+          site: "#",
+        },
+        slug: "crt-shader-kit",
+        source: "projects/crt-shader-kit.md",
+        status: "live",
+        tags: ["webgl", "glsl"],
+        thumbnail: {
+          hue: "cyan",
+          kind: "grid",
+        },
+        title: "crt.shader",
+        year: 2025,
+      },
+    });
+  });
+
+  it("returns not found for an unknown project slug", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/api/projects/unknown-project");
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "not_found",
+      resource: "project",
+    });
+  });
+});

--- a/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
@@ -33,6 +33,9 @@ const createTestContainer = (): BootstrapContainer => ({
     },
   },
   content: {
+    getPublishedProjectBySlug: {
+      execute: async () => null,
+    },
     getPublishedThoughtBySlug: {
       execute: async ({ slug }) =>
         slug === "night-cable-interfaces"
@@ -70,6 +73,17 @@ const createTestContainer = (): BootstrapContainer => ({
         ],
         pageInfo: {
           nextCursor: null,
+        },
+      }),
+    },
+    listPublishedProjects: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          page: 1,
+          pageSize: 12,
+          totalItems: 0,
+          totalPages: 1,
         },
       }),
     },

--- a/backend/src/adapters/outbound/persistence/prisma/content-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/content-repository.ts
@@ -2,7 +2,9 @@ import type {
   ContentRepositoryPort,
   PhotoListQuery,
   PhotoRepositoryRow,
+  ProjectDetailRepositoryRow,
   ProjectListQuery,
+  ProjectListPage,
   ProjectRepositoryRow,
   StatusStripEntryRepositoryRow,
   ThoughtDetailRepositoryRow,
@@ -10,7 +12,7 @@ import type {
   ThoughtListPage,
   ThoughtRepositoryRow,
 } from "@/modules/content/ports/outbound";
-import { Prisma, ThoughtStatus } from "../../../../../generated/prisma/client";
+import { Prisma, ProjectStatus, ThoughtStatus } from "../../../../../generated/prisma/client";
 
 import type { PrismaDatabaseClient } from "./prisma-client";
 
@@ -66,6 +68,64 @@ const mapThoughtDetailRow = (row: {
   updatedAt: Date;
 }): ThoughtDetailRepositoryRow => ({
   ...mapThoughtRow(row),
+  body: row.body,
+  source: row.source,
+});
+
+const mapProjectRow = (row: {
+  channel: string;
+  createdAt: Date;
+  description: string;
+  featured: boolean;
+  githubUrl: string | null;
+  id: string;
+  siteUrl: string | null;
+  slug: string;
+  status: ProjectStatus;
+  tags: string[];
+  thumbnailHue: number;
+  thumbnailKind: string;
+  title: string;
+  updatedAt: Date;
+  year: number;
+}): ProjectRepositoryRow => ({
+  channel: row.channel,
+  createdAt: row.createdAt,
+  description: row.description,
+  featured: row.featured,
+  githubUrl: row.githubUrl,
+  id: row.id,
+  siteUrl: row.siteUrl,
+  slug: row.slug,
+  status: row.status === ProjectStatus.in_progress ? "in-progress" : row.status,
+  tags: [...row.tags],
+  thumbnailHue: row.thumbnailHue,
+  thumbnailKind: row.thumbnailKind,
+  title: row.title,
+  updatedAt: row.updatedAt,
+  year: row.year,
+});
+
+const mapProjectDetailRow = (row: {
+  body: string;
+  channel: string;
+  createdAt: Date;
+  description: string;
+  featured: boolean;
+  githubUrl: string | null;
+  id: string;
+  siteUrl: string | null;
+  slug: string;
+  source: string | null;
+  status: ProjectStatus;
+  tags: string[];
+  thumbnailHue: number;
+  thumbnailKind: string;
+  title: string;
+  updatedAt: Date;
+  year: number;
+}): ProjectDetailRepositoryRow => ({
+  ...mapProjectRow(row),
   body: row.body,
   source: row.source,
 });
@@ -139,6 +199,16 @@ const buildThoughtBaseWhere = (query: ThoughtListQuery): Prisma.ThoughtWhereInpu
   status: ThoughtStatus.published,
 });
 
+const mapProjectStatusFilter = (
+  value: "live" | "archived" | "in-progress" | undefined,
+): ProjectStatus | undefined => {
+  if (value === "in-progress") {
+    return ProjectStatus.in_progress;
+  }
+
+  return value;
+};
+
 export const createPrismaContentRepository = (client: PrismaDatabaseClient): ContentRepositoryPort => ({
   findPublishedThoughts: async (query: ThoughtListQuery): Promise<ThoughtListPage> => {
     const limit = query.limit ?? 6;
@@ -208,8 +278,100 @@ export const createPrismaContentRepository = (client: PrismaDatabaseClient): Con
 
     return row ? mapThoughtDetailRow(row) : null;
   },
-  findPublishedProjects: (_query: ProjectListQuery): Promise<readonly ProjectRepositoryRow[]> =>
-    notImplemented("findPublishedProjects"),
+  findPublishedProjects: async (query: ProjectListQuery): Promise<ProjectListPage> => {
+    const page = query.page ?? 1;
+    const pageSize = query.pageSize ?? 12;
+    const rows = await client.project.findMany({
+      orderBy:
+        query.sort === "alpha"
+          ? [{ title: "asc" }]
+          : query.sort === "channel"
+            ? [{ channel: "asc" }]
+            : [{ year: "desc" }, { createdAt: "desc" }],
+      select: {
+        channel: true,
+        createdAt: true,
+        description: true,
+        featured: true,
+        githubUrl: true,
+        id: true,
+        siteUrl: true,
+        slug: true,
+        status: true,
+        tags: true,
+        thumbnailHue: true,
+        thumbnailKind: true,
+        title: true,
+        updatedAt: true,
+        year: true,
+      },
+      where: {
+        ...(query.status
+          ? {
+              status: mapProjectStatusFilter(query.status),
+            }
+          : {}),
+        ...(query.tags?.length
+          ? {
+              tags: {
+                hasEvery: [...query.tags],
+              },
+            }
+          : {}),
+      },
+    });
+
+    const normalizedSearch = query.search?.trim().toLowerCase();
+    const filteredRows = normalizedSearch
+      ? rows.filter((row) => {
+          return (
+            row.title.toLowerCase().includes(normalizedSearch) ||
+            row.description.toLowerCase().includes(normalizedSearch) ||
+            row.channel.toLowerCase().includes(normalizedSearch) ||
+            row.tags.some((tag) => tag.toLowerCase().includes(normalizedSearch))
+          );
+        })
+      : rows;
+    const totalItems = filteredRows.length;
+    const totalPages = Math.max(Math.ceil(totalItems / pageSize), 1);
+    const startIndex = (page - 1) * pageSize;
+
+    return {
+      items: filteredRows.slice(startIndex, startIndex + pageSize).map(mapProjectRow),
+      page,
+      pageSize,
+      totalItems,
+      totalPages,
+    };
+  },
+  findPublishedProjectBySlug: async (slug: string): Promise<ProjectDetailRepositoryRow | null> => {
+    const row = await client.project.findFirst({
+      select: {
+        body: true,
+        channel: true,
+        createdAt: true,
+        description: true,
+        featured: true,
+        githubUrl: true,
+        id: true,
+        siteUrl: true,
+        slug: true,
+        source: true,
+        status: true,
+        tags: true,
+        thumbnailHue: true,
+        thumbnailKind: true,
+        title: true,
+        updatedAt: true,
+        year: true,
+      },
+      where: {
+        OR: [{ id: slug }, { slug }],
+      },
+    });
+
+    return row ? mapProjectDetailRow(row) : null;
+  },
   findPublishedPhotos: (_query: PhotoListQuery): Promise<readonly PhotoRepositoryRow[]> =>
     notImplemented("findPublishedPhotos"),
   listStatusStripEntries: (): Promise<readonly StatusStripEntryRepositoryRow[]> =>

--- a/backend/src/adapters/outbound/persistence/prisma/project-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/project-repository.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+
+import { createPrismaContentRepository } from "./content-repository";
+import type { PrismaDatabaseClient } from "./prisma-client";
+
+describe("prisma project repository", () => {
+  it("maps paginated project rows without leaking Prisma types", async () => {
+    const repository = createPrismaContentRepository({
+      project: {
+        findMany: async () => [
+          {
+            channel: "07",
+            createdAt: new Date("2025-01-01T00:00:00.000Z"),
+            description: "a tiny webgl shader kit",
+            featured: true,
+            githubUrl: "#",
+            id: "project_1",
+            siteUrl: "#",
+            slug: "crt-shader-kit",
+            status: "live" as const,
+            tags: ["webgl", "glsl"],
+            thumbnailHue: 180,
+            thumbnailKind: "grid",
+            title: "crt.shader",
+            updatedAt: new Date("2025-01-02T00:00:00.000Z"),
+            year: 2025,
+          },
+          {
+            channel: "15",
+            createdAt: new Date("2024-01-01T00:00:00.000Z"),
+            description: "offline-first music library",
+            featured: false,
+            githubUrl: "#",
+            id: "project_2",
+            siteUrl: null,
+            slug: "tape-deck",
+            status: "archived" as const,
+            tags: ["rust", "tauri"],
+            thumbnailHue: 30,
+            thumbnailKind: "bars",
+            title: "tape.deck",
+            updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+            year: 2024,
+          },
+        ],
+        findFirst: async () => null,
+      },
+      thought: {
+        findMany: async () => [],
+        findFirst: async () => null,
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    const page = await repository.findPublishedProjects({
+      page: 1,
+      pageSize: 1,
+      sort: "recent",
+    });
+
+    expect(page).toEqual({
+      items: [
+        {
+          channel: "07",
+          createdAt: new Date("2025-01-01T00:00:00.000Z"),
+          description: "a tiny webgl shader kit",
+          featured: true,
+          githubUrl: "#",
+          id: "project_1",
+          siteUrl: "#",
+          slug: "crt-shader-kit",
+          status: "live",
+          tags: ["webgl", "glsl"],
+          thumbnailHue: 180,
+          thumbnailKind: "grid",
+          title: "crt.shader",
+          updatedAt: new Date("2025-01-02T00:00:00.000Z"),
+          year: 2025,
+        },
+      ],
+      page: 1,
+      pageSize: 1,
+      totalItems: 2,
+      totalPages: 2,
+    });
+  });
+
+  it("maps a project detail row without leaking Prisma types", async () => {
+    const repository = createPrismaContentRepository({
+      project: {
+        findMany: async () => [],
+        findFirst: async () => ({
+          body: "Shader notes",
+          channel: "07",
+          createdAt: new Date("2025-01-01T00:00:00.000Z"),
+          description: "a tiny webgl shader kit",
+          featured: true,
+          githubUrl: "#",
+          id: "project_1",
+          siteUrl: "#",
+          slug: "crt-shader-kit",
+          source: "projects/crt-shader-kit.md",
+          status: "live" as const,
+          tags: ["webgl", "glsl"],
+          thumbnailHue: 180,
+          thumbnailKind: "grid",
+          title: "crt.shader",
+          updatedAt: new Date("2025-01-02T00:00:00.000Z"),
+          year: 2025,
+        }),
+      },
+      thought: {
+        findMany: async () => [],
+        findFirst: async () => null,
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    const project = await repository.findPublishedProjectBySlug("crt-shader-kit");
+
+    expect(project).toEqual({
+      body: "Shader notes",
+      channel: "07",
+      createdAt: new Date("2025-01-01T00:00:00.000Z"),
+      description: "a tiny webgl shader kit",
+      featured: true,
+      githubUrl: "#",
+      id: "project_1",
+      siteUrl: "#",
+      slug: "crt-shader-kit",
+      source: "projects/crt-shader-kit.md",
+      status: "live",
+      tags: ["webgl", "glsl"],
+      thumbnailHue: 180,
+      thumbnailKind: "grid",
+      title: "crt.shader",
+      updatedAt: new Date("2025-01-02T00:00:00.000Z"),
+      year: 2025,
+    });
+  });
+});

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -1,10 +1,14 @@
 import { createPrismaPersistenceAdapter } from "@/adapters/outbound/persistence";
 import {
+  createGetPublishedProjectBySlugUseCase,
   createGetPublishedThoughtBySlugUseCase,
+  createListPublishedProjectsUseCase,
   createListPublishedThoughtsUseCase,
 } from "@/modules/content/application";
 import type {
+  GetPublishedProjectBySlugPort,
   GetPublishedThoughtBySlugPort,
+  ListPublishedProjectsPort,
   ListPublishedThoughtsPort,
 } from "@/modules/content/ports/inbound";
 
@@ -13,7 +17,9 @@ import { loadBootstrapConfig, type BootstrapConfig } from "../config";
 export type BootstrapContainer = Readonly<{
   config: BootstrapConfig;
   content: Readonly<{
+    getPublishedProjectBySlug: GetPublishedProjectBySlugPort;
     getPublishedThoughtBySlug: GetPublishedThoughtBySlugPort;
+    listPublishedProjects: ListPublishedProjectsPort;
     listPublishedThoughts: ListPublishedThoughtsPort;
   }>;
 }>;
@@ -26,7 +32,13 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
   return {
     config: loadBootstrapConfig(env),
     content: {
+      getPublishedProjectBySlug: createGetPublishedProjectBySlugUseCase({
+        repository: persistence.content,
+      }),
       getPublishedThoughtBySlug: createGetPublishedThoughtBySlugUseCase({
+        repository: persistence.content,
+      }),
+      listPublishedProjects: createListPublishedProjectsUseCase({
         repository: persistence.content,
       }),
       listPublishedThoughts: createListPublishedThoughtsUseCase({

--- a/backend/src/bootstrap/server.test.ts
+++ b/backend/src/bootstrap/server.test.ts
@@ -72,6 +72,61 @@ const createTestContainer = (): BootstrapContainer => ({
         },
       }),
     },
+    getPublishedProjectBySlug: {
+      execute: async ({ slug }) =>
+        slug === "crt-shader-kit"
+          ? {
+              body: "Shader notes",
+              channel: "07",
+              description: "a tiny webgl shader kit",
+              id: "project_1",
+              links: {
+                github: "#",
+                site: "#",
+              },
+              slug,
+              source: null,
+              status: "live",
+              tags: ["webgl", "glsl"],
+              thumbnail: {
+                hue: "cyan",
+                kind: "grid",
+              },
+              title: "crt.shader",
+              year: 2025,
+            }
+          : null,
+    },
+    listPublishedProjects: {
+      execute: async () => ({
+        items: [
+          {
+            channel: "07",
+            description: "a tiny webgl shader kit",
+            id: "project_1",
+            links: {
+              github: "#",
+              site: "#",
+            },
+            slug: "crt-shader-kit",
+            status: "live",
+            tags: ["webgl", "glsl"],
+            thumbnail: {
+              hue: "cyan",
+              kind: "grid",
+            },
+            title: "crt.shader",
+            year: 2025,
+          },
+        ],
+        pageInfo: {
+          page: 1,
+          pageSize: 12,
+          totalItems: 1,
+          totalPages: 1,
+        },
+      }),
+    },
   },
 });
 
@@ -121,8 +176,38 @@ describe("backend server scaffold", () => {
       },
     });
 
+    const projectsResponse = await app.request("/api/projects");
+    expect(projectsResponse.status).toBe(200);
+    await expect(projectsResponse.json()).resolves.toEqual({
+      items: [
+        {
+          channel: "07",
+          description: "a tiny webgl shader kit",
+          id: "project_1",
+          links: {
+            github: "#",
+            site: "#",
+          },
+          slug: "crt-shader-kit",
+          status: "live",
+          tags: ["webgl", "glsl"],
+          thumbnail: {
+            hue: "cyan",
+            kind: "grid",
+          },
+          title: "crt.shader",
+          year: 2025,
+        },
+      ],
+      pageInfo: {
+        page: 1,
+        pageSize: 12,
+        totalItems: 1,
+        totalPages: 1,
+      },
+    });
+
     const placeholderRoutes = [
-      ["/api/projects", "public content"],
       ["/api/photos", "public content"],
       ["/api/status-strip", "status strip"],
       ["/api/chat", "chat"],

--- a/backend/src/modules/content/application/index.ts
+++ b/backend/src/modules/content/application/index.ts
@@ -3,19 +3,30 @@ import type {
   ThoughtCursor,
   ThoughtDetailRepositoryRow,
   ThoughtRepositoryRow,
+  ProjectDetailRepositoryRow,
+  ProjectRepositoryRow,
 } from "@/modules/content/ports/outbound";
 
 import type {
+  GetPublishedProjectBySlugPort,
   GetPublishedThoughtBySlugPort,
+  ListPublishedProjectsInput,
+  ListPublishedProjectsOutput,
+  ListPublishedProjectsPort,
   ListPublishedThoughtsInput,
   ListPublishedThoughtsOutput,
   ListPublishedThoughtsPort,
+  PublishedProjectDetail,
+  PublishedProjectSummary,
   PublishedThoughtDetail,
   PublishedThoughtSummary,
 } from "../ports/inbound";
 
 const DEFAULT_THOUGHTS_PAGE_SIZE = 6;
 const MAX_THOUGHTS_PAGE_SIZE = 24;
+const DEFAULT_PROJECTS_PAGE = 1;
+const DEFAULT_PROJECTS_PAGE_SIZE = 12;
+const MAX_PROJECTS_PAGE_SIZE = 48;
 
 export class InvalidThoughtCursorError extends Error {
   constructor() {
@@ -59,12 +70,73 @@ const mapThoughtDetail = (row: ThoughtDetailRepositoryRow): PublishedThoughtDeta
   source: row.source,
 });
 
+const mapProjectHue = (value: number): "amber" | "cyan" | "pink" => {
+  if (value <= 90) {
+    return "amber";
+  }
+
+  if (value <= 270) {
+    return "cyan";
+  }
+
+  return "pink";
+};
+
+const mapProjectKind = (value: string): "bars" | "grid" | "noise" | "sig" => {
+  if (value === "bars" || value === "grid" || value === "noise" || value === "sig") {
+    return value;
+  }
+
+  return "bars";
+};
+
+const mapProjectSummary = (row: ProjectRepositoryRow): PublishedProjectSummary => ({
+  channel: row.channel,
+  description: row.description,
+  id: row.id,
+  links: {
+    github: row.githubUrl,
+    site: row.siteUrl,
+  },
+  slug: row.slug,
+  status: row.status,
+  tags: [...row.tags],
+  thumbnail: {
+    hue: mapProjectHue(row.thumbnailHue),
+    kind: mapProjectKind(row.thumbnailKind),
+  },
+  title: row.title,
+  year: row.year,
+});
+
+const mapProjectDetail = (row: ProjectDetailRepositoryRow): PublishedProjectDetail => ({
+  ...mapProjectSummary(row),
+  body: row.body,
+  source: row.source,
+});
+
 const normalizeLimit = (value?: number): number => {
   if (typeof value !== "number" || Number.isNaN(value)) {
     return DEFAULT_THOUGHTS_PAGE_SIZE;
   }
 
   return Math.min(Math.max(Math.trunc(value), 1), MAX_THOUGHTS_PAGE_SIZE);
+};
+
+const normalizeProjectPage = (value?: number): number => {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return DEFAULT_PROJECTS_PAGE;
+  }
+
+  return Math.max(Math.trunc(value), 1);
+};
+
+const normalizeProjectPageSize = (value?: number): number => {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return DEFAULT_PROJECTS_PAGE_SIZE;
+  }
+
+  return Math.min(Math.max(Math.trunc(value), 1), MAX_PROJECTS_PAGE_SIZE);
 };
 
 const encodeThoughtCursor = (cursor: ThoughtCursor): string => {
@@ -136,5 +208,40 @@ export const createGetPublishedThoughtBySlugUseCase = ({
     const thought = await repository.findPublishedThoughtBySlug(slug);
 
     return thought ? mapThoughtDetail(thought) : null;
+  },
+});
+
+export const createListPublishedProjectsUseCase = ({
+  repository,
+}: ContentApplicationDependencies): ListPublishedProjectsPort => ({
+  execute: async (input: ListPublishedProjectsInput): Promise<ListPublishedProjectsOutput> => {
+    const result = await repository.findPublishedProjects({
+      page: normalizeProjectPage(input.page),
+      pageSize: normalizeProjectPageSize(input.pageSize),
+      search: input.search?.trim() || undefined,
+      sort: input.sort,
+      status: input.status,
+      tags: input.tags?.filter(Boolean),
+    });
+
+    return {
+      items: result.items.map(mapProjectSummary),
+      pageInfo: {
+        page: result.page,
+        pageSize: result.pageSize,
+        totalItems: result.totalItems,
+        totalPages: result.totalPages,
+      },
+    };
+  },
+});
+
+export const createGetPublishedProjectBySlugUseCase = ({
+  repository,
+}: ContentApplicationDependencies): GetPublishedProjectBySlugPort => ({
+  execute: async ({ slug }) => {
+    const project = await repository.findPublishedProjectBySlug(slug);
+
+    return project ? mapProjectDetail(project) : null;
   },
 });

--- a/backend/src/modules/content/ports/inbound/index.ts
+++ b/backend/src/modules/content/ports/inbound/index.ts
@@ -43,3 +43,57 @@ export interface ListPublishedThoughtsPort
 
 export interface GetPublishedThoughtBySlugPort
   extends UseCase<GetPublishedThoughtBySlugInput, PublishedThoughtDetail | null> {}
+
+export type PublishedProjectSummary = Readonly<{
+  id: string;
+  channel: string;
+  title: string;
+  slug: string;
+  year: number;
+  status: "live" | "archived" | "in-progress";
+  description: string;
+  tags: readonly string[];
+  links: Readonly<{
+    github?: string | null;
+    site?: string | null;
+  }>;
+  thumbnail: Readonly<{
+    hue: "amber" | "cyan" | "pink";
+    kind: "bars" | "grid" | "noise" | "sig";
+  }>;
+}>;
+
+export type PublishedProjectDetail = PublishedProjectSummary &
+  Readonly<{
+    body: string;
+    source: string | null;
+  }>;
+
+export type ListPublishedProjectsInput = Readonly<{
+  page?: number;
+  pageSize?: number;
+  status?: "live" | "archived" | "in-progress";
+  tags?: readonly string[];
+  search?: string;
+  sort?: "recent" | "alpha" | "channel";
+}>;
+
+export type ListPublishedProjectsOutput = Readonly<{
+  items: readonly PublishedProjectSummary[];
+  pageInfo: Readonly<{
+    page: number;
+    pageSize: number;
+    totalItems: number;
+    totalPages: number;
+  }>;
+}>;
+
+export type GetPublishedProjectBySlugInput = Readonly<{
+  slug: string;
+}>;
+
+export interface ListPublishedProjectsPort
+  extends UseCase<ListPublishedProjectsInput, ListPublishedProjectsOutput> {}
+
+export interface GetPublishedProjectBySlugPort
+  extends UseCase<GetPublishedProjectBySlugInput, PublishedProjectDetail | null> {}

--- a/backend/src/modules/content/ports/outbound/index.ts
+++ b/backend/src/modules/content/ports/outbound/index.ts
@@ -48,6 +48,20 @@ export type ProjectRepositoryRow = Readonly<{
   updatedAt: Date;
 }>;
 
+export type ProjectDetailRepositoryRow = ProjectRepositoryRow &
+  Readonly<{
+    body: string;
+    source: string | null;
+  }>;
+
+export type ProjectListPage = Readonly<{
+  items: readonly ProjectRepositoryRow[];
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+}>;
+
 export type PhotoRepositoryRow = Readonly<{
   id: string;
   frame: string;
@@ -100,7 +114,8 @@ export type PhotoListQuery = Readonly<{
 export interface ContentRepositoryPort {
   findPublishedThoughts(query: ThoughtListQuery): Promise<ThoughtListPage>;
   findPublishedThoughtBySlug(slug: string): Promise<ThoughtDetailRepositoryRow | null>;
-  findPublishedProjects(query: ProjectListQuery): Promise<readonly ProjectRepositoryRow[]>;
+  findPublishedProjects(query: ProjectListQuery): Promise<ProjectListPage>;
+  findPublishedProjectBySlug(slug: string): Promise<ProjectDetailRepositoryRow | null>;
   findPublishedPhotos(query: PhotoListQuery): Promise<readonly PhotoRepositoryRow[]>;
   listStatusStripEntries(): Promise<readonly StatusStripEntryRepositoryRow[]>;
 }


### PR DESCRIPTION
## Summary
- implement the public Projects list/detail API under `/api/projects`
- add server-side search, status/tag/sort filters, page pagination, and DTO mapping
- add focused route and repository tests for the Projects slice

## Testing
- bun test
- bun run typecheck
- bun run build
- bun run verify

Closes #40
