### PR TITLE
[BE-008] Implement Photos public list detail API

### DIFF
--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -269,6 +269,97 @@ const createProjectsFamily = (container: BootstrapContainer) => {
   return projectsApp;
 };
 
+const parsePhotosQuery = (query: Record<string, string | undefined>) => {
+  const page = parsePositiveInteger(query.page);
+
+  if (typeof query.page !== "undefined" && typeof page === "undefined") {
+    return {
+      error: {
+        error: "invalid_query",
+        field: "page",
+      },
+    } as const;
+  }
+
+  const pageSize = parsePositiveInteger(query.pageSize);
+
+  if (typeof query.pageSize !== "undefined" && typeof pageSize === "undefined") {
+    return {
+      error: {
+        error: "invalid_query",
+        field: "pageSize",
+      },
+    } as const;
+  }
+
+  const year = parsePositiveInteger(query.year);
+
+  if (typeof query.year !== "undefined" && typeof year === "undefined") {
+    return {
+      error: {
+        error: "invalid_query",
+        field: "year",
+      },
+    } as const;
+  }
+
+  return {
+    value: {
+      location: query.location,
+      page,
+      pageSize,
+      search: query.search,
+      year,
+    },
+  } as const;
+};
+
+const createPhotosFamily = (container: BootstrapContainer) => {
+  const photosApp = new Hono();
+
+  photosApp.get("/", async (c) => {
+    const parsed = parsePhotosQuery(c.req.query());
+
+    if ("error" in parsed) {
+      return c.json(parsed.error, 400);
+    }
+
+    const response = await container.content.listPublishedPhotos.execute(parsed.value);
+
+    return c.json(response);
+  });
+
+  photosApp.get("/:id", async (c) => {
+    const id = c.req.param("id")?.trim();
+
+    if (!id) {
+      return c.json(
+        {
+          error: "invalid_path",
+          field: "id",
+        },
+        400,
+      );
+    }
+
+    const photo = await container.content.getPublishedPhotoById.execute({ id });
+
+    if (!photo) {
+      return c.json(
+        {
+          error: "not_found",
+          resource: "photo",
+        },
+        404,
+      );
+    }
+
+    return c.json({ item: photo });
+  });
+
+  return photosApp;
+};
+
 export const createHonoHttpAdapter = (container: BootstrapContainer) => {
   const app = new Hono();
 
@@ -283,7 +374,7 @@ export const createHonoHttpAdapter = (container: BootstrapContainer) => {
 
   app.route("/api/thoughts", createThoughtsFamily(container));
   app.route("/api/projects", createProjectsFamily(container));
-  mountPlaceholderFamily(app, "/api/photos", "public content");
+  app.route("/api/photos", createPhotosFamily(container));
   mountPlaceholderFamily(app, "/api/status-strip", "status strip");
   mountPlaceholderFamily(app, "/api/chat", "chat");
   mountPlaceholderFamily(app, "/api/admin", "admin");

--- a/backend/src/adapters/inbound/http/hono/photos-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/photos-routes.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "bun:test";
+
+import type { BootstrapContainer } from "@/bootstrap/container";
+
+import { createHonoHttpAdapter } from "./http-adapter";
+
+const createTestContainer = (): BootstrapContainer => ({
+  config: {
+    auth: {
+      mfaCodeMaxAgeSeconds: 600,
+      roomPasswordSecret: "test-room-secret",
+      sessionCookieName: "vinicius.dev-session",
+      sessionMaxAgeSeconds: 604800,
+      sessionSecret: "test-session-secret",
+    },
+    cors: {
+      allowCredentials: true,
+      allowedOrigins: [],
+    },
+    media: {
+      chatRoot: "/tmp/chat",
+      chatUploadAllowedMimeTypes: ["image/jpeg", "image/png", "image/webp"],
+      chatUploadMaxBytes: 5 * 1024 * 1024,
+      chatUploadMaxFilesPerMessage: 1,
+      photosRoot: "/tmp/photos",
+      publicUrlBase: "/media",
+    },
+    server: {
+      apiBasePath: "/api",
+      mediaPhotoOriginalPath: "/media/photos/:id/original",
+      nodeEnv: "test",
+      port: 4000,
+    },
+  },
+  content: {
+    getPublishedProjectBySlug: {
+      execute: async () => null,
+    },
+    getPublishedPhotoById: {
+      execute: async ({ id }) =>
+        id === "p-2026-014"
+          ? {
+              camera: "Canon T7+",
+              caption: "Night street frame.",
+              date: "2026-03-22",
+              film: "digital",
+              frame: "014",
+              id,
+              location: "Sao Paulo",
+              originalUrl: "/media/photos/p-2026-014/original",
+              tags: ["night", "street"],
+              title: "paulista at 02:14",
+              tone: "sunset",
+            }
+          : null,
+    },
+    getPublishedThoughtBySlug: {
+      execute: async () => null,
+    },
+    listPublishedPhotos: {
+      execute: async ({ location, page, pageSize, search, year }) => ({
+        items: [
+          {
+            date: "2026-03-22",
+            frame: "014",
+            id: "p-2026-014",
+            location: location ?? "Sao Paulo",
+            originalUrl: "/media/photos/p-2026-014/original",
+            tags: ["night", "street"],
+            title: `search=${search ?? "none"} year=${year ?? 0} page=${page ?? 0} size=${pageSize ?? 0}`,
+            tone: "sunset",
+          },
+        ],
+        pageInfo: {
+          page: page ?? 1,
+          pageSize: pageSize ?? 24,
+          totalItems: 1,
+          totalPages: 1,
+        },
+      }),
+    },
+    listPublishedProjects: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          page: 1,
+          pageSize: 12,
+          totalItems: 0,
+          totalPages: 1,
+        },
+      }),
+    },
+    listPublishedThoughts: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          nextCursor: null,
+        },
+      }),
+    },
+  },
+});
+
+describe("photos routes", () => {
+  it("maps validated list queries to the Photos use case", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request(
+      "/api/photos?year=2026&location=Sao%20Paulo&search=night&page=2&pageSize=8",
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      items: [
+        {
+          date: "2026-03-22",
+          frame: "014",
+          id: "p-2026-014",
+          location: "Sao Paulo",
+          originalUrl: "/media/photos/p-2026-014/original",
+          tags: ["night", "street"],
+          title: "search=night year=2026 page=2 size=8",
+          tone: "sunset",
+        },
+      ],
+      pageInfo: {
+        page: 2,
+        pageSize: 8,
+        totalItems: 1,
+        totalPages: 1,
+      },
+    });
+  });
+
+  it("rejects invalid photo list queries before reaching the core", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/api/photos?year=nope");
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_query",
+      field: "year",
+    });
+  });
+
+  it("returns a photo detail by id", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/api/photos/p-2026-014");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      item: {
+        camera: "Canon T7+",
+        caption: "Night street frame.",
+        date: "2026-03-22",
+        film: "digital",
+        frame: "014",
+        id: "p-2026-014",
+        location: "Sao Paulo",
+        originalUrl: "/media/photos/p-2026-014/original",
+        tags: ["night", "street"],
+        title: "paulista at 02:14",
+        tone: "sunset",
+      },
+    });
+  });
+
+  it("returns not found for an unknown photo id", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/api/photos/missing");
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "not_found",
+      resource: "photo",
+    });
+  });
+});

--- a/backend/src/adapters/inbound/http/hono/projects-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/projects-routes.test.ts
@@ -58,6 +58,9 @@ const createTestContainer = (): BootstrapContainer => ({
             }
           : null,
     },
+    getPublishedPhotoById: {
+      execute: async () => null,
+    },
     getPublishedThoughtBySlug: {
       execute: async () => null,
     },
@@ -87,6 +90,17 @@ const createTestContainer = (): BootstrapContainer => ({
           page: page ?? 1,
           pageSize: pageSize ?? 12,
           totalItems: 1,
+          totalPages: 1,
+        },
+      }),
+    },
+    listPublishedPhotos: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          page: 1,
+          pageSize: 24,
+          totalItems: 0,
           totalPages: 1,
         },
       }),

--- a/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
@@ -36,6 +36,9 @@ const createTestContainer = (): BootstrapContainer => ({
     getPublishedProjectBySlug: {
       execute: async () => null,
     },
+    getPublishedPhotoById: {
+      execute: async () => null,
+    },
     getPublishedThoughtBySlug: {
       execute: async ({ slug }) =>
         slug === "night-cable-interfaces"
@@ -82,6 +85,17 @@ const createTestContainer = (): BootstrapContainer => ({
         pageInfo: {
           page: 1,
           pageSize: 12,
+          totalItems: 0,
+          totalPages: 1,
+        },
+      }),
+    },
+    listPublishedPhotos: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          page: 1,
+          pageSize: 24,
           totalItems: 0,
           totalPages: 1,
         },

--- a/backend/src/adapters/outbound/persistence/prisma/content-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/content-repository.ts
@@ -1,6 +1,8 @@
 import type {
   ContentRepositoryPort,
+  PhotoDetailRepositoryRow,
   PhotoListQuery,
+  PhotoListPage,
   PhotoRepositoryRow,
   ProjectDetailRepositoryRow,
   ProjectListQuery,
@@ -12,7 +14,12 @@ import type {
   ThoughtListPage,
   ThoughtRepositoryRow,
 } from "@/modules/content/ports/outbound";
-import { Prisma, ProjectStatus, ThoughtStatus } from "../../../../../generated/prisma/client";
+import {
+  PhotoStatus,
+  Prisma,
+  ProjectStatus,
+  ThoughtStatus,
+} from "../../../../../generated/prisma/client";
 
 import type { PrismaDatabaseClient } from "./prisma-client";
 
@@ -128,6 +135,54 @@ const mapProjectDetailRow = (row: {
   ...mapProjectRow(row),
   body: row.body,
   source: row.source,
+});
+
+const mapPhotoRow = (row: {
+  caption: string | null;
+  createdAt: Date;
+  date: Date;
+  featured: boolean;
+  frame: string;
+  id: string;
+  location: string;
+  tags: string[];
+  title: string;
+  tone: "amber" | "cyan" | "mono" | "sunset" | "violet";
+  updatedAt: Date;
+}): PhotoRepositoryRow => ({
+  caption: row.caption,
+  createdAt: row.createdAt,
+  date: row.date,
+  featured: row.featured,
+  frame: row.frame,
+  id: row.id,
+  location: row.location,
+  tags: [...row.tags],
+  title: row.title,
+  tone: row.tone,
+  updatedAt: row.updatedAt,
+});
+
+const mapPhotoDetailRow = (row: {
+  camera: string | null;
+  caption: string | null;
+  createdAt: Date;
+  date: Date;
+  featured: boolean;
+  film: string | null;
+  frame: string;
+  id: string;
+  location: string;
+  originalPath: string;
+  tags: string[];
+  title: string;
+  tone: "amber" | "cyan" | "mono" | "sunset" | "violet";
+  updatedAt: Date;
+}): PhotoDetailRepositoryRow => ({
+  ...mapPhotoRow(row),
+  camera: row.camera,
+  film: row.film,
+  originalPath: row.originalPath,
 });
 
 const applyThoughtSearch = <
@@ -372,8 +427,91 @@ export const createPrismaContentRepository = (client: PrismaDatabaseClient): Con
 
     return row ? mapProjectDetailRow(row) : null;
   },
-  findPublishedPhotos: (_query: PhotoListQuery): Promise<readonly PhotoRepositoryRow[]> =>
-    notImplemented("findPublishedPhotos"),
+  findPublishedPhotos: async (query: PhotoListQuery): Promise<PhotoListPage> => {
+    const page = query.page ?? 1;
+    const pageSize = query.pageSize ?? 24;
+    const rows = await client.photo.findMany({
+      orderBy: [{ date: "desc" }, { id: "desc" }],
+      select: {
+        caption: true,
+        createdAt: true,
+        date: true,
+        featured: true,
+        frame: true,
+        id: true,
+        location: true,
+        tags: true,
+        title: true,
+        tone: true,
+        updatedAt: true,
+      },
+      where: {
+        ...(query.location
+          ? {
+              location: query.location,
+            }
+          : {}),
+        ...(query.year
+          ? {
+              date: {
+                gte: new Date(Date.UTC(query.year, 0, 1)),
+                lt: new Date(Date.UTC(query.year + 1, 0, 1)),
+              },
+            }
+          : {}),
+        status: PhotoStatus.published,
+      },
+    });
+
+    const normalizedSearch = query.search?.trim().toLowerCase();
+    const filteredRows = normalizedSearch
+      ? rows.filter((row) => {
+          return (
+            row.title.toLowerCase().includes(normalizedSearch) ||
+            row.location.toLowerCase().includes(normalizedSearch) ||
+            row.frame.toLowerCase().includes(normalizedSearch) ||
+            row.tags.some((tag) => tag.toLowerCase().includes(normalizedSearch))
+          );
+        })
+      : rows;
+    const totalItems = filteredRows.length;
+    const totalPages = Math.max(Math.ceil(totalItems / pageSize), 1);
+    const startIndex = (page - 1) * pageSize;
+
+    return {
+      items: filteredRows.slice(startIndex, startIndex + pageSize).map(mapPhotoRow),
+      page,
+      pageSize,
+      totalItems,
+      totalPages,
+    };
+  },
+  findPublishedPhotoById: async (id: string): Promise<PhotoDetailRepositoryRow | null> => {
+    const row = await client.photo.findFirst({
+      select: {
+        camera: true,
+        caption: true,
+        createdAt: true,
+        date: true,
+        featured: true,
+        film: true,
+        frame: true,
+        id: true,
+        location: true,
+        originalPath: true,
+        tags: true,
+        title: true,
+        tone: true,
+        updatedAt: true,
+      },
+      where: {
+        id,
+        status: PhotoStatus.published,
+      },
+    });
+
+    return row ? mapPhotoDetailRow(row) : null;
+  },
   listStatusStripEntries: (): Promise<readonly StatusStripEntryRepositoryRow[]> =>
     notImplemented("listStatusStripEntries"),
 });

--- a/backend/src/adapters/outbound/persistence/prisma/photo-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/photo-repository.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "bun:test";
+
+import { createPrismaContentRepository } from "./content-repository";
+import type { PrismaDatabaseClient } from "./prisma-client";
+
+describe("prisma photo repository", () => {
+  it("maps paginated photo rows without leaking Prisma types", async () => {
+    const repository = createPrismaContentRepository({
+      photo: {
+        findMany: async () => [
+          {
+            caption: "Night street frame.",
+            createdAt: new Date("2026-03-22T00:00:00.000Z"),
+            date: new Date("2026-03-22T00:00:00.000Z"),
+            featured: true,
+            frame: "014",
+            id: "p-2026-014",
+            location: "Sao Paulo",
+            tags: ["night", "street"],
+            title: "paulista at 02:14",
+            tone: "sunset" as const,
+            updatedAt: new Date("2026-03-23T00:00:00.000Z"),
+          },
+          {
+            caption: null,
+            createdAt: new Date("2026-03-18T00:00:00.000Z"),
+            date: new Date("2026-03-18T00:00:00.000Z"),
+            featured: false,
+            frame: "013",
+            id: "p-2026-013",
+            location: "Sao Paulo",
+            tags: ["night", "arcade"],
+            title: "arcade exit",
+            tone: "cyan" as const,
+            updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+          },
+        ],
+        findFirst: async () => null,
+      },
+      project: {
+        findMany: async () => [],
+        findFirst: async () => null,
+      },
+      thought: {
+        findMany: async () => [],
+        findFirst: async () => null,
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    const page = await repository.findPublishedPhotos({
+      page: 1,
+      pageSize: 1,
+      year: 2026,
+    });
+
+    expect(page).toEqual({
+      items: [
+        {
+          caption: "Night street frame.",
+          createdAt: new Date("2026-03-22T00:00:00.000Z"),
+          date: new Date("2026-03-22T00:00:00.000Z"),
+          featured: true,
+          frame: "014",
+          id: "p-2026-014",
+          location: "Sao Paulo",
+          tags: ["night", "street"],
+          title: "paulista at 02:14",
+          tone: "sunset",
+          updatedAt: new Date("2026-03-23T00:00:00.000Z"),
+        },
+      ],
+      page: 1,
+      pageSize: 1,
+      totalItems: 2,
+      totalPages: 2,
+    });
+  });
+
+  it("maps a published photo detail row without leaking Prisma types", async () => {
+    const repository = createPrismaContentRepository({
+      photo: {
+        findMany: async () => [],
+        findFirst: async () => ({
+          camera: "Canon T7+",
+          caption: "Night street frame.",
+          createdAt: new Date("2026-03-22T00:00:00.000Z"),
+          date: new Date("2026-03-22T00:00:00.000Z"),
+          featured: true,
+          film: "digital",
+          frame: "014",
+          id: "p-2026-014",
+          location: "Sao Paulo",
+          originalPath: "photos/p-2026-014/original.jpg",
+          tags: ["night", "street"],
+          title: "paulista at 02:14",
+          tone: "sunset" as const,
+          updatedAt: new Date("2026-03-23T00:00:00.000Z"),
+        }),
+      },
+      project: {
+        findMany: async () => [],
+        findFirst: async () => null,
+      },
+      thought: {
+        findMany: async () => [],
+        findFirst: async () => null,
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    const photo = await repository.findPublishedPhotoById("p-2026-014");
+
+    expect(photo).toEqual({
+      camera: "Canon T7+",
+      caption: "Night street frame.",
+      createdAt: new Date("2026-03-22T00:00:00.000Z"),
+      date: new Date("2026-03-22T00:00:00.000Z"),
+      featured: true,
+      film: "digital",
+      frame: "014",
+      id: "p-2026-014",
+      location: "Sao Paulo",
+      originalPath: "photos/p-2026-014/original.jpg",
+      tags: ["night", "street"],
+      title: "paulista at 02:14",
+      tone: "sunset",
+      updatedAt: new Date("2026-03-23T00:00:00.000Z"),
+    });
+  });
+});

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -1,13 +1,17 @@
 import { createPrismaPersistenceAdapter } from "@/adapters/outbound/persistence";
 import {
   createGetPublishedProjectBySlugUseCase,
+  createGetPublishedPhotoByIdUseCase,
   createGetPublishedThoughtBySlugUseCase,
+  createListPublishedPhotosUseCase,
   createListPublishedProjectsUseCase,
   createListPublishedThoughtsUseCase,
 } from "@/modules/content/application";
 import type {
   GetPublishedProjectBySlugPort,
+  GetPublishedPhotoByIdPort,
   GetPublishedThoughtBySlugPort,
+  ListPublishedPhotosPort,
   ListPublishedProjectsPort,
   ListPublishedThoughtsPort,
 } from "@/modules/content/ports/inbound";
@@ -18,7 +22,9 @@ export type BootstrapContainer = Readonly<{
   config: BootstrapConfig;
   content: Readonly<{
     getPublishedProjectBySlug: GetPublishedProjectBySlugPort;
+    getPublishedPhotoById: GetPublishedPhotoByIdPort;
     getPublishedThoughtBySlug: GetPublishedThoughtBySlugPort;
+    listPublishedPhotos: ListPublishedPhotosPort;
     listPublishedProjects: ListPublishedProjectsPort;
     listPublishedThoughts: ListPublishedThoughtsPort;
   }>;
@@ -35,7 +41,13 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
       getPublishedProjectBySlug: createGetPublishedProjectBySlugUseCase({
         repository: persistence.content,
       }),
+      getPublishedPhotoById: createGetPublishedPhotoByIdUseCase({
+        repository: persistence.content,
+      }),
       getPublishedThoughtBySlug: createGetPublishedThoughtBySlugUseCase({
+        repository: persistence.content,
+      }),
+      listPublishedPhotos: createListPublishedPhotosUseCase({
         repository: persistence.content,
       }),
       listPublishedProjects: createListPublishedProjectsUseCase({

--- a/backend/src/bootstrap/server.test.ts
+++ b/backend/src/bootstrap/server.test.ts
@@ -127,6 +127,46 @@ const createTestContainer = (): BootstrapContainer => ({
         },
       }),
     },
+    getPublishedPhotoById: {
+      execute: async ({ id }) =>
+        id === "p-2026-014"
+          ? {
+              camera: "Canon T7+",
+              caption: "Night street frame.",
+              date: "2026-03-22",
+              film: "digital",
+              frame: "014",
+              id,
+              location: "Sao Paulo",
+              originalUrl: "/media/photos/p-2026-014/original",
+              tags: ["night", "street"],
+              title: "paulista at 02:14",
+              tone: "sunset",
+            }
+          : null,
+    },
+    listPublishedPhotos: {
+      execute: async () => ({
+        items: [
+          {
+            date: "2026-03-22",
+            frame: "014",
+            id: "p-2026-014",
+            location: "Sao Paulo",
+            originalUrl: "/media/photos/p-2026-014/original",
+            tags: ["night", "street"],
+            title: "paulista at 02:14",
+            tone: "sunset",
+          },
+        ],
+        pageInfo: {
+          page: 1,
+          pageSize: 24,
+          totalItems: 1,
+          totalPages: 1,
+        },
+      }),
+    },
   },
 });
 
@@ -207,13 +247,34 @@ describe("backend server scaffold", () => {
       },
     });
 
+    const photosResponse = await app.request("/api/photos");
+    expect(photosResponse.status).toBe(200);
+    await expect(photosResponse.json()).resolves.toEqual({
+      items: [
+        {
+          date: "2026-03-22",
+          frame: "014",
+          id: "p-2026-014",
+          location: "Sao Paulo",
+          originalUrl: "/media/photos/p-2026-014/original",
+          tags: ["night", "street"],
+          title: "paulista at 02:14",
+          tone: "sunset",
+        },
+      ],
+      pageInfo: {
+        page: 1,
+        pageSize: 24,
+        totalItems: 1,
+        totalPages: 1,
+      },
+    });
+
     const placeholderRoutes = [
-      ["/api/photos", "public content"],
       ["/api/status-strip", "status strip"],
       ["/api/chat", "chat"],
       ["/api/admin", "admin"],
       ["/api/auth", "auth"],
-      ["/api/rss", "rss"],
       ["/api/sitemap", "sitemap"],
       ["/media/photos/123/original", "photo media"],
     ] as const;

--- a/backend/src/modules/content/application/index.ts
+++ b/backend/src/modules/content/application/index.ts
@@ -1,5 +1,7 @@
 import type {
   ContentRepositoryPort,
+  PhotoDetailRepositoryRow,
+  PhotoRepositoryRow,
   ThoughtCursor,
   ThoughtDetailRepositoryRow,
   ThoughtRepositoryRow,
@@ -9,7 +11,11 @@ import type {
 
 import type {
   GetPublishedProjectBySlugPort,
+  GetPublishedPhotoByIdPort,
   GetPublishedThoughtBySlugPort,
+  ListPublishedPhotosInput,
+  ListPublishedPhotosOutput,
+  ListPublishedPhotosPort,
   ListPublishedProjectsInput,
   ListPublishedProjectsOutput,
   ListPublishedProjectsPort,
@@ -18,6 +24,8 @@ import type {
   ListPublishedThoughtsPort,
   PublishedProjectDetail,
   PublishedProjectSummary,
+  PublishedPhotoDetail,
+  PublishedPhotoSummary,
   PublishedThoughtDetail,
   PublishedThoughtSummary,
 } from "../ports/inbound";
@@ -27,6 +35,9 @@ const MAX_THOUGHTS_PAGE_SIZE = 24;
 const DEFAULT_PROJECTS_PAGE = 1;
 const DEFAULT_PROJECTS_PAGE_SIZE = 12;
 const MAX_PROJECTS_PAGE_SIZE = 48;
+const DEFAULT_PHOTOS_PAGE = 1;
+const DEFAULT_PHOTOS_PAGE_SIZE = 24;
+const MAX_PHOTOS_PAGE_SIZE = 96;
 
 export class InvalidThoughtCursorError extends Error {
   constructor() {
@@ -115,6 +126,26 @@ const mapProjectDetail = (row: ProjectDetailRepositoryRow): PublishedProjectDeta
   source: row.source,
 });
 
+const buildPhotoOriginalUrl = (id: string): string => `/media/photos/${id}/original`;
+
+const mapPhotoSummary = (row: PhotoRepositoryRow): PublishedPhotoSummary => ({
+  date: row.date.toISOString().slice(0, 10),
+  frame: row.frame,
+  id: row.id,
+  location: row.location,
+  originalUrl: buildPhotoOriginalUrl(row.id),
+  tags: [...row.tags],
+  title: row.title,
+  tone: row.tone,
+});
+
+const mapPhotoDetail = (row: PhotoDetailRepositoryRow): PublishedPhotoDetail => ({
+  ...mapPhotoSummary(row),
+  camera: row.camera,
+  caption: row.caption,
+  film: row.film,
+});
+
 const normalizeLimit = (value?: number): number => {
   if (typeof value !== "number" || Number.isNaN(value)) {
     return DEFAULT_THOUGHTS_PAGE_SIZE;
@@ -137,6 +168,22 @@ const normalizeProjectPageSize = (value?: number): number => {
   }
 
   return Math.min(Math.max(Math.trunc(value), 1), MAX_PROJECTS_PAGE_SIZE);
+};
+
+const normalizePhotoPage = (value?: number): number => {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return DEFAULT_PHOTOS_PAGE;
+  }
+
+  return Math.max(Math.trunc(value), 1);
+};
+
+const normalizePhotoPageSize = (value?: number): number => {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return DEFAULT_PHOTOS_PAGE_SIZE;
+  }
+
+  return Math.min(Math.max(Math.trunc(value), 1), MAX_PHOTOS_PAGE_SIZE);
 };
 
 const encodeThoughtCursor = (cursor: ThoughtCursor): string => {
@@ -243,5 +290,39 @@ export const createGetPublishedProjectBySlugUseCase = ({
     const project = await repository.findPublishedProjectBySlug(slug);
 
     return project ? mapProjectDetail(project) : null;
+  },
+});
+
+export const createListPublishedPhotosUseCase = ({
+  repository,
+}: ContentApplicationDependencies): ListPublishedPhotosPort => ({
+  execute: async (input: ListPublishedPhotosInput): Promise<ListPublishedPhotosOutput> => {
+    const result = await repository.findPublishedPhotos({
+      location: input.location?.trim() || undefined,
+      page: normalizePhotoPage(input.page),
+      pageSize: normalizePhotoPageSize(input.pageSize),
+      search: input.search?.trim() || undefined,
+      year: input.year,
+    });
+
+    return {
+      items: result.items.map(mapPhotoSummary),
+      pageInfo: {
+        page: result.page,
+        pageSize: result.pageSize,
+        totalItems: result.totalItems,
+        totalPages: result.totalPages,
+      },
+    };
+  },
+});
+
+export const createGetPublishedPhotoByIdUseCase = ({
+  repository,
+}: ContentApplicationDependencies): GetPublishedPhotoByIdPort => ({
+  execute: async ({ id }) => {
+    const photo = await repository.findPublishedPhotoById(id);
+
+    return photo ? mapPhotoDetail(photo) : null;
   },
 });

--- a/backend/src/modules/content/ports/inbound/index.ts
+++ b/backend/src/modules/content/ports/inbound/index.ts
@@ -97,3 +97,49 @@ export interface ListPublishedProjectsPort
 
 export interface GetPublishedProjectBySlugPort
   extends UseCase<GetPublishedProjectBySlugInput, PublishedProjectDetail | null> {}
+
+export type PublishedPhotoSummary = Readonly<{
+  id: string;
+  frame: string;
+  title: string;
+  date: string;
+  location: string;
+  tags: readonly string[];
+  tone: "amber" | "cyan" | "mono" | "sunset" | "violet";
+  originalUrl: string;
+}>;
+
+export type PublishedPhotoDetail = PublishedPhotoSummary &
+  Readonly<{
+    camera: string | null;
+    caption: string | null;
+    film: string | null;
+  }>;
+
+export type ListPublishedPhotosInput = Readonly<{
+  page?: number;
+  pageSize?: number;
+  year?: number;
+  location?: string;
+  search?: string;
+}>;
+
+export type ListPublishedPhotosOutput = Readonly<{
+  items: readonly PublishedPhotoSummary[];
+  pageInfo: Readonly<{
+    page: number;
+    pageSize: number;
+    totalItems: number;
+    totalPages: number;
+  }>;
+}>;
+
+export type GetPublishedPhotoByIdInput = Readonly<{
+  id: string;
+}>;
+
+export interface ListPublishedPhotosPort
+  extends UseCase<ListPublishedPhotosInput, ListPublishedPhotosOutput> {}
+
+export interface GetPublishedPhotoByIdPort
+  extends UseCase<GetPublishedPhotoByIdInput, PublishedPhotoDetail | null> {}

--- a/backend/src/modules/content/ports/outbound/index.ts
+++ b/backend/src/modules/content/ports/outbound/index.ts
@@ -76,6 +76,21 @@ export type PhotoRepositoryRow = Readonly<{
   updatedAt: Date;
 }>;
 
+export type PhotoDetailRepositoryRow = PhotoRepositoryRow &
+  Readonly<{
+    camera: string | null;
+    film: string | null;
+    originalPath: string;
+  }>;
+
+export type PhotoListPage = Readonly<{
+  items: readonly PhotoRepositoryRow[];
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+}>;
+
 export type StatusStripEntryRepositoryRow = Readonly<{
   id: string;
   label: string;
@@ -116,6 +131,7 @@ export interface ContentRepositoryPort {
   findPublishedThoughtBySlug(slug: string): Promise<ThoughtDetailRepositoryRow | null>;
   findPublishedProjects(query: ProjectListQuery): Promise<ProjectListPage>;
   findPublishedProjectBySlug(slug: string): Promise<ProjectDetailRepositoryRow | null>;
-  findPublishedPhotos(query: PhotoListQuery): Promise<readonly PhotoRepositoryRow[]>;
+  findPublishedPhotos(query: PhotoListQuery): Promise<PhotoListPage>;
+  findPublishedPhotoById(id: string): Promise<PhotoDetailRepositoryRow | null>;
   listStatusStripEntries(): Promise<readonly StatusStripEntryRepositoryRow[]>;
 }


### PR DESCRIPTION
## Summary
- implement the public Photos list/detail API under `/api/photos`
- add server-side year, location, and search filters with page pagination
- expose frontend-compatible Photo DTOs with stable `/media/photos/:id/original` URLs
- add focused route and repository tests for the Photos slice

## Testing
- `bun run typecheck`
- `bun test`
- `bun run prisma:check`
- `bun run build`
- `bun run verify`

Closes #41
