### PR TITLE
[BE-010] Implement Thoughts RSS feed

### DIFF
--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -3,6 +3,8 @@ import { Hono } from "hono";
 import { InvalidThoughtCursorError } from "@/modules/content/application";
 import type { BootstrapContainer } from "@/bootstrap/container";
 
+import { presentThoughtsRssFeed } from "./rss-presenter";
+
 const serviceName = "vinicius.dev-backend";
 
 type NotImplementedResponse = {
@@ -360,6 +362,26 @@ const createPhotosFamily = (container: BootstrapContainer) => {
   return photosApp;
 };
 
+const createRssFamily = (container: BootstrapContainer) => {
+  const rssApp = new Hono();
+
+  rssApp.get("/", async (c) => {
+    const response = await container.content.listPublishedThoughts.execute({
+      limit: 24,
+    });
+    const feed = presentThoughtsRssFeed({
+      baseUrl: new URL(c.req.url).origin,
+      thoughts: response.items,
+    });
+
+    return c.body(feed, 200, {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+    });
+  });
+
+  return rssApp;
+};
+
 export const createHonoHttpAdapter = (container: BootstrapContainer) => {
   const app = new Hono();
 
@@ -375,11 +397,11 @@ export const createHonoHttpAdapter = (container: BootstrapContainer) => {
   app.route("/api/thoughts", createThoughtsFamily(container));
   app.route("/api/projects", createProjectsFamily(container));
   app.route("/api/photos", createPhotosFamily(container));
+  app.route("/api/rss", createRssFamily(container));
   mountPlaceholderFamily(app, "/api/status-strip", "status strip");
   mountPlaceholderFamily(app, "/api/chat", "chat");
   mountPlaceholderFamily(app, "/api/admin", "admin");
   mountPlaceholderFamily(app, "/api/auth", "auth");
-  mountPlaceholderFamily(app, "/api/rss", "rss");
   mountPlaceholderFamily(app, "/api/sitemap", "sitemap");
 
   app.get("/media/photos/:id/original", (c) =>

--- a/backend/src/adapters/inbound/http/hono/rss-presenter.ts
+++ b/backend/src/adapters/inbound/http/hono/rss-presenter.ts
@@ -1,0 +1,88 @@
+import type { PublishedThoughtSummary } from "@/modules/content/ports/inbound";
+
+const FEED_TITLE = "vinicius.dev Thoughts";
+const FEED_DESCRIPTION = "Published essays and notes from vinicius.dev.";
+const FEED_LANGUAGE = "en";
+
+const escapeXml = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+
+const normalizeBaseUrl = (baseUrl: string): string => baseUrl.replace(/\/+$/, "");
+
+const formatRssDate = (value: string): string => {
+  const date = new Date(`${value}T00:00:00.000Z`);
+
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  return date.toUTCString();
+};
+
+const createThoughtUrl = (baseUrl: string, slug: string): string => {
+  const encodedSlug = slug
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+
+  return `${normalizeBaseUrl(baseUrl)}/thoughts/${encodedSlug}`;
+};
+
+const renderElement = (name: string, value: string): string =>
+  value ? `    <${name}>${escapeXml(value)}</${name}>` : "";
+
+const renderThoughtItem = (baseUrl: string, thought: PublishedThoughtSummary): string => {
+  const url = createThoughtUrl(baseUrl, thought.slug);
+  const pubDate = formatRssDate(thought.publishedAt);
+  const categories = thought.tags
+    .map((tag) => `    <category>${escapeXml(tag)}</category>`)
+    .join("\n");
+  const optionalLines = [
+    renderElement("description", thought.excerpt),
+    pubDate ? `    <pubDate>${escapeXml(pubDate)}</pubDate>` : "",
+    categories,
+  ].filter(Boolean);
+
+  return [
+    "  <item>",
+    `    <title>${escapeXml(thought.title)}</title>`,
+    `    <link>${escapeXml(url)}</link>`,
+    `    <guid isPermaLink="true">${escapeXml(url)}</guid>`,
+    ...optionalLines,
+    "  </item>",
+  ].join("\n");
+};
+
+export type RssFeedInput = Readonly<{
+  baseUrl: string;
+  thoughts: readonly PublishedThoughtSummary[];
+}>;
+
+export const presentThoughtsRssFeed = ({ baseUrl, thoughts }: RssFeedInput): string => {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  const items = thoughts.map((thought) => renderThoughtItem(normalizedBaseUrl, thought));
+  const latestPublishedAt = thoughts.find((thought) => thought.publishedAt)?.publishedAt;
+  const lastBuildDate = latestPublishedAt ? formatRssDate(latestPublishedAt) : "";
+  const channelLines = [
+    `  <title>${escapeXml(FEED_TITLE)}</title>`,
+    `  <link>${escapeXml(`${normalizedBaseUrl}/thoughts`)}</link>`,
+    `  <description>${escapeXml(FEED_DESCRIPTION)}</description>`,
+    `  <language>${escapeXml(FEED_LANGUAGE)}</language>`,
+    lastBuildDate ? `  <lastBuildDate>${escapeXml(lastBuildDate)}</lastBuildDate>` : "",
+    ...items,
+  ].filter(Boolean);
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0">',
+    "<channel>",
+    ...channelLines,
+    "</channel>",
+    "</rss>",
+  ].join("\n");
+};

--- a/backend/src/adapters/inbound/http/hono/rss-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/rss-routes.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "bun:test";
+
+import type { BootstrapContainer } from "@/bootstrap/container";
+
+import { createHonoHttpAdapter } from "./http-adapter";
+import { presentThoughtsRssFeed } from "./rss-presenter";
+
+const createTestContainer = (): BootstrapContainer => ({
+  config: {
+    auth: {
+      mfaCodeMaxAgeSeconds: 600,
+      roomPasswordSecret: "test-room-secret",
+      sessionCookieName: "vinicius.dev-session",
+      sessionMaxAgeSeconds: 604800,
+      sessionSecret: "test-session-secret",
+    },
+    cors: {
+      allowCredentials: true,
+      allowedOrigins: [],
+    },
+    media: {
+      chatRoot: "/tmp/chat",
+      chatUploadAllowedMimeTypes: ["image/jpeg", "image/png", "image/webp"],
+      chatUploadMaxBytes: 5 * 1024 * 1024,
+      chatUploadMaxFilesPerMessage: 1,
+      photosRoot: "/tmp/photos",
+      publicUrlBase: "/media",
+    },
+    server: {
+      apiBasePath: "/api",
+      mediaPhotoOriginalPath: "/media/photos/:id/original",
+      nodeEnv: "test",
+      port: 4000,
+    },
+  },
+  content: {
+    getPublishedPhotoById: {
+      execute: async () => null,
+    },
+    getPublishedProjectBySlug: {
+      execute: async () => null,
+    },
+    getPublishedThoughtBySlug: {
+      execute: async () => null,
+    },
+    listPublishedPhotos: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          page: 1,
+          pageSize: 24,
+          totalItems: 0,
+          totalPages: 1,
+        },
+      }),
+    },
+    listPublishedProjects: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          page: 1,
+          pageSize: 12,
+          totalItems: 0,
+          totalPages: 1,
+        },
+      }),
+    },
+    listPublishedThoughts: {
+      execute: async ({ limit }) => ({
+        items: [
+          {
+            bodyPreview: "A homepage does not need to convert anyone.",
+            excerpt: "The best personal websites feel less like products.",
+            id: "thought_1",
+            publishedAt: "2026-03-28",
+            readingTime: "7 min",
+            slug: "night-cable-interfaces",
+            status: "published",
+            tags: ["interface", "nostalgia"],
+            title: `Night Cable Interfaces (${limit ?? 0})`,
+            type: "essay",
+          },
+        ],
+        pageInfo: {
+          nextCursor: null,
+        },
+      }),
+    },
+  },
+});
+
+describe("rss routes", () => {
+  it("serves an RSS XML feed from published Thoughts", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("https://vinicius.dev/api/rss");
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/rss+xml");
+    expect(body).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(body).toContain("<rss version=\"2.0\">");
+    expect(body).toContain("<title>vinicius.dev Thoughts</title>");
+    expect(body).toContain("<link>https://vinicius.dev/thoughts</link>");
+    expect(body).toContain("<title>Night Cable Interfaces (24)</title>");
+    expect(body).toContain("<link>https://vinicius.dev/thoughts/night-cable-interfaces</link>");
+    expect(body).toContain("<pubDate>Sat, 28 Mar 2026 00:00:00 GMT</pubDate>");
+    expect(body).toContain("<category>interface</category>");
+  });
+
+  it("escapes XML-sensitive values in feed fields", () => {
+    const feed = presentThoughtsRssFeed({
+      baseUrl: "https://vinicius.dev/",
+      thoughts: [
+        {
+          bodyPreview: "preview",
+          excerpt: "Use <tags> & quoted \"text\" safely.",
+          id: "thought_1",
+          publishedAt: "2026-04-01",
+          readingTime: null,
+          slug: "xml & feeds",
+          status: "published",
+          tags: ["rss & xml"],
+          title: "RSS <Thoughts> & \"Notes\"",
+          type: "note",
+        },
+      ],
+    });
+
+    expect(feed).toContain("RSS &lt;Thoughts&gt; &amp; &quot;Notes&quot;");
+    expect(feed).toContain("Use &lt;tags&gt; &amp; quoted &quot;text&quot; safely.");
+    expect(feed).toContain("rss &amp; xml");
+    expect(feed).toContain("https://vinicius.dev/thoughts/xml%20%26%20feeds");
+  });
+});


### PR DESCRIPTION
## Summary
- implement `/api/rss` for published Thoughts
- add an RSS XML presenter with XML escaping
- set RSS content type and cover route/output behavior with tests

## Testing
- `bun run typecheck`
- `bun test`
- `bun run build`
- `bun run verify`

Closes #43
