### PR TITLE
[BE-009] Implement Status Strip public API

### DIFF
--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -382,6 +382,18 @@ const createRssFamily = (container: BootstrapContainer) => {
   return rssApp;
 };
 
+const createStatusStripFamily = (container: BootstrapContainer) => {
+  const statusStripApp = new Hono();
+
+  statusStripApp.get("/", async (c) => {
+    const response = await container.content.listStatusStripEntries.execute();
+
+    return c.json(response);
+  });
+
+  return statusStripApp;
+};
+
 export const createHonoHttpAdapter = (container: BootstrapContainer) => {
   const app = new Hono();
 
@@ -398,7 +410,7 @@ export const createHonoHttpAdapter = (container: BootstrapContainer) => {
   app.route("/api/projects", createProjectsFamily(container));
   app.route("/api/photos", createPhotosFamily(container));
   app.route("/api/rss", createRssFamily(container));
-  mountPlaceholderFamily(app, "/api/status-strip", "status strip");
+  app.route("/api/status-strip", createStatusStripFamily(container));
   mountPlaceholderFamily(app, "/api/chat", "chat");
   mountPlaceholderFamily(app, "/api/admin", "admin");
   mountPlaceholderFamily(app, "/api/auth", "auth");

--- a/backend/src/adapters/inbound/http/hono/photos-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/photos-routes.test.ts
@@ -98,6 +98,11 @@ const createTestContainer = (): BootstrapContainer => ({
         },
       }),
     },
+    listStatusStripEntries: {
+      execute: async () => ({
+        items: [],
+      }),
+    },
   },
 });
 

--- a/backend/src/adapters/inbound/http/hono/projects-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/projects-routes.test.ts
@@ -113,6 +113,11 @@ const createTestContainer = (): BootstrapContainer => ({
         },
       }),
     },
+    listStatusStripEntries: {
+      execute: async () => ({
+        items: [],
+      }),
+    },
   },
 });
 

--- a/backend/src/adapters/inbound/http/hono/rss-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/rss-routes.test.ts
@@ -86,6 +86,11 @@ const createTestContainer = (): BootstrapContainer => ({
         },
       }),
     },
+    listStatusStripEntries: {
+      execute: async () => ({
+        items: [],
+      }),
+    },
   },
 });
 

--- a/backend/src/adapters/inbound/http/hono/status-strip-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/status-strip-routes.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "bun:test";
+
+import type { BootstrapContainer } from "@/bootstrap/container";
+
+import { createHonoHttpAdapter } from "./http-adapter";
+
+const createTestContainer = (): BootstrapContainer => ({
+  config: {
+    auth: {
+      mfaCodeMaxAgeSeconds: 600,
+      roomPasswordSecret: "test-room-secret",
+      sessionCookieName: "vinicius.dev-session",
+      sessionMaxAgeSeconds: 604800,
+      sessionSecret: "test-session-secret",
+    },
+    cors: {
+      allowCredentials: true,
+      allowedOrigins: [],
+    },
+    media: {
+      chatRoot: "/tmp/chat",
+      chatUploadAllowedMimeTypes: ["image/jpeg", "image/png", "image/webp"],
+      chatUploadMaxBytes: 5 * 1024 * 1024,
+      chatUploadMaxFilesPerMessage: 1,
+      photosRoot: "/tmp/photos",
+      publicUrlBase: "/media",
+    },
+    server: {
+      apiBasePath: "/api",
+      mediaPhotoOriginalPath: "/media/photos/:id/original",
+      nodeEnv: "test",
+      port: 4000,
+    },
+  },
+  content: {
+    getPublishedProjectBySlug: {
+      execute: async () => null,
+    },
+    getPublishedPhotoById: {
+      execute: async () => null,
+    },
+    getPublishedThoughtBySlug: {
+      execute: async () => null,
+    },
+    listPublishedPhotos: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          page: 1,
+          pageSize: 24,
+          totalItems: 0,
+          totalPages: 1,
+        },
+      }),
+    },
+    listPublishedProjects: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          page: 1,
+          pageSize: 12,
+          totalItems: 0,
+          totalPages: 1,
+        },
+      }),
+    },
+    listPublishedThoughts: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          nextCursor: null,
+        },
+      }),
+    },
+    listStatusStripEntries: {
+      execute: async () => ({
+        items: [
+          {
+            accent: "pink",
+            label: "current focus",
+            value: "cluster 3",
+          },
+          {
+            label: "location",
+            value: "Sao Paulo",
+          },
+        ],
+      }),
+    },
+  },
+});
+
+describe("status strip routes", () => {
+  it("serves ordered status strip entries", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/api/status-strip");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      items: [
+        {
+          accent: "pink",
+          label: "current focus",
+          value: "cluster 3",
+        },
+        {
+          label: "location",
+          value: "Sao Paulo",
+        },
+      ],
+    });
+  });
+});

--- a/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
@@ -101,6 +101,11 @@ const createTestContainer = (): BootstrapContainer => ({
         },
       }),
     },
+    listStatusStripEntries: {
+      execute: async () => ({
+        items: [],
+      }),
+    },
   },
 });
 

--- a/backend/src/adapters/outbound/persistence/prisma/content-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/content-repository.ts
@@ -512,6 +512,28 @@ export const createPrismaContentRepository = (client: PrismaDatabaseClient): Con
 
     return row ? mapPhotoDetailRow(row) : null;
   },
-  listStatusStripEntries: (): Promise<readonly StatusStripEntryRepositoryRow[]> =>
-    notImplemented("listStatusStripEntries"),
+  listStatusStripEntries: async (): Promise<readonly StatusStripEntryRepositoryRow[]> => {
+    const rows = await client.statusStripEntry.findMany({
+      orderBy: [{ displayOrder: "asc" }],
+      select: {
+        accent: true,
+        createdAt: true,
+        displayOrder: true,
+        id: true,
+        label: true,
+        updatedAt: true,
+        value: true,
+      },
+    });
+
+    return rows.map((row) => ({
+      accent: row.accent,
+      createdAt: row.createdAt,
+      displayOrder: row.displayOrder,
+      id: row.id,
+      label: row.label,
+      updatedAt: row.updatedAt,
+      value: row.value,
+    }));
+  },
 });

--- a/backend/src/adapters/outbound/persistence/prisma/status-strip-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/status-strip-repository.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+
+import { createPrismaContentRepository } from "./content-repository";
+import type { PrismaDatabaseClient } from "./prisma-client";
+
+describe("prisma status strip repository", () => {
+  it("maps ordered status strip rows without leaking Prisma types", async () => {
+    const repository = createPrismaContentRepository({
+      photo: {
+        findMany: async () => [],
+        findFirst: async () => null,
+      },
+      project: {
+        findMany: async () => [],
+        findFirst: async () => null,
+      },
+      statusStripEntry: {
+        findMany: async () => [
+          {
+            accent: "cyan" as const,
+            createdAt: new Date("2026-04-24T00:00:00.000Z"),
+            displayOrder: 1,
+            id: "status_1",
+            label: "now building",
+            updatedAt: new Date("2026-04-24T00:00:00.000Z"),
+            value: "vinicius.dev backend",
+          },
+          {
+            accent: null,
+            createdAt: new Date("2026-04-24T00:00:00.000Z"),
+            displayOrder: 2,
+            id: "status_2",
+            label: "location",
+            updatedAt: new Date("2026-04-24T00:00:00.000Z"),
+            value: "Sao Paulo",
+          },
+        ],
+      },
+      thought: {
+        findMany: async () => [],
+        findFirst: async () => null,
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    const entries = await repository.listStatusStripEntries();
+
+    expect(entries).toEqual([
+      {
+        accent: "cyan",
+        createdAt: new Date("2026-04-24T00:00:00.000Z"),
+        displayOrder: 1,
+        id: "status_1",
+        label: "now building",
+        updatedAt: new Date("2026-04-24T00:00:00.000Z"),
+        value: "vinicius.dev backend",
+      },
+      {
+        accent: null,
+        createdAt: new Date("2026-04-24T00:00:00.000Z"),
+        displayOrder: 2,
+        id: "status_2",
+        label: "location",
+        updatedAt: new Date("2026-04-24T00:00:00.000Z"),
+        value: "Sao Paulo",
+      },
+    ]);
+  });
+});

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -6,6 +6,7 @@ import {
   createListPublishedPhotosUseCase,
   createListPublishedProjectsUseCase,
   createListPublishedThoughtsUseCase,
+  createListStatusStripEntriesUseCase,
 } from "@/modules/content/application";
 import type {
   GetPublishedProjectBySlugPort,
@@ -14,6 +15,7 @@ import type {
   ListPublishedPhotosPort,
   ListPublishedProjectsPort,
   ListPublishedThoughtsPort,
+  ListStatusStripEntriesPort,
 } from "@/modules/content/ports/inbound";
 
 import { loadBootstrapConfig, type BootstrapConfig } from "../config";
@@ -27,6 +29,7 @@ export type BootstrapContainer = Readonly<{
     listPublishedPhotos: ListPublishedPhotosPort;
     listPublishedProjects: ListPublishedProjectsPort;
     listPublishedThoughts: ListPublishedThoughtsPort;
+    listStatusStripEntries: ListStatusStripEntriesPort;
   }>;
 }>;
 
@@ -54,6 +57,9 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
         repository: persistence.content,
       }),
       listPublishedThoughts: createListPublishedThoughtsUseCase({
+        repository: persistence.content,
+      }),
+      listStatusStripEntries: createListStatusStripEntriesUseCase({
         repository: persistence.content,
       }),
     },

--- a/backend/src/bootstrap/server.test.ts
+++ b/backend/src/bootstrap/server.test.ts
@@ -167,6 +167,21 @@ const createTestContainer = (): BootstrapContainer => ({
         },
       }),
     },
+    listStatusStripEntries: {
+      execute: async () => ({
+        items: [
+          {
+            accent: "cyan",
+            label: "now building",
+            value: "vinicius.dev backend",
+          },
+          {
+            label: "location",
+            value: "Sao Paulo",
+          },
+        ],
+      }),
+    },
   },
 });
 
@@ -270,8 +285,23 @@ describe("backend server scaffold", () => {
       },
     });
 
+    const statusStripResponse = await app.request("/api/status-strip");
+    expect(statusStripResponse.status).toBe(200);
+    await expect(statusStripResponse.json()).resolves.toEqual({
+      items: [
+        {
+          accent: "cyan",
+          label: "now building",
+          value: "vinicius.dev backend",
+        },
+        {
+          label: "location",
+          value: "Sao Paulo",
+        },
+      ],
+    });
+
     const placeholderRoutes = [
-      ["/api/status-strip", "status strip"],
       ["/api/chat", "chat"],
       ["/api/admin", "admin"],
       ["/api/auth", "auth"],

--- a/backend/src/modules/content/application/index.ts
+++ b/backend/src/modules/content/application/index.ts
@@ -13,6 +13,7 @@ import type {
   GetPublishedProjectBySlugPort,
   GetPublishedPhotoByIdPort,
   GetPublishedThoughtBySlugPort,
+  ListStatusStripEntriesPort,
   ListPublishedPhotosInput,
   ListPublishedPhotosOutput,
   ListPublishedPhotosPort,
@@ -26,6 +27,7 @@ import type {
   PublishedProjectSummary,
   PublishedPhotoDetail,
   PublishedPhotoSummary,
+  StatusStripEntry,
   PublishedThoughtDetail,
   PublishedThoughtSummary,
 } from "../ports/inbound";
@@ -144,6 +146,16 @@ const mapPhotoDetail = (row: PhotoDetailRepositoryRow): PublishedPhotoDetail => 
   camera: row.camera,
   caption: row.caption,
   film: row.film,
+});
+
+const mapStatusStripEntry = (row: {
+  accent: "amber" | "cyan" | "pink" | null;
+  label: string;
+  value: string;
+}): StatusStripEntry => ({
+  ...(row.accent ? { accent: row.accent } : {}),
+  label: row.label,
+  value: row.value,
 });
 
 const normalizeLimit = (value?: number): number => {
@@ -324,5 +336,17 @@ export const createGetPublishedPhotoByIdUseCase = ({
     const photo = await repository.findPublishedPhotoById(id);
 
     return photo ? mapPhotoDetail(photo) : null;
+  },
+});
+
+export const createListStatusStripEntriesUseCase = ({
+  repository,
+}: ContentApplicationDependencies): ListStatusStripEntriesPort => ({
+  execute: async () => {
+    const entries = await repository.listStatusStripEntries();
+
+    return {
+      items: entries.map(mapStatusStripEntry),
+    };
   },
 });

--- a/backend/src/modules/content/ports/inbound/index.ts
+++ b/backend/src/modules/content/ports/inbound/index.ts
@@ -143,3 +143,16 @@ export interface ListPublishedPhotosPort
 
 export interface GetPublishedPhotoByIdPort
   extends UseCase<GetPublishedPhotoByIdInput, PublishedPhotoDetail | null> {}
+
+export type StatusStripEntry = Readonly<{
+  accent?: "amber" | "cyan" | "pink";
+  label: string;
+  value: string;
+}>;
+
+export type ListStatusStripEntriesOutput = Readonly<{
+  items: readonly StatusStripEntry[];
+}>;
+
+export interface ListStatusStripEntriesPort
+  extends UseCase<void, ListStatusStripEntriesOutput> {}


### PR DESCRIPTION
## Summary
- add /api/status-strip as a real Hono route backed by the content application layer
- implement ordered status strip retrieval in the Prisma content repository
- add route, repository, and server coverage for DTO mapping and ordering

## Checks
- bun run typecheck
- bun test
- bun run build
- bun run verify

## GitHub
Closes #42