### PR TITLE
[BE-011] Implement public sitemap generation API

### DIFF
--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -4,6 +4,7 @@ import { InvalidThoughtCursorError } from "@/modules/content/application";
 import type { BootstrapContainer } from "@/bootstrap/container";
 
 import { presentThoughtsRssFeed } from "./rss-presenter";
+import { presentSitemapXml } from "./sitemap-presenter";
 
 const serviceName = "vinicius.dev-backend";
 
@@ -394,6 +395,23 @@ const createStatusStripFamily = (container: BootstrapContainer) => {
   return statusStripApp;
 };
 
+const createSitemapFamily = () => {
+  const sitemapApp = new Hono();
+
+  sitemapApp.get("/", (c) => {
+    const sitemap = presentSitemapXml({
+      baseUrl: new URL(c.req.url).origin,
+      paths: ["/", "/thoughts", "/projects", "/photos", "/chat"],
+    });
+
+    return c.body(sitemap, 200, {
+      "Content-Type": "application/xml; charset=utf-8",
+    });
+  });
+
+  return sitemapApp;
+};
+
 export const createHonoHttpAdapter = (container: BootstrapContainer) => {
   const app = new Hono();
 
@@ -410,11 +428,11 @@ export const createHonoHttpAdapter = (container: BootstrapContainer) => {
   app.route("/api/projects", createProjectsFamily(container));
   app.route("/api/photos", createPhotosFamily(container));
   app.route("/api/rss", createRssFamily(container));
+  app.route("/api/sitemap", createSitemapFamily());
   app.route("/api/status-strip", createStatusStripFamily(container));
   mountPlaceholderFamily(app, "/api/chat", "chat");
   mountPlaceholderFamily(app, "/api/admin", "admin");
   mountPlaceholderFamily(app, "/api/auth", "auth");
-  mountPlaceholderFamily(app, "/api/sitemap", "sitemap");
 
   app.get("/media/photos/:id/original", (c) =>
     c.json<NotImplementedResponse>(

--- a/backend/src/adapters/inbound/http/hono/sitemap-presenter.ts
+++ b/backend/src/adapters/inbound/http/hono/sitemap-presenter.ts
@@ -1,0 +1,38 @@
+const escapeXml = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+
+const normalizeBaseUrl = (baseUrl: string): string => baseUrl.replace(/\/+$/, "");
+
+const createAbsoluteUrl = (baseUrl: string, path: string): string => {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+
+  if (path === "/") {
+    return `${normalizedBaseUrl}/`;
+  }
+
+  return `${normalizedBaseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+};
+
+export type SitemapXmlInput = Readonly<{
+  baseUrl: string;
+  paths: readonly string[];
+}>;
+
+export const presentSitemapXml = ({ baseUrl, paths }: SitemapXmlInput): string => {
+  const urls = paths.map((path) => createAbsoluteUrl(baseUrl, path));
+  const entries = urls.map(
+    (url) => ["  <url>", `    <loc>${escapeXml(url)}</loc>`, "  </url>"].join("\n"),
+  );
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...entries,
+    "</urlset>",
+  ].join("\n");
+};

--- a/backend/src/adapters/inbound/http/hono/sitemap-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/sitemap-routes.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "bun:test";
+
+import type { BootstrapContainer } from "@/bootstrap/container";
+
+import { createHonoHttpAdapter } from "./http-adapter";
+import { presentSitemapXml } from "./sitemap-presenter";
+
+const createTestContainer = (): BootstrapContainer => ({
+  config: {
+    auth: {
+      mfaCodeMaxAgeSeconds: 600,
+      roomPasswordSecret: "test-room-secret",
+      sessionCookieName: "vinicius.dev-session",
+      sessionMaxAgeSeconds: 604800,
+      sessionSecret: "test-session-secret",
+    },
+    cors: {
+      allowCredentials: true,
+      allowedOrigins: [],
+    },
+    media: {
+      chatRoot: "/tmp/chat",
+      chatUploadAllowedMimeTypes: ["image/jpeg", "image/png", "image/webp"],
+      chatUploadMaxBytes: 5 * 1024 * 1024,
+      chatUploadMaxFilesPerMessage: 1,
+      photosRoot: "/tmp/photos",
+      publicUrlBase: "/media",
+    },
+    server: {
+      apiBasePath: "/api",
+      mediaPhotoOriginalPath: "/media/photos/:id/original",
+      nodeEnv: "test",
+      port: 4000,
+    },
+  },
+  content: {
+    getPublishedPhotoById: {
+      execute: async () => null,
+    },
+    getPublishedProjectBySlug: {
+      execute: async () => null,
+    },
+    getPublishedThoughtBySlug: {
+      execute: async () => null,
+    },
+    listPublishedPhotos: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          page: 1,
+          pageSize: 24,
+          totalItems: 0,
+          totalPages: 1,
+        },
+      }),
+    },
+    listPublishedProjects: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          page: 1,
+          pageSize: 12,
+          totalItems: 0,
+          totalPages: 1,
+        },
+      }),
+    },
+    listPublishedThoughts: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          nextCursor: null,
+        },
+      }),
+    },
+    listStatusStripEntries: {
+      execute: async () => ({
+        items: [],
+      }),
+    },
+  },
+});
+
+describe("sitemap routes", () => {
+  it("serves an XML sitemap for the stable public pages", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("https://vinicius.dev/api/sitemap");
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/xml");
+    expect(body).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(body).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect(body).toContain("<loc>https://vinicius.dev/</loc>");
+    expect(body).toContain("<loc>https://vinicius.dev/thoughts</loc>");
+    expect(body).toContain("<loc>https://vinicius.dev/projects</loc>");
+    expect(body).toContain("<loc>https://vinicius.dev/photos</loc>");
+    expect(body).toContain("<loc>https://vinicius.dev/chat</loc>");
+    expect(body).not.toContain("/admin");
+    expect(body).not.toContain("/api");
+    expect(body).not.toContain("/media");
+  });
+
+  it("escapes XML-sensitive characters in sitemap URLs", () => {
+    const sitemap = presentSitemapXml({
+      baseUrl: "https://vinicius.dev",
+      paths: ["/chat?ref=a&b=c"],
+    });
+
+    expect(sitemap).toContain("https://vinicius.dev/chat?ref=a&amp;b=c");
+  });
+});

--- a/backend/src/bootstrap/server.test.ts
+++ b/backend/src/bootstrap/server.test.ts
@@ -301,11 +301,21 @@ describe("backend server scaffold", () => {
       ],
     });
 
+    const sitemapResponse = await app.request("https://vinicius.dev/api/sitemap");
+    const sitemapBody = await sitemapResponse.text();
+    expect(sitemapResponse.status).toBe(200);
+    expect(sitemapResponse.headers.get("content-type")).toContain("application/xml");
+    expect(sitemapBody).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(sitemapBody).toContain("<loc>https://vinicius.dev/</loc>");
+    expect(sitemapBody).toContain("<loc>https://vinicius.dev/thoughts</loc>");
+    expect(sitemapBody).toContain("<loc>https://vinicius.dev/projects</loc>");
+    expect(sitemapBody).toContain("<loc>https://vinicius.dev/photos</loc>");
+    expect(sitemapBody).toContain("<loc>https://vinicius.dev/chat</loc>");
+
     const placeholderRoutes = [
       ["/api/chat", "chat"],
       ["/api/admin", "admin"],
       ["/api/auth", "auth"],
-      ["/api/sitemap", "sitemap"],
       ["/media/photos/123/original", "photo media"],
     ] as const;
 


### PR DESCRIPTION
## Summary
- add /api/sitemap as a real XML route for the stable public frontend pages
- build absolute URLs from the request origin and exclude admin, api, and media routes
- add sitemap and server coverage for XML output and public route inclusion

## Checks
- bun run typecheck
- bun test
- bun run build
- bun run verify

## GitHub
Closes #44