### PR TITLE
[BE-012] Implement media repository and filesystem storage foundation

### DIFF
--- a/backend/src/adapters/inbound/http/hono/photos-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/photos-routes.test.ts
@@ -104,6 +104,26 @@ const createTestContainer = (): BootstrapContainer => ({
       }),
     },
   },
+  media: {
+    repository: {
+      findChatUploadMediaById: async () => null,
+      findPhotoMediaById: async () => null,
+    },
+    storage: {
+      chatUploads: {
+        deleteUpload: async () => {},
+        openUpload: async () => null,
+        writeUpload: async () => ({
+          byteSize: 0,
+          storageKey: "test-upload",
+          storagePath: "test-upload",
+        }),
+      },
+      photos: {
+        openOriginal: async () => null,
+      },
+    },
+  },
 });
 
 describe("photos routes", () => {

--- a/backend/src/adapters/inbound/http/hono/projects-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/projects-routes.test.ts
@@ -119,6 +119,26 @@ const createTestContainer = (): BootstrapContainer => ({
       }),
     },
   },
+  media: {
+    repository: {
+      findChatUploadMediaById: async () => null,
+      findPhotoMediaById: async () => null,
+    },
+    storage: {
+      chatUploads: {
+        deleteUpload: async () => {},
+        openUpload: async () => null,
+        writeUpload: async () => ({
+          byteSize: 0,
+          storageKey: "test-upload",
+          storagePath: "test-upload",
+        }),
+      },
+      photos: {
+        openOriginal: async () => null,
+      },
+    },
+  },
 });
 
 describe("projects routes", () => {

--- a/backend/src/adapters/inbound/http/hono/rss-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/rss-routes.test.ts
@@ -92,6 +92,26 @@ const createTestContainer = (): BootstrapContainer => ({
       }),
     },
   },
+  media: {
+    repository: {
+      findChatUploadMediaById: async () => null,
+      findPhotoMediaById: async () => null,
+    },
+    storage: {
+      chatUploads: {
+        deleteUpload: async () => {},
+        openUpload: async () => null,
+        writeUpload: async () => ({
+          byteSize: 0,
+          storageKey: "test-upload",
+          storagePath: "test-upload",
+        }),
+      },
+      photos: {
+        openOriginal: async () => null,
+      },
+    },
+  },
 });
 
 describe("rss routes", () => {

--- a/backend/src/adapters/inbound/http/hono/sitemap-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/sitemap-routes.test.ts
@@ -79,6 +79,26 @@ const createTestContainer = (): BootstrapContainer => ({
       }),
     },
   },
+  media: {
+    repository: {
+      findChatUploadMediaById: async () => null,
+      findPhotoMediaById: async () => null,
+    },
+    storage: {
+      chatUploads: {
+        deleteUpload: async () => {},
+        openUpload: async () => null,
+        writeUpload: async () => ({
+          byteSize: 0,
+          storageKey: "test-upload",
+          storagePath: "test-upload",
+        }),
+      },
+      photos: {
+        openOriginal: async () => null,
+      },
+    },
+  },
 });
 
 describe("sitemap routes", () => {

--- a/backend/src/adapters/inbound/http/hono/status-strip-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/status-strip-routes.test.ts
@@ -88,6 +88,26 @@ const createTestContainer = (): BootstrapContainer => ({
       }),
     },
   },
+  media: {
+    repository: {
+      findChatUploadMediaById: async () => null,
+      findPhotoMediaById: async () => null,
+    },
+    storage: {
+      chatUploads: {
+        deleteUpload: async () => {},
+        openUpload: async () => null,
+        writeUpload: async () => ({
+          byteSize: 0,
+          storageKey: "test-upload",
+          storagePath: "test-upload",
+        }),
+      },
+      photos: {
+        openOriginal: async () => null,
+      },
+    },
+  },
 });
 
 describe("status strip routes", () => {

--- a/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
@@ -107,6 +107,26 @@ const createTestContainer = (): BootstrapContainer => ({
       }),
     },
   },
+  media: {
+    repository: {
+      findChatUploadMediaById: async () => null,
+      findPhotoMediaById: async () => null,
+    },
+    storage: {
+      chatUploads: {
+        deleteUpload: async () => {},
+        openUpload: async () => null,
+        writeUpload: async () => ({
+          byteSize: 0,
+          storageKey: "test-upload",
+          storagePath: "test-upload",
+        }),
+      },
+      photos: {
+        openOriginal: async () => null,
+      },
+    },
+  },
 });
 
 describe("thoughts routes", () => {

--- a/backend/src/adapters/outbound/persistence/prisma/media-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/media-repository.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+
+import { createPrismaMediaRepository } from "./media-repository";
+import type { PrismaDatabaseClient } from "./prisma-client";
+
+describe("prisma media repository", () => {
+  it("maps photo media rows without leaking Prisma types", async () => {
+    const repository = createPrismaMediaRepository({
+      chatUpload: {
+        findFirst: async () => null,
+      },
+      photo: {
+        findFirst: async () => ({
+          createdAt: new Date("2026-03-22T00:00:00.000Z"),
+          id: "p-2026-014",
+          originalPath: "published/p-2026-014.jpg",
+          originalReferencePolicy: "filesystem_reference" as const,
+          title: "paulista at 02:14",
+          updatedAt: new Date("2026-03-23T00:00:00.000Z"),
+        }),
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    const photo = await repository.findPhotoMediaById("p-2026-014");
+
+    expect(photo).toEqual({
+      createdAt: new Date("2026-03-22T00:00:00.000Z"),
+      id: "p-2026-014",
+      originalReference: "published/p-2026-014.jpg",
+      originalReferencePolicy: "filesystem_reference",
+      title: "paulista at 02:14",
+      updatedAt: new Date("2026-03-23T00:00:00.000Z"),
+    });
+  });
+
+  it("maps chat upload media rows without leaking Prisma types", async () => {
+    const repository = createPrismaMediaRepository({
+      chatUpload: {
+        findFirst: async () => ({
+          byteSize: 482113,
+          createdAt: new Date("2026-03-22T00:00:00.000Z"),
+          displayFilename: "scan.webp",
+          id: "upload_1",
+          mimeType: "image/webp" as const,
+          storageKey: "room_123/upload_1.webp",
+          updatedAt: new Date("2026-03-23T00:00:00.000Z"),
+        }),
+      },
+      photo: {
+        findFirst: async () => null,
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    const upload = await repository.findChatUploadMediaById("upload_1");
+
+    expect(upload).toEqual({
+      byteSize: 482113,
+      createdAt: new Date("2026-03-22T00:00:00.000Z"),
+      displayFilename: "scan.webp",
+      id: "upload_1",
+      mimeType: "image/webp",
+      storageKey: "room_123/upload_1.webp",
+      updatedAt: new Date("2026-03-23T00:00:00.000Z"),
+    });
+  });
+});

--- a/backend/src/adapters/outbound/persistence/prisma/media-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/media-repository.ts
@@ -3,16 +3,88 @@ import type {
   MediaRepositoryPort,
   PhotoMediaRepositoryRow,
 } from "@/modules/media/ports/outbound";
+import {
+  ChatUploadMimeType,
+  PhotoOriginalReferencePolicy,
+} from "../../../../../generated/prisma/client";
 
 import type { PrismaDatabaseClient } from "./prisma-client";
 
-const notImplemented = <T>(method: string): Promise<T> => {
-  return Promise.reject(new Error(`Prisma media repository method not implemented: ${method}`));
-};
+const mapPhotoMediaRow = (row: {
+  createdAt: Date;
+  id: string;
+  originalPath: string;
+  originalReferencePolicy: PhotoOriginalReferencePolicy;
+  title: string;
+  updatedAt: Date;
+}): PhotoMediaRepositoryRow => ({
+  createdAt: row.createdAt,
+  id: row.id,
+  originalReference: row.originalPath,
+  originalReferencePolicy: row.originalReferencePolicy,
+  title: row.title,
+  updatedAt: row.updatedAt,
+});
 
-export const createPrismaMediaRepository = (_client: PrismaDatabaseClient): MediaRepositoryPort => ({
-  findPhotoMediaById: (_photoId: string): Promise<PhotoMediaRepositoryRow | null> =>
-    notImplemented("findPhotoMediaById"),
-  findChatUploadMediaById: (_uploadId: string): Promise<ChatUploadMediaRepositoryRow | null> =>
-    notImplemented("findChatUploadMediaById"),
+const mapChatUploadMediaRow = (row: {
+  byteSize: number;
+  createdAt: Date;
+  displayFilename: string;
+  id: string;
+  mimeType: ChatUploadMimeType;
+  storageKey: string;
+  updatedAt: Date;
+}): ChatUploadMediaRepositoryRow => ({
+  byteSize: row.byteSize,
+  createdAt: row.createdAt,
+  displayFilename: row.displayFilename,
+  id: row.id,
+  mimeType:
+    row.mimeType === ChatUploadMimeType.image_jpeg
+      ? "image/jpeg"
+      : row.mimeType === ChatUploadMimeType.image_png
+        ? "image/png"
+        : "image/webp",
+  storageKey: row.storageKey,
+  updatedAt: row.updatedAt,
+});
+
+export const createPrismaMediaRepository = (client: PrismaDatabaseClient): MediaRepositoryPort => ({
+  findPhotoMediaById: async (photoId: string): Promise<PhotoMediaRepositoryRow | null> => {
+    const photo = await client.photo.findFirst({
+      select: {
+        createdAt: true,
+        id: true,
+        originalPath: true,
+        originalReferencePolicy: true,
+        title: true,
+        updatedAt: true,
+      },
+      where: {
+        id: photoId,
+      },
+    });
+
+    return photo ? mapPhotoMediaRow(photo) : null;
+  },
+  findChatUploadMediaById: async (
+    uploadId: string,
+  ): Promise<ChatUploadMediaRepositoryRow | null> => {
+    const upload = await client.chatUpload.findFirst({
+      select: {
+        byteSize: true,
+        createdAt: true,
+        displayFilename: true,
+        id: true,
+        mimeType: true,
+        storageKey: true,
+        updatedAt: true,
+      },
+      where: {
+        id: uploadId,
+      },
+    });
+
+    return upload ? mapChatUploadMediaRow(upload) : null;
+  },
 });

--- a/backend/src/adapters/outbound/storage/filesystem/create-filesystem-media-storage-adapter.test.ts
+++ b/backend/src/adapters/outbound/storage/filesystem/create-filesystem-media-storage-adapter.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { createFilesystemMediaStorageAdapter } from "./create-filesystem-media-storage-adapter";
+
+const tempRoots: string[] = [];
+
+const createTempRoot = async (name: string) => {
+  const root = await mkdtemp(join(process.cwd(), `.tmp-${name}-`));
+  tempRoots.push(root);
+  return root;
+};
+
+const readStorageObjectText = async (stream: ReadableStream<Uint8Array>) =>
+  new Response(stream).text();
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
+});
+
+describe("filesystem media storage adapter", () => {
+  it("opens photo originals from the configured photos root", async () => {
+    const photosRoot = await createTempRoot("photos");
+    const chatRoot = await createTempRoot("chat");
+
+    await mkdir(join(photosRoot, "published"), { recursive: true });
+    await writeFile(join(photosRoot, "published/p-2026-014.jpg"), "photo-bytes");
+
+    const adapter = createFilesystemMediaStorageAdapter({
+      chatRoot,
+      photosRoot,
+    });
+
+    const file = await adapter.photos.openOriginal("published/p-2026-014.jpg");
+
+    expect(file?.absolutePath).toBe(join(photosRoot, "published/p-2026-014.jpg"));
+    expect(file?.byteSize).toBe(11);
+    await expect(readStorageObjectText(file!.stream)).resolves.toBe("photo-bytes");
+  });
+
+  it("writes chat uploads under the configured chat root and reopens them", async () => {
+    const photosRoot = await createTempRoot("photos");
+    const chatRoot = await createTempRoot("chat");
+    const adapter = createFilesystemMediaStorageAdapter({
+      chatRoot,
+      photosRoot,
+    });
+
+    const written = await adapter.chatUploads.writeUpload({
+      body: new TextEncoder().encode("upload-bytes"),
+      storageKey: "room_123/upload_456.webp",
+    });
+
+    expect(written).toEqual({
+      byteSize: 12,
+      storageKey: "room_123/upload_456.webp",
+      storagePath: "room_123/upload_456.webp",
+    });
+
+    const reopened = await adapter.chatUploads.openUpload(written.storagePath);
+
+    expect(reopened?.absolutePath).toBe(join(chatRoot, "room_123/upload_456.webp"));
+    await expect(readStorageObjectText(reopened!.stream)).resolves.toBe("upload-bytes");
+  });
+
+  it("rejects storage paths that escape the configured root", async () => {
+    const photosRoot = await createTempRoot("photos");
+    const chatRoot = await createTempRoot("chat");
+    const adapter = createFilesystemMediaStorageAdapter({
+      chatRoot,
+      photosRoot,
+    });
+
+    await expect(adapter.photos.openOriginal("../outside.jpg")).rejects.toThrow(
+      "Storage path escapes configured root",
+    );
+    await expect(
+      adapter.chatUploads.writeUpload({
+        body: new TextEncoder().encode("x"),
+        storageKey: "../outside.webp",
+      }),
+    ).rejects.toThrow("Storage path escapes configured root");
+  });
+});

--- a/backend/src/adapters/outbound/storage/filesystem/create-filesystem-media-storage-adapter.test.ts
+++ b/backend/src/adapters/outbound/storage/filesystem/create-filesystem-media-storage-adapter.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "bun:test";
@@ -82,5 +82,26 @@ describe("filesystem media storage adapter", () => {
         storageKey: "../outside.webp",
       }),
     ).rejects.toThrow("Storage path escapes configured root");
+  });
+
+  it("rejects symlink-backed paths inside the configured root", async () => {
+    const photosRoot = await createTempRoot("photos");
+    const chatRoot = await createTempRoot("chat");
+    const outsideRoot = await createTempRoot("outside");
+    const adapter = createFilesystemMediaStorageAdapter({
+      chatRoot,
+      photosRoot,
+    });
+
+    await writeFile(join(outsideRoot, "secret.txt"), "not-photo-bytes");
+    await symlink(join(outsideRoot, "secret.txt"), join(photosRoot, "linked-photo.jpg"));
+    await symlink(join(outsideRoot, "secret.txt"), join(chatRoot, "linked-upload.webp"));
+
+    await expect(adapter.photos.openOriginal("linked-photo.jpg")).rejects.toThrow(
+      "Storage path references a symbolic link",
+    );
+    await expect(adapter.chatUploads.openUpload("linked-upload.webp")).rejects.toThrow(
+      "Storage path references a symbolic link",
+    );
   });
 });

--- a/backend/src/adapters/outbound/storage/filesystem/create-filesystem-media-storage-adapter.ts
+++ b/backend/src/adapters/outbound/storage/filesystem/create-filesystem-media-storage-adapter.ts
@@ -1,4 +1,4 @@
-import { mkdir, stat, unlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, stat, unlink, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 
 import type {
@@ -24,7 +24,30 @@ const normalizeStoragePath = (value: string) => value.replaceAll("\\", "/");
 const createSafeStoragePathResolver = (root: string) => {
   const resolvedRoot = resolve(root);
 
-  return (storagePath: string) => {
+  const assertNoSymlinkSegments = async (normalizedStoragePath: string) => {
+    const segments = normalizedStoragePath.split("/").filter(Boolean);
+    let currentPath = resolvedRoot;
+
+    for (const segment of segments) {
+      currentPath = resolve(currentPath, segment);
+
+      try {
+        const entryStats = await lstat(currentPath);
+
+        if (entryStats.isSymbolicLink()) {
+          throw new Error(`Storage path references a symbolic link: ${normalizedStoragePath}`);
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          break;
+        }
+
+        throw error;
+      }
+    }
+  };
+
+  return async (storagePath: string) => {
     const normalizedStoragePath = normalizeStoragePath(storagePath).trim();
 
     if (normalizedStoragePath.length === 0) {
@@ -46,6 +69,8 @@ const createSafeStoragePathResolver = (root: string) => {
     ) {
       throw new Error(`Storage path escapes configured root: ${storagePath}`);
     }
+
+    await assertNoSymlinkSegments(normalizedStoragePath);
 
     return {
       absolutePath: resolvedPath,
@@ -81,7 +106,7 @@ const createPhotoMediaStorage = (photosRoot: string): PhotoMediaStoragePort => {
 
   return {
     openOriginal: async (reference) => {
-      const { absolutePath } = resolvePhotoPath(reference);
+      const { absolutePath } = await resolvePhotoPath(reference);
 
       return openStorageObject(absolutePath);
     },
@@ -93,7 +118,7 @@ const createChatUploadStorage = (chatRoot: string): ChatUploadStoragePort => {
 
   return {
     deleteUpload: async (storagePath) => {
-      const { absolutePath } = resolveChatPath(storagePath);
+      const { absolutePath } = await resolveChatPath(storagePath);
 
       try {
         await unlink(absolutePath);
@@ -104,14 +129,14 @@ const createChatUploadStorage = (chatRoot: string): ChatUploadStoragePort => {
       }
     },
     openUpload: async (storagePath) => {
-      const { absolutePath } = resolveChatPath(storagePath);
+      const { absolutePath } = await resolveChatPath(storagePath);
 
       return openStorageObject(absolutePath);
     },
     writeUpload: async (
       input: ChatUploadStorageWriteRequest,
     ): Promise<ChatUploadStorageWriteResult> => {
-      const { absolutePath, storagePath } = resolveChatPath(input.storageKey);
+      const { absolutePath, storagePath } = await resolveChatPath(input.storageKey);
 
       await mkdir(dirname(absolutePath), { recursive: true });
       await writeFile(absolutePath, input.body);

--- a/backend/src/adapters/outbound/storage/filesystem/create-filesystem-media-storage-adapter.ts
+++ b/backend/src/adapters/outbound/storage/filesystem/create-filesystem-media-storage-adapter.ts
@@ -1,0 +1,133 @@
+import { mkdir, stat, unlink, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+
+import type {
+  ChatUploadStoragePort,
+  ChatUploadStorageWriteRequest,
+  ChatUploadStorageWriteResult,
+  MediaStorageObject,
+  PhotoMediaStoragePort,
+} from "@/modules/media/ports/outbound";
+
+export type FilesystemMediaStorageAdapter = Readonly<{
+  chatUploads: ChatUploadStoragePort;
+  photos: PhotoMediaStoragePort;
+}>;
+
+export type FilesystemMediaStorageConfig = Readonly<{
+  chatRoot: string;
+  photosRoot: string;
+}>;
+
+const normalizeStoragePath = (value: string) => value.replaceAll("\\", "/");
+
+const createSafeStoragePathResolver = (root: string) => {
+  const resolvedRoot = resolve(root);
+
+  return (storagePath: string) => {
+    const normalizedStoragePath = normalizeStoragePath(storagePath).trim();
+
+    if (normalizedStoragePath.length === 0) {
+      throw new Error("Storage path must not be empty");
+    }
+
+    if (isAbsolute(normalizedStoragePath)) {
+      throw new Error(`Storage path must be relative: ${storagePath}`);
+    }
+
+    const resolvedPath = resolve(resolvedRoot, normalizedStoragePath);
+    const relativePath = relative(resolvedRoot, resolvedPath);
+
+    if (
+      relativePath.length === 0 ||
+      relativePath === ".." ||
+      relativePath.startsWith(`..${sep}`) ||
+      isAbsolute(relativePath)
+    ) {
+      throw new Error(`Storage path escapes configured root: ${storagePath}`);
+    }
+
+    return {
+      absolutePath: resolvedPath,
+      storagePath: normalizeStoragePath(relativePath),
+    };
+  };
+};
+
+const openStorageObject = async (absolutePath: string): Promise<MediaStorageObject | null> => {
+  try {
+    const fileStats = await stat(absolutePath);
+
+    if (!fileStats.isFile()) {
+      return null;
+    }
+
+    return {
+      absolutePath,
+      byteSize: fileStats.size,
+      stream: Bun.file(absolutePath).stream(),
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+
+    throw error;
+  }
+};
+
+const createPhotoMediaStorage = (photosRoot: string): PhotoMediaStoragePort => {
+  const resolvePhotoPath = createSafeStoragePathResolver(photosRoot);
+
+  return {
+    openOriginal: async (reference) => {
+      const { absolutePath } = resolvePhotoPath(reference);
+
+      return openStorageObject(absolutePath);
+    },
+  };
+};
+
+const createChatUploadStorage = (chatRoot: string): ChatUploadStoragePort => {
+  const resolveChatPath = createSafeStoragePathResolver(chatRoot);
+
+  return {
+    deleteUpload: async (storagePath) => {
+      const { absolutePath } = resolveChatPath(storagePath);
+
+      try {
+        await unlink(absolutePath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+      }
+    },
+    openUpload: async (storagePath) => {
+      const { absolutePath } = resolveChatPath(storagePath);
+
+      return openStorageObject(absolutePath);
+    },
+    writeUpload: async (
+      input: ChatUploadStorageWriteRequest,
+    ): Promise<ChatUploadStorageWriteResult> => {
+      const { absolutePath, storagePath } = resolveChatPath(input.storageKey);
+
+      await mkdir(dirname(absolutePath), { recursive: true });
+      await writeFile(absolutePath, input.body);
+
+      return {
+        byteSize: input.body.byteLength,
+        storageKey: input.storageKey,
+        storagePath,
+      };
+    },
+  };
+};
+
+export const createFilesystemMediaStorageAdapter = (
+  config: FilesystemMediaStorageConfig,
+): FilesystemMediaStorageAdapter => ({
+  chatUploads: createChatUploadStorage(config.chatRoot),
+  photos: createPhotoMediaStorage(config.photosRoot),
+});

--- a/backend/src/adapters/outbound/storage/filesystem/index.ts
+++ b/backend/src/adapters/outbound/storage/filesystem/index.ts
@@ -1,0 +1,5 @@
+export {
+  createFilesystemMediaStorageAdapter,
+  type FilesystemMediaStorageAdapter,
+  type FilesystemMediaStorageConfig,
+} from "./create-filesystem-media-storage-adapter";

--- a/backend/src/bootstrap/config/bootstrap-config.test.ts
+++ b/backend/src/bootstrap/config/bootstrap-config.test.ts
@@ -132,4 +132,19 @@ describe("bootstrap config", () => {
       }),
     ).toThrow("MEDIA_PHOTOS_ROOT and MEDIA_CHAT_ROOT must be different");
   });
+
+  it("rejects roots under a symlinked parent even when the leaf path does not exist yet", async () => {
+    const sharedRoot = await createTempRoot("shared-media");
+    const aliasParent = await createTempRoot("shared-alias");
+    const aliasPath = join(aliasParent, "alias");
+
+    await symlink(sharedRoot, aliasPath);
+
+    expect(() =>
+      loadBootstrapConfig({
+        MEDIA_CHAT_ROOT: join(aliasPath, "chat"),
+        MEDIA_PHOTOS_ROOT: sharedRoot,
+      }),
+    ).toThrow("MEDIA_PHOTOS_ROOT and MEDIA_CHAT_ROOT must be different");
+  });
 });

--- a/backend/src/bootstrap/config/bootstrap-config.test.ts
+++ b/backend/src/bootstrap/config/bootstrap-config.test.ts
@@ -79,4 +79,13 @@ describe("bootstrap config", () => {
     ]);
     expect(config.media.publicUrlBase).toBe("https://media.example.com");
   });
+
+  it("rejects overlapping media roots", () => {
+    expect(() =>
+      loadBootstrapConfig({
+        MEDIA_CHAT_ROOT: "/tmp/media",
+        MEDIA_PHOTOS_ROOT: "/tmp/media",
+      }),
+    ).toThrow("MEDIA_PHOTOS_ROOT and MEDIA_CHAT_ROOT must be different");
+  });
 });

--- a/backend/src/bootstrap/config/bootstrap-config.test.ts
+++ b/backend/src/bootstrap/config/bootstrap-config.test.ts
@@ -1,6 +1,21 @@
-import { describe, expect, it } from "bun:test";
+import { mkdtemp, rm, symlink } from "node:fs/promises";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "bun:test";
 
 import { loadBootstrapConfig } from "./bootstrap-config";
+
+const tempRoots: string[] = [];
+
+const createTempRoot = async (name: string) => {
+  const root = await mkdtemp(join(process.cwd(), `.tmp-${name}-`));
+  tempRoots.push(root);
+  return root;
+};
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
+});
 
 describe("bootstrap config", () => {
   it("loads defaults for runtime placeholders", () => {
@@ -92,6 +107,28 @@ describe("bootstrap config", () => {
       loadBootstrapConfig({
         MEDIA_CHAT_ROOT: "/tmp/media/",
         MEDIA_PHOTOS_ROOT: "/tmp/media",
+      }),
+    ).toThrow("MEDIA_PHOTOS_ROOT and MEDIA_CHAT_ROOT must be different");
+
+    expect(() =>
+      loadBootstrapConfig({
+        MEDIA_CHAT_ROOT: "/tmp/media/chat",
+        MEDIA_PHOTOS_ROOT: "/tmp/media",
+      }),
+    ).toThrow("MEDIA_PHOTOS_ROOT and MEDIA_CHAT_ROOT must be different");
+  });
+
+  it("rejects existing symlink aliases to the same root", async () => {
+    const sharedRoot = await createTempRoot("shared-media");
+    const aliasParent = await createTempRoot("shared-alias");
+    const aliasPath = join(aliasParent, "alias");
+
+    await symlink(sharedRoot, aliasPath);
+
+    expect(() =>
+      loadBootstrapConfig({
+        MEDIA_CHAT_ROOT: aliasPath,
+        MEDIA_PHOTOS_ROOT: sharedRoot,
       }),
     ).toThrow("MEDIA_PHOTOS_ROOT and MEDIA_CHAT_ROOT must be different");
   });

--- a/backend/src/bootstrap/config/bootstrap-config.test.ts
+++ b/backend/src/bootstrap/config/bootstrap-config.test.ts
@@ -87,5 +87,12 @@ describe("bootstrap config", () => {
         MEDIA_PHOTOS_ROOT: "/tmp/media",
       }),
     ).toThrow("MEDIA_PHOTOS_ROOT and MEDIA_CHAT_ROOT must be different");
+
+    expect(() =>
+      loadBootstrapConfig({
+        MEDIA_CHAT_ROOT: "/tmp/media/",
+        MEDIA_PHOTOS_ROOT: "/tmp/media",
+      }),
+    ).toThrow("MEDIA_PHOTOS_ROOT and MEDIA_CHAT_ROOT must be different");
   });
 });

--- a/backend/src/bootstrap/config/bootstrap-config.ts
+++ b/backend/src/bootstrap/config/bootstrap-config.ts
@@ -123,8 +123,36 @@ const parseString = (value: string | undefined, fallback: string) =>
 
 export const loadBootstrapConfig = (
   env: BootstrapEnv = Bun.env,
-): BootstrapConfig => ({
-  auth: {
+): BootstrapConfig => {
+  const media = {
+    chatRoot: parseString(env.MEDIA_CHAT_ROOT, DEFAULT_MEDIA_CHAT_ROOT),
+    chatUploadAllowedMimeTypes: parseList(
+      env.CHAT_UPLOAD_ALLOWED_MIME_TYPES,
+      DEFAULT_CHAT_UPLOAD_ALLOWED_MIME_TYPES,
+    ),
+    chatUploadMaxBytes: parseInteger(
+      env.CHAT_UPLOAD_MAX_BYTES,
+      DEFAULT_CHAT_UPLOAD_MAX_BYTES,
+      "CHAT_UPLOAD_MAX_BYTES",
+    ),
+    chatUploadMaxFilesPerMessage: parseInteger(
+      env.CHAT_UPLOAD_MAX_FILES_PER_MESSAGE,
+      DEFAULT_CHAT_UPLOAD_MAX_FILES_PER_MESSAGE,
+      "CHAT_UPLOAD_MAX_FILES_PER_MESSAGE",
+    ),
+    photosRoot: parseString(env.MEDIA_PHOTOS_ROOT, DEFAULT_MEDIA_PHOTOS_ROOT),
+    publicUrlBase: parseString(
+      env.MEDIA_PUBLIC_URL_BASE,
+      DEFAULT_MEDIA_PUBLIC_URL_BASE,
+    ),
+  };
+
+  if (media.photosRoot === media.chatRoot) {
+    throw new Error("MEDIA_PHOTOS_ROOT and MEDIA_CHAT_ROOT must be different");
+  }
+
+  return {
+    auth: {
     mfaCodeMaxAgeSeconds: parseInteger(
       env.AUTH_MFA_CODE_MAX_AGE_SECONDS,
       DEFAULT_MFA_CODE_MAX_AGE_SECONDS,
@@ -149,32 +177,12 @@ export const loadBootstrapConfig = (
     allowCredentials: parseBoolean(env.CORS_ALLOW_CREDENTIALS, true),
     allowedOrigins: parseList(env.CORS_ALLOWED_ORIGINS, []),
   },
-  media: {
-    chatRoot: parseString(env.MEDIA_CHAT_ROOT, DEFAULT_MEDIA_CHAT_ROOT),
-    chatUploadAllowedMimeTypes: parseList(
-      env.CHAT_UPLOAD_ALLOWED_MIME_TYPES,
-      DEFAULT_CHAT_UPLOAD_ALLOWED_MIME_TYPES,
-    ),
-    chatUploadMaxBytes: parseInteger(
-      env.CHAT_UPLOAD_MAX_BYTES,
-      DEFAULT_CHAT_UPLOAD_MAX_BYTES,
-      "CHAT_UPLOAD_MAX_BYTES",
-    ),
-    chatUploadMaxFilesPerMessage: parseInteger(
-      env.CHAT_UPLOAD_MAX_FILES_PER_MESSAGE,
-      DEFAULT_CHAT_UPLOAD_MAX_FILES_PER_MESSAGE,
-      "CHAT_UPLOAD_MAX_FILES_PER_MESSAGE",
-    ),
-    photosRoot: parseString(env.MEDIA_PHOTOS_ROOT, DEFAULT_MEDIA_PHOTOS_ROOT),
-    publicUrlBase: parseString(
-      env.MEDIA_PUBLIC_URL_BASE,
-      DEFAULT_MEDIA_PUBLIC_URL_BASE,
-    ),
-  },
+  media,
   server: {
     apiBasePath: API_BASE_PATH,
     mediaPhotoOriginalPath: MEDIA_PHOTO_ORIGINAL_PATH,
     nodeEnv: parseNodeEnv(env.NODE_ENV),
     port: parsePort(env.PORT),
   },
-});
+  };
+};

--- a/backend/src/bootstrap/config/bootstrap-config.ts
+++ b/backend/src/bootstrap/config/bootstrap-config.ts
@@ -1,5 +1,5 @@
 import { realpathSync } from "node:fs";
-import { isAbsolute, relative, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
 
 export const API_BASE_PATH = "/api" as const;
 export const MEDIA_PHOTO_ORIGINAL_PATH = "/media/photos/:id/original" as const;
@@ -125,16 +125,34 @@ const parseString = (value: string | undefined, fallback: string) =>
   value === undefined || value === "" ? fallback : value;
 
 const normalizeRootPath = (value: string) => {
-  const resolvedPath = resolve(value);
+  let resolvedPath = resolve(value);
+  const missingSegments: string[] = [];
 
-  try {
-    return realpathSync.native(resolvedPath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return resolvedPath;
+  while (true) {
+    try {
+      const canonicalBase = realpathSync.native(resolvedPath);
+
+      return missingSegments.reduceRight(
+        (currentPath, segment) => resolve(currentPath, segment),
+        canonicalBase,
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+
+      const parentPath = dirname(resolvedPath);
+
+      if (parentPath === resolvedPath) {
+        return missingSegments.reduceRight(
+          (currentPath, segment) => resolve(currentPath, segment),
+          resolvedPath,
+        );
+      }
+
+      missingSegments.push(basename(resolvedPath));
+      resolvedPath = parentPath;
     }
-
-    throw error;
   }
 };
 

--- a/backend/src/bootstrap/config/bootstrap-config.ts
+++ b/backend/src/bootstrap/config/bootstrap-config.ts
@@ -1,3 +1,5 @@
+import { resolve } from "node:path";
+
 export const API_BASE_PATH = "/api" as const;
 export const MEDIA_PHOTO_ORIGINAL_PATH = "/media/photos/:id/original" as const;
 
@@ -121,6 +123,8 @@ const parseList = (value: string | undefined, fallback: string[]) => {
 const parseString = (value: string | undefined, fallback: string) =>
   value === undefined || value === "" ? fallback : value;
 
+const normalizeRootPath = (value: string) => resolve(value);
+
 export const loadBootstrapConfig = (
   env: BootstrapEnv = Bun.env,
 ): BootstrapConfig => {
@@ -147,42 +151,42 @@ export const loadBootstrapConfig = (
     ),
   };
 
-  if (media.photosRoot === media.chatRoot) {
+  if (normalizeRootPath(media.photosRoot) === normalizeRootPath(media.chatRoot)) {
     throw new Error("MEDIA_PHOTOS_ROOT and MEDIA_CHAT_ROOT must be different");
   }
 
   return {
     auth: {
-    mfaCodeMaxAgeSeconds: parseInteger(
-      env.AUTH_MFA_CODE_MAX_AGE_SECONDS,
-      DEFAULT_MFA_CODE_MAX_AGE_SECONDS,
-      "AUTH_MFA_CODE_MAX_AGE_SECONDS",
-    ),
-    roomPasswordSecret: parseString(
-      env.AUTH_ROOM_PASSWORD_SECRET,
-      DEFAULT_ROOM_PASSWORD_SECRET,
-    ),
-    sessionCookieName: parseString(
-      env.AUTH_SESSION_COOKIE_NAME,
-      DEFAULT_SESSION_COOKIE_NAME,
-    ),
-    sessionMaxAgeSeconds: parseInteger(
-      env.AUTH_SESSION_MAX_AGE_SECONDS,
-      DEFAULT_SESSION_MAX_AGE_SECONDS,
-      "AUTH_SESSION_MAX_AGE_SECONDS",
-    ),
-    sessionSecret: parseString(env.AUTH_SESSION_SECRET, DEFAULT_SESSION_SECRET),
-  },
-  cors: {
-    allowCredentials: parseBoolean(env.CORS_ALLOW_CREDENTIALS, true),
-    allowedOrigins: parseList(env.CORS_ALLOWED_ORIGINS, []),
-  },
-  media,
-  server: {
-    apiBasePath: API_BASE_PATH,
-    mediaPhotoOriginalPath: MEDIA_PHOTO_ORIGINAL_PATH,
-    nodeEnv: parseNodeEnv(env.NODE_ENV),
-    port: parsePort(env.PORT),
-  },
+      mfaCodeMaxAgeSeconds: parseInteger(
+        env.AUTH_MFA_CODE_MAX_AGE_SECONDS,
+        DEFAULT_MFA_CODE_MAX_AGE_SECONDS,
+        "AUTH_MFA_CODE_MAX_AGE_SECONDS",
+      ),
+      roomPasswordSecret: parseString(
+        env.AUTH_ROOM_PASSWORD_SECRET,
+        DEFAULT_ROOM_PASSWORD_SECRET,
+      ),
+      sessionCookieName: parseString(
+        env.AUTH_SESSION_COOKIE_NAME,
+        DEFAULT_SESSION_COOKIE_NAME,
+      ),
+      sessionMaxAgeSeconds: parseInteger(
+        env.AUTH_SESSION_MAX_AGE_SECONDS,
+        DEFAULT_SESSION_MAX_AGE_SECONDS,
+        "AUTH_SESSION_MAX_AGE_SECONDS",
+      ),
+      sessionSecret: parseString(env.AUTH_SESSION_SECRET, DEFAULT_SESSION_SECRET),
+    },
+    cors: {
+      allowCredentials: parseBoolean(env.CORS_ALLOW_CREDENTIALS, true),
+      allowedOrigins: parseList(env.CORS_ALLOWED_ORIGINS, []),
+    },
+    media,
+    server: {
+      apiBasePath: API_BASE_PATH,
+      mediaPhotoOriginalPath: MEDIA_PHOTO_ORIGINAL_PATH,
+      nodeEnv: parseNodeEnv(env.NODE_ENV),
+      port: parsePort(env.PORT),
+    },
   };
 };

--- a/backend/src/bootstrap/config/bootstrap-config.ts
+++ b/backend/src/bootstrap/config/bootstrap-config.ts
@@ -1,4 +1,5 @@
-import { resolve } from "node:path";
+import { realpathSync } from "node:fs";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 
 export const API_BASE_PATH = "/api" as const;
 export const MEDIA_PHOTO_ORIGINAL_PATH = "/media/photos/:id/original" as const;
@@ -123,7 +124,32 @@ const parseList = (value: string | undefined, fallback: string[]) => {
 const parseString = (value: string | undefined, fallback: string) =>
   value === undefined || value === "" ? fallback : value;
 
-const normalizeRootPath = (value: string) => resolve(value);
+const normalizeRootPath = (value: string) => {
+  const resolvedPath = resolve(value);
+
+  try {
+    return realpathSync.native(resolvedPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return resolvedPath;
+    }
+
+    throw error;
+  }
+};
+
+const pathsOverlap = (left: string, right: string) => {
+  const normalizedLeft = normalizeRootPath(left);
+  const normalizedRight = normalizeRootPath(right);
+  const leftToRight = relative(normalizedLeft, normalizedRight);
+  const rightToLeft = relative(normalizedRight, normalizedLeft);
+
+  const isContained = (candidate: string) =>
+    candidate.length === 0 ||
+    (!isAbsolute(candidate) && candidate !== ".." && !candidate.startsWith(`..${sep}`));
+
+  return isContained(leftToRight) || isContained(rightToLeft);
+};
 
 export const loadBootstrapConfig = (
   env: BootstrapEnv = Bun.env,
@@ -151,7 +177,7 @@ export const loadBootstrapConfig = (
     ),
   };
 
-  if (normalizeRootPath(media.photosRoot) === normalizeRootPath(media.chatRoot)) {
+  if (pathsOverlap(media.photosRoot, media.chatRoot)) {
     throw new Error("MEDIA_PHOTOS_ROOT and MEDIA_CHAT_ROOT must be different");
   }
 

--- a/backend/src/bootstrap/container/create-container.test.ts
+++ b/backend/src/bootstrap/container/create-container.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+
+import { createContainer } from "./create-container";
+
+describe("bootstrap container", () => {
+  it("wires media repository and filesystem storage ports", () => {
+    const container = createContainer({
+      MEDIA_CHAT_ROOT: "/tmp/chat",
+      MEDIA_PHOTOS_ROOT: "/tmp/photos",
+      NODE_ENV: "test",
+    });
+
+    expect(typeof container.media.repository.findPhotoMediaById).toBe("function");
+    expect(typeof container.media.repository.findChatUploadMediaById).toBe("function");
+    expect(typeof container.media.storage.photos.openOriginal).toBe("function");
+    expect(typeof container.media.storage.chatUploads.openUpload).toBe("function");
+    expect(typeof container.media.storage.chatUploads.writeUpload).toBe("function");
+  });
+});

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -1,4 +1,5 @@
 import { createPrismaPersistenceAdapter } from "@/adapters/outbound/persistence";
+import { createFilesystemMediaStorageAdapter } from "@/adapters/outbound/storage/filesystem";
 import {
   createGetPublishedProjectBySlugUseCase,
   createGetPublishedPhotoByIdUseCase,
@@ -31,15 +32,24 @@ export type BootstrapContainer = Readonly<{
     listPublishedThoughts: ListPublishedThoughtsPort;
     listStatusStripEntries: ListStatusStripEntriesPort;
   }>;
+  media: Readonly<{
+    repository: ReturnType<typeof createPrismaPersistenceAdapter>["media"];
+    storage: ReturnType<typeof createFilesystemMediaStorageAdapter>;
+  }>;
 }>;
 
 type BootstrapEnv = Readonly<Record<string, string | undefined>>;
 
 export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer => {
+  const config = loadBootstrapConfig(env);
   const persistence = createPrismaPersistenceAdapter();
+  const storage = createFilesystemMediaStorageAdapter({
+    chatRoot: config.media.chatRoot,
+    photosRoot: config.media.photosRoot,
+  });
 
   return {
-    config: loadBootstrapConfig(env),
+    config,
     content: {
       getPublishedProjectBySlug: createGetPublishedProjectBySlugUseCase({
         repository: persistence.content,
@@ -62,6 +72,10 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
       listStatusStripEntries: createListStatusStripEntriesUseCase({
         repository: persistence.content,
       }),
+    },
+    media: {
+      repository: persistence.media,
+      storage,
     },
   };
 };

--- a/backend/src/bootstrap/server.test.ts
+++ b/backend/src/bootstrap/server.test.ts
@@ -183,6 +183,26 @@ const createTestContainer = (): BootstrapContainer => ({
       }),
     },
   },
+  media: {
+    repository: {
+      findChatUploadMediaById: async () => null,
+      findPhotoMediaById: async () => null,
+    },
+    storage: {
+      chatUploads: {
+        deleteUpload: async () => {},
+        openUpload: async () => null,
+        writeUpload: async () => ({
+          byteSize: 0,
+          storageKey: "test-upload",
+          storagePath: "test-upload",
+        }),
+      },
+      photos: {
+        openOriginal: async () => null,
+      },
+    },
+  },
 });
 
 describe("backend server scaffold", () => {

--- a/backend/src/modules/media/ports/outbound/index.ts
+++ b/backend/src/modules/media/ports/outbound/index.ts
@@ -21,3 +21,30 @@ export interface MediaRepositoryPort {
   findPhotoMediaById(photoId: string): Promise<PhotoMediaRepositoryRow | null>;
   findChatUploadMediaById(uploadId: string): Promise<ChatUploadMediaRepositoryRow | null>;
 }
+
+export type MediaStorageObject = Readonly<{
+  absolutePath: string;
+  byteSize: number;
+  stream: ReadableStream<Uint8Array>;
+}>;
+
+export type ChatUploadStorageWriteRequest = Readonly<{
+  body: Uint8Array;
+  storageKey: string;
+}>;
+
+export type ChatUploadStorageWriteResult = Readonly<{
+  byteSize: number;
+  storageKey: string;
+  storagePath: string;
+}>;
+
+export interface PhotoMediaStoragePort {
+  openOriginal(reference: string): Promise<MediaStorageObject | null>;
+}
+
+export interface ChatUploadStoragePort {
+  deleteUpload(storagePath: string): Promise<void>;
+  openUpload(storagePath: string): Promise<MediaStorageObject | null>;
+  writeUpload(input: ChatUploadStorageWriteRequest): Promise<ChatUploadStorageWriteResult>;
+}


### PR DESCRIPTION
## Summary
- implement real Prisma media reads and a filesystem-backed storage adapter boundary
- wire media repository and storage dependencies through bootstrap/config
- add repository, storage, config, and container coverage for the Cluster 4 media foundation

## Checks
- bun run typecheck
- bun test
- bun run build
- bun run verify

## GitHub
Closes #53