### PR TITLE
[BE-014] Implement chat upload validation and storage flow

### DIFF
--- a/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from "bun:test";
+
+import type { BootstrapContainer } from "@/bootstrap/container";
+import type {
+  UploadChatMessageWithImageInput,
+  UploadChatMessageWithImageOutput,
+} from "@/modules/chat/ports/inbound";
+import { InvalidChatUploadActorError } from "@/modules/chat/application";
+
+import { createHonoHttpAdapter } from "./http-adapter";
+
+const createTestContainer = (
+  executeUpload: (
+    input: UploadChatMessageWithImageInput,
+  ) => UploadChatMessageWithImageOutput | Promise<UploadChatMessageWithImageOutput>,
+): BootstrapContainer => ({
+  chat: {
+    uploadMessageWithImage: {
+      execute: executeUpload,
+    },
+  },
+  config: {
+    auth: {
+      mfaCodeMaxAgeSeconds: 600,
+      roomPasswordSecret: "test-room-secret",
+      sessionCookieName: "vinicius.dev-session",
+      sessionMaxAgeSeconds: 604800,
+      sessionSecret: "test-session-secret",
+    },
+    cors: {
+      allowCredentials: true,
+      allowedOrigins: [],
+    },
+    media: {
+      chatRoot: "/tmp/chat",
+      chatUploadAllowedMimeTypes: ["image/jpeg", "image/png", "image/webp"],
+      chatUploadMaxBytes: 5 * 1024 * 1024,
+      chatUploadMaxFilesPerMessage: 1,
+      photosRoot: "/tmp/photos",
+      publicUrlBase: "/media",
+    },
+    server: {
+      apiBasePath: "/api",
+      mediaPhotoOriginalPath: "/media/photos/:id/original",
+      nodeEnv: "test",
+      port: 4000,
+    },
+  },
+  content: {
+    getPublishedProjectBySlug: {
+      execute: async () => null,
+    },
+    getPublishedPhotoById: {
+      execute: async () => null,
+    },
+    getPublishedThoughtBySlug: {
+      execute: async () => null,
+    },
+    listPublishedPhotos: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          page: 1,
+          pageSize: 24,
+          totalItems: 0,
+          totalPages: 1,
+        },
+      }),
+    },
+    listPublishedProjects: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          page: 1,
+          pageSize: 12,
+          totalItems: 0,
+          totalPages: 1,
+        },
+      }),
+    },
+    listPublishedThoughts: {
+      execute: async () => ({
+        items: [],
+        pageInfo: {
+          nextCursor: null,
+        },
+      }),
+    },
+    listStatusStripEntries: {
+      execute: async () => ({
+        items: [],
+      }),
+    },
+  },
+  media: {
+    repository: {
+      findChatUploadMediaById: async () => null,
+      findPhotoMediaById: async () => null,
+    },
+    storage: {
+      chatUploads: {
+        deleteUpload: async () => {},
+        openUpload: async () => null,
+        writeUpload: async () => ({
+          byteSize: 0,
+          storageKey: "test-upload",
+          storagePath: "test-upload",
+        }),
+      },
+      photos: {
+        openOriginal: async () => null,
+      },
+    },
+  },
+});
+
+const createUploadFormData = ({
+  body = "message body",
+  bytes = new Uint8Array([1, 2, 3, 4]),
+  fileName = "scan.png",
+  mimeType = "image/png",
+  tone = "cyan",
+}: {
+  body?: string;
+  bytes?: Uint8Array;
+  fileName?: string;
+  mimeType?: string;
+  tone?: string;
+} = {}): FormData => {
+  const formData = new FormData();
+  const fileBytes = new Uint8Array(bytes.byteLength);
+  fileBytes.set(bytes);
+  formData.append("roomId", "room_1");
+  formData.append("roomSessionId", "session_1");
+  formData.append("authorHandleId", "handle_1");
+  formData.append("body", body);
+  formData.append("tone", tone);
+  formData.append("file", new File([fileBytes.buffer], fileName, { type: mimeType }));
+
+  return formData;
+};
+
+describe("chat routes", () => {
+  it("maps a valid upload request into the chat upload use case", async () => {
+    let capturedAuthorHandleId: string | undefined;
+    let capturedMimeType: string | undefined;
+    let capturedRoomId: string | undefined;
+    let capturedRoomSessionId: string | undefined;
+    let capturedTone: "cyan" | "pink" | "system" | null | undefined;
+    const app = createHonoHttpAdapter(
+      createTestContainer(async (input) => {
+        capturedAuthorHandleId = input.authorHandleId;
+        capturedMimeType = input.image.mimeType;
+        capturedRoomId = input.roomId;
+        capturedRoomSessionId = input.roomSessionId;
+        capturedTone = input.tone;
+
+        return {
+          attachment: {
+            byteSize: 4,
+            fileName: "scan.png",
+            id: "upload_1",
+            kind: "image",
+            mimeType: "image/png",
+          },
+          authorHandleId: "handle_1",
+          body: "message body",
+          id: "message_1",
+          sentAt: "2026-04-24T12:00:00.000Z",
+          tone: "cyan",
+        };
+      }),
+    );
+
+    const response = await app.request("/api/chat/messages/upload", {
+      body: createUploadFormData(),
+      method: "POST",
+    });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      item: {
+        attachment: {
+          byteSize: 4,
+          fileName: "scan.png",
+          id: "upload_1",
+          kind: "image",
+          mimeType: "image/png",
+        },
+        authorHandleId: "handle_1",
+        body: "message body",
+        id: "message_1",
+        sentAt: "2026-04-24T12:00:00.000Z",
+        tone: "cyan",
+      },
+    });
+    expect(capturedRoomId).toBe("room_1");
+    expect(capturedRoomSessionId).toBe("session_1");
+    expect(capturedAuthorHandleId).toBe("handle_1");
+    expect(capturedTone).toBe("cyan");
+    expect(capturedMimeType).toBe("image/png");
+  });
+
+  it("rejects invalid MIME types before reaching the core", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer(async () => {
+        called = true;
+        throw new Error("should not run");
+      }),
+    );
+
+    const response = await app.request("/api/chat/messages/upload", {
+      body: createUploadFormData({
+        fileName: "scan.bin",
+        mimeType: "application/octet-stream",
+      }),
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_upload",
+      field: "file",
+      reason: "unsupported_mime_type",
+    });
+    expect(called).toBe(false);
+  });
+
+  it("rejects oversized uploads before reaching the core", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer(async () => {
+        called = true;
+        throw new Error("should not run");
+      }),
+    );
+
+    const response = await app.request("/api/chat/messages/upload", {
+      body: createUploadFormData({ bytes: new Uint8Array(5 * 1024 * 1024 + 1) }),
+      method: "POST",
+    });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_upload",
+      field: "file",
+      reason: "file_too_large",
+    });
+    expect(called).toBe(false);
+  });
+
+  it("rejects multiple upload files per message", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer(async () => {
+        called = true;
+        throw new Error("should not run");
+      }),
+    );
+    const formData = createUploadFormData();
+    formData.append("file", new File([new Uint8Array([5, 6])], "extra.jpg", { type: "image/jpeg" }));
+
+    const response = await app.request("/api/chat/messages/upload", {
+      body: formData,
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_upload",
+      field: "file",
+      reason: "too_many_files",
+    });
+    expect(called).toBe(false);
+  });
+
+  it("returns denied when the room session and author ids do not match", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer(async () => {
+        throw new InvalidChatUploadActorError();
+      }),
+    );
+
+    const response = await app.request("/api/chat/messages/upload", {
+      body: createUploadFormData(),
+      method: "POST",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "denied",
+      resource: "chat",
+    });
+  });
+});

--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 
+import { InvalidChatUploadActorError } from "@/modules/chat/application";
 import { InvalidThoughtCursorError } from "@/modules/content/application";
+import type { ChatUploadMimeType } from "@/modules/chat/ports/inbound";
 import type { BootstrapContainer } from "@/bootstrap/container";
 
 import { presentThoughtsRssFeed } from "./rss-presenter";
@@ -395,6 +397,240 @@ const createStatusStripFamily = (container: BootstrapContainer) => {
   return statusStripApp;
 };
 
+const supportedChatUploadMimeTypes: readonly ChatUploadMimeType[] = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+];
+
+const isSupportedChatUploadMimeType = (value: string): value is ChatUploadMimeType => {
+  return supportedChatUploadMimeTypes.includes(value as ChatUploadMimeType);
+};
+
+const getRequiredFormText = (
+  formData: FormData,
+  field: string,
+): { error: { error: "invalid_request"; field: string } } | { value: string } => {
+  const value = formData.get(field);
+
+  if (typeof value !== "string") {
+    return {
+      error: {
+        error: "invalid_request",
+        field,
+      },
+    };
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return {
+      error: {
+        error: "invalid_request",
+        field,
+      },
+    };
+  }
+
+  return {
+    value: trimmed,
+  };
+};
+
+const getOptionalFormText = (formData: FormData, field: string): string | undefined => {
+  const value = formData.get(field);
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  return value;
+};
+
+const collectUploadFiles = (formData: FormData): File[] => {
+  const files: File[] = [];
+
+  for (const value of formData.values()) {
+    if (typeof value !== "string") {
+      files.push(value);
+    }
+  }
+
+  return files;
+};
+
+const createChatFamily = (container: BootstrapContainer) => {
+  const chatApp = new Hono();
+
+  chatApp.post("/messages/upload", async (c) => {
+    let formData: FormData;
+
+    try {
+      formData = await c.req.formData();
+    } catch (_error) {
+      return c.json(
+        {
+          error: "invalid_request",
+          field: "formData",
+        },
+        400,
+      );
+    }
+
+    const roomId = getRequiredFormText(formData, "roomId");
+
+    if ("error" in roomId) {
+      return c.json(roomId.error, 400);
+    }
+
+    const roomSessionId = getRequiredFormText(formData, "roomSessionId");
+
+    if ("error" in roomSessionId) {
+      return c.json(roomSessionId.error, 400);
+    }
+
+    const authorHandleId = getRequiredFormText(formData, "authorHandleId");
+
+    if ("error" in authorHandleId) {
+      return c.json(authorHandleId.error, 400);
+    }
+
+    const toneInput = getOptionalFormText(formData, "tone")?.trim();
+
+    if (
+      toneInput &&
+      toneInput !== "cyan" &&
+      toneInput !== "pink" &&
+      toneInput !== "system"
+    ) {
+      return c.json(
+        {
+          error: "invalid_request",
+          field: "tone",
+        },
+        400,
+      );
+    }
+
+    const tone: "cyan" | "pink" | "system" | null =
+      toneInput === "cyan" || toneInput === "pink" || toneInput === "system"
+        ? toneInput
+        : null;
+
+    const files = collectUploadFiles(formData);
+
+    if (files.length === 0) {
+      return c.json(
+        {
+          error: "invalid_upload",
+          field: "file",
+          reason: "missing_file",
+        },
+        400,
+      );
+    }
+
+    if (files.length > container.config.media.chatUploadMaxFilesPerMessage) {
+      return c.json(
+        {
+          error: "invalid_upload",
+          field: "file",
+          reason: "too_many_files",
+        },
+        400,
+      );
+    }
+
+    const uploadFile = files[0];
+    const mimeType = uploadFile.type.trim().toLowerCase();
+
+    if (!isSupportedChatUploadMimeType(mimeType)) {
+      return c.json(
+        {
+          error: "invalid_upload",
+          field: "file",
+          reason: "unsupported_mime_type",
+        },
+        400,
+      );
+    }
+
+    if (!container.config.media.chatUploadAllowedMimeTypes.includes(mimeType)) {
+      return c.json(
+        {
+          error: "invalid_upload",
+          field: "file",
+          reason: "unsupported_mime_type",
+        },
+        400,
+      );
+    }
+
+    if (uploadFile.size > container.config.media.chatUploadMaxBytes) {
+      return c.json(
+        {
+          error: "invalid_upload",
+          field: "file",
+          reason: "file_too_large",
+        },
+        413,
+      );
+    }
+
+    let result;
+
+    try {
+      result = await container.chat.uploadMessageWithImage.execute({
+        authorHandleId: authorHandleId.value,
+        body: getOptionalFormText(formData, "body"),
+        image: {
+          body: new Uint8Array(await uploadFile.arrayBuffer()),
+          displayFilename: uploadFile.name.trim() || "upload",
+          mimeType,
+        },
+        roomId: roomId.value,
+        roomSessionId: roomSessionId.value,
+        tone,
+      });
+    } catch (error) {
+      if (error instanceof InvalidChatUploadActorError) {
+        return c.json(
+          {
+            error: "denied",
+            resource: "chat",
+          },
+          403,
+        );
+      }
+
+      throw error;
+    }
+
+    return c.json(
+      {
+        item: result,
+      },
+      201,
+    );
+  });
+
+  chatApp.all("*", (c) =>
+    c.json<NotImplementedResponse>(
+      {
+        family: "chat",
+        method: c.req.method,
+        route: c.req.path,
+        service: serviceName,
+        status: "not_implemented",
+      },
+      501,
+    ),
+  );
+
+  return chatApp;
+};
+
 const createSitemapFamily = () => {
   const sitemapApp = new Hono();
 
@@ -430,7 +666,7 @@ export const createHonoHttpAdapter = (container: BootstrapContainer) => {
   app.route("/api/rss", createRssFamily(container));
   app.route("/api/sitemap", createSitemapFamily());
   app.route("/api/status-strip", createStatusStripFamily(container));
-  mountPlaceholderFamily(app, "/api/chat", "chat");
+  app.route("/api/chat", createChatFamily(container));
   mountPlaceholderFamily(app, "/api/admin", "admin");
   mountPlaceholderFamily(app, "/api/auth", "auth");
 

--- a/backend/src/adapters/inbound/http/hono/photos-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/photos-routes.test.ts
@@ -5,6 +5,24 @@ import type { BootstrapContainer } from "@/bootstrap/container";
 import { createHonoHttpAdapter } from "./http-adapter";
 
 const createTestContainer = (): BootstrapContainer => ({
+  chat: {
+    uploadMessageWithImage: {
+      execute: async () => ({
+        attachment: {
+          byteSize: 0,
+          fileName: "upload.webp",
+          id: "upload_1",
+          kind: "image",
+          mimeType: "image/webp",
+        },
+        authorHandleId: "handle_1",
+        body: "uploaded an image without a caption",
+        id: "message_1",
+        sentAt: "2026-04-24T00:00:00.000Z",
+        tone: null,
+      }),
+    },
+  },
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,

--- a/backend/src/adapters/inbound/http/hono/projects-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/projects-routes.test.ts
@@ -5,6 +5,24 @@ import type { BootstrapContainer } from "@/bootstrap/container";
 import { createHonoHttpAdapter } from "./http-adapter";
 
 const createTestContainer = (): BootstrapContainer => ({
+  chat: {
+    uploadMessageWithImage: {
+      execute: async () => ({
+        attachment: {
+          byteSize: 0,
+          fileName: "upload.webp",
+          id: "upload_1",
+          kind: "image",
+          mimeType: "image/webp",
+        },
+        authorHandleId: "handle_1",
+        body: "uploaded an image without a caption",
+        id: "message_1",
+        sentAt: "2026-04-24T00:00:00.000Z",
+        tone: null,
+      }),
+    },
+  },
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,

--- a/backend/src/adapters/inbound/http/hono/rss-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/rss-routes.test.ts
@@ -6,6 +6,24 @@ import { createHonoHttpAdapter } from "./http-adapter";
 import { presentThoughtsRssFeed } from "./rss-presenter";
 
 const createTestContainer = (): BootstrapContainer => ({
+  chat: {
+    uploadMessageWithImage: {
+      execute: async () => ({
+        attachment: {
+          byteSize: 0,
+          fileName: "upload.webp",
+          id: "upload_1",
+          kind: "image",
+          mimeType: "image/webp",
+        },
+        authorHandleId: "handle_1",
+        body: "uploaded an image without a caption",
+        id: "message_1",
+        sentAt: "2026-04-24T00:00:00.000Z",
+        tone: null,
+      }),
+    },
+  },
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,

--- a/backend/src/adapters/inbound/http/hono/sitemap-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/sitemap-routes.test.ts
@@ -6,6 +6,24 @@ import { createHonoHttpAdapter } from "./http-adapter";
 import { presentSitemapXml } from "./sitemap-presenter";
 
 const createTestContainer = (): BootstrapContainer => ({
+  chat: {
+    uploadMessageWithImage: {
+      execute: async () => ({
+        attachment: {
+          byteSize: 0,
+          fileName: "upload.webp",
+          id: "upload_1",
+          kind: "image",
+          mimeType: "image/webp",
+        },
+        authorHandleId: "handle_1",
+        body: "uploaded an image without a caption",
+        id: "message_1",
+        sentAt: "2026-04-24T00:00:00.000Z",
+        tone: null,
+      }),
+    },
+  },
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,

--- a/backend/src/adapters/inbound/http/hono/status-strip-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/status-strip-routes.test.ts
@@ -5,6 +5,24 @@ import type { BootstrapContainer } from "@/bootstrap/container";
 import { createHonoHttpAdapter } from "./http-adapter";
 
 const createTestContainer = (): BootstrapContainer => ({
+  chat: {
+    uploadMessageWithImage: {
+      execute: async () => ({
+        attachment: {
+          byteSize: 0,
+          fileName: "upload.webp",
+          id: "upload_1",
+          kind: "image",
+          mimeType: "image/webp",
+        },
+        authorHandleId: "handle_1",
+        body: "uploaded an image without a caption",
+        id: "message_1",
+        sentAt: "2026-04-24T00:00:00.000Z",
+        tone: null,
+      }),
+    },
+  },
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,

--- a/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
@@ -5,6 +5,24 @@ import type { BootstrapContainer } from "@/bootstrap/container";
 import { createHonoHttpAdapter } from "./http-adapter";
 
 const createTestContainer = (): BootstrapContainer => ({
+  chat: {
+    uploadMessageWithImage: {
+      execute: async () => ({
+        attachment: {
+          byteSize: 0,
+          fileName: "upload.webp",
+          id: "upload_1",
+          kind: "image",
+          mimeType: "image/webp",
+        },
+        authorHandleId: "handle_1",
+        body: "uploaded an image without a caption",
+        id: "message_1",
+        sentAt: "2026-04-24T00:00:00.000Z",
+        tone: null,
+      }),
+    },
+  },
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "bun:test";
+
+import { createPrismaChatRepository } from "./chat-repository";
+import type { PrismaDatabaseClient } from "./prisma-client";
+
+describe("prisma chat repository", () => {
+  it("maps a room session row for upload actor validation", async () => {
+    const repository = createPrismaChatRepository({
+      chatRoomSession: {
+        findUnique: async () => ({
+          createdAt: new Date("2026-04-24T10:00:00.000Z"),
+          expiresAt: null,
+          handleId: "handle_1",
+          id: "session_1",
+          joinedAt: new Date("2026-04-24T10:00:00.000Z"),
+          lastSeenAt: new Date("2026-04-24T10:05:00.000Z"),
+          leftAt: null,
+          roomId: "room_1",
+          status: "active" as const,
+          updatedAt: new Date("2026-04-24T10:05:00.000Z"),
+        }),
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    await expect(repository.findSessionById("session_1")).resolves.toEqual({
+      createdAt: new Date("2026-04-24T10:00:00.000Z"),
+      expiresAt: null,
+      handleId: "handle_1",
+      id: "session_1",
+      joinedAt: new Date("2026-04-24T10:00:00.000Z"),
+      lastSeenAt: new Date("2026-04-24T10:05:00.000Z"),
+      leftAt: null,
+      roomId: "room_1",
+      status: "active",
+      updatedAt: new Date("2026-04-24T10:05:00.000Z"),
+    });
+  });
+
+  it("persists and maps a message with upload metadata in one transaction", async () => {
+    let capturedMessageData: Record<string, unknown> | null = null;
+    let capturedUploadData: Record<string, unknown> | null = null;
+    const repository = createPrismaChatRepository({
+      $transaction: async <T>(
+        runInTransaction: (tx: {
+          chatMessage: {
+            create: (args: { data: Record<string, unknown> }) => Promise<Record<string, unknown>>;
+          };
+          chatUpload: {
+            create: (args: { data: Record<string, unknown> }) => Promise<Record<string, unknown>>;
+          };
+        }) => Promise<T>,
+      ) =>
+        runInTransaction({
+          chatMessage: {
+            create: async ({ data }: { data: Record<string, unknown> }) => {
+              capturedMessageData = data;
+
+              return {
+                authorHandleId: "handle_1",
+                body: "night drop",
+                createdAt: new Date("2026-04-24T10:00:00.000Z"),
+                deletedAt: null,
+                hiddenAt: null,
+                id: "message_1",
+                moderationState: "visible" as const,
+                roomId: "room_1",
+                roomSessionId: "session_1",
+                sentAt: new Date("2026-04-24T10:00:00.000Z"),
+                tone: "pink" as const,
+                updatedAt: new Date("2026-04-24T10:00:00.000Z"),
+              };
+            },
+          },
+          chatUpload: {
+            create: async ({ data }: { data: Record<string, unknown> }) => {
+              capturedUploadData = data;
+
+              return {
+                byteSize: 1234,
+                createdAt: new Date("2026-04-24T10:00:00.000Z"),
+                deletedAt: null,
+                displayFilename: "drop.png",
+                hiddenAt: null,
+                id: "upload_1",
+                kind: "image" as const,
+                messageId: "message_1",
+                mimeType: "image_png" as const,
+                moderationState: "visible" as const,
+                roomId: "room_1",
+                storageKey: "room_1/upload_1.png",
+                storagePath: "room_1/upload_1.png",
+                updatedAt: new Date("2026-04-24T10:00:00.000Z"),
+                uploaderHandleId: "handle_1",
+                uploaderSessionId: "session_1",
+              };
+            },
+          },
+        }),
+    } as unknown as PrismaDatabaseClient);
+
+    const result = await repository.createMessageWithUpload({
+      authorHandleId: "handle_1",
+      body: "night drop",
+      byteSize: 1234,
+      displayFilename: "drop.png",
+      messageId: "message_1",
+      mimeType: "image/png",
+      roomId: "room_1",
+      roomSessionId: "session_1",
+      sentAt: new Date("2026-04-24T10:00:00.000Z"),
+      storageKey: "room_1/upload_1.png",
+      storagePath: "room_1/upload_1.png",
+      tone: "pink",
+      uploadId: "upload_1",
+    });
+
+    expect(capturedMessageData).toMatchObject({
+      authorHandleId: "handle_1",
+      body: "night drop",
+      id: "message_1",
+      roomId: "room_1",
+      roomSessionId: "session_1",
+      tone: "pink",
+    });
+    expect(capturedUploadData).toMatchObject({
+      byteSize: 1234,
+      displayFilename: "drop.png",
+      id: "upload_1",
+      messageId: "message_1",
+      mimeType: "image_png",
+      roomId: "room_1",
+      storageKey: "room_1/upload_1.png",
+      storagePath: "room_1/upload_1.png",
+      uploaderHandleId: "handle_1",
+      uploaderSessionId: "session_1",
+    });
+    expect(result).toEqual({
+      message: {
+        authorHandleId: "handle_1",
+        body: "night drop",
+        createdAt: new Date("2026-04-24T10:00:00.000Z"),
+        deletedAt: null,
+        hiddenAt: null,
+        id: "message_1",
+        moderationState: "visible",
+        roomId: "room_1",
+        roomSessionId: "session_1",
+        sentAt: new Date("2026-04-24T10:00:00.000Z"),
+        tone: "pink",
+        updatedAt: new Date("2026-04-24T10:00:00.000Z"),
+      },
+      upload: {
+        byteSize: 1234,
+        createdAt: new Date("2026-04-24T10:00:00.000Z"),
+        deletedAt: null,
+        displayFilename: "drop.png",
+        hiddenAt: null,
+        id: "upload_1",
+        kind: "image",
+        messageId: "message_1",
+        mimeType: "image/png",
+        moderationState: "visible",
+        roomId: "room_1",
+        storageKey: "room_1/upload_1.png",
+        storagePath: "room_1/upload_1.png",
+        updatedAt: new Date("2026-04-24T10:00:00.000Z"),
+        uploaderHandleId: "handle_1",
+        uploaderSessionId: "session_1",
+      },
+    });
+  });
+});

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
@@ -1,11 +1,15 @@
 import type {
+  CreateChatMessageWithUploadCommand,
+  CreateChatMessageWithUploadResult,
   ChatHandleRepositoryRow,
   ChatMessageListQuery,
   ChatMessageRepositoryRow,
   ChatRepositoryPort,
   ChatRoomRepositoryRow,
+  ChatRoomSessionRepositoryRow,
   ChatUploadRepositoryRow,
 } from "@/modules/chat/ports/outbound";
+import { ChatUploadMimeType } from "../../../../../generated/prisma/client";
 
 import type { PrismaDatabaseClient } from "./prisma-client";
 
@@ -13,9 +17,218 @@ const notImplemented = <T>(method: string): Promise<T> => {
   return Promise.reject(new Error(`Prisma chat repository method not implemented: ${method}`));
 };
 
-export const createPrismaChatRepository = (_client: PrismaDatabaseClient): ChatRepositoryPort => ({
-  findRoomBySlug: (_query): Promise<ChatRoomRepositoryRow | null> =>
-    notImplemented("findRoomBySlug"),
+const mapUploadMimeTypeToPrisma = (
+  value: "image/jpeg" | "image/png" | "image/webp",
+): ChatUploadMimeType => {
+  if (value === "image/jpeg") {
+    return ChatUploadMimeType.image_jpeg;
+  }
+
+  if (value === "image/png") {
+    return ChatUploadMimeType.image_png;
+  }
+
+  return ChatUploadMimeType.image_webp;
+};
+
+const mapUploadMimeTypeFromPrisma = (
+  value: ChatUploadMimeType,
+): "image/jpeg" | "image/png" | "image/webp" => {
+  if (value === ChatUploadMimeType.image_jpeg) {
+    return "image/jpeg";
+  }
+
+  if (value === ChatUploadMimeType.image_png) {
+    return "image/png";
+  }
+
+  return "image/webp";
+};
+
+const mapMessageRow = (row: {
+  authorHandleId: string;
+  body: string;
+  createdAt: Date;
+  deletedAt: Date | null;
+  hiddenAt: Date | null;
+  id: string;
+  moderationState: "visible" | "hidden" | "deleted";
+  roomId: string;
+  roomSessionId: string;
+  sentAt: Date;
+  tone: "cyan" | "pink" | "system" | null;
+  updatedAt: Date;
+}): ChatMessageRepositoryRow => ({
+  authorHandleId: row.authorHandleId,
+  body: row.body,
+  createdAt: row.createdAt,
+  deletedAt: row.deletedAt,
+  hiddenAt: row.hiddenAt,
+  id: row.id,
+  moderationState: row.moderationState,
+  roomId: row.roomId,
+  roomSessionId: row.roomSessionId,
+  sentAt: row.sentAt,
+  tone: row.tone,
+  updatedAt: row.updatedAt,
+});
+
+const mapSessionRow = (row: {
+  createdAt: Date;
+  expiresAt: Date | null;
+  handleId: string;
+  id: string;
+  joinedAt: Date;
+  lastSeenAt: Date | null;
+  leftAt: Date | null;
+  roomId: string;
+  status: "active" | "revoked" | "expired";
+  updatedAt: Date;
+}): ChatRoomSessionRepositoryRow => ({
+  createdAt: row.createdAt,
+  expiresAt: row.expiresAt,
+  handleId: row.handleId,
+  id: row.id,
+  joinedAt: row.joinedAt,
+  lastSeenAt: row.lastSeenAt,
+  leftAt: row.leftAt,
+  roomId: row.roomId,
+  status: row.status,
+  updatedAt: row.updatedAt,
+});
+
+const mapUploadRow = (row: {
+  byteSize: number;
+  createdAt: Date;
+  deletedAt: Date | null;
+  displayFilename: string;
+  hiddenAt: Date | null;
+  id: string;
+  kind: "image";
+  messageId: string | null;
+  mimeType: ChatUploadMimeType;
+  moderationState: "visible" | "hidden" | "deleted";
+  roomId: string;
+  storageKey: string;
+  storagePath: string;
+  updatedAt: Date;
+  uploaderHandleId: string;
+  uploaderSessionId: string | null;
+}): ChatUploadRepositoryRow => ({
+  byteSize: row.byteSize,
+  createdAt: row.createdAt,
+  deletedAt: row.deletedAt,
+  displayFilename: row.displayFilename,
+  hiddenAt: row.hiddenAt,
+  id: row.id,
+  kind: row.kind,
+  messageId: row.messageId,
+  mimeType: mapUploadMimeTypeFromPrisma(row.mimeType),
+  moderationState: row.moderationState,
+  roomId: row.roomId,
+  storageKey: row.storageKey,
+  storagePath: row.storagePath,
+  updatedAt: row.updatedAt,
+  uploaderHandleId: row.uploaderHandleId,
+  uploaderSessionId: row.uploaderSessionId,
+});
+
+const createMessageWithUpload = async (
+  client: PrismaDatabaseClient,
+  input: CreateChatMessageWithUploadCommand,
+): Promise<CreateChatMessageWithUploadResult> => {
+  return client.$transaction(async (tx) => {
+    const message = await tx.chatMessage.create({
+      data: {
+        authorHandleId: input.authorHandleId,
+        body: input.body,
+        id: input.messageId,
+        roomId: input.roomId,
+        roomSessionId: input.roomSessionId,
+        sentAt: input.sentAt,
+        tone: input.tone,
+      },
+      select: {
+        authorHandleId: true,
+        body: true,
+        createdAt: true,
+        deletedAt: true,
+        hiddenAt: true,
+        id: true,
+        moderationState: true,
+        roomId: true,
+        roomSessionId: true,
+        sentAt: true,
+        tone: true,
+        updatedAt: true,
+      },
+    });
+
+    const upload = await tx.chatUpload.create({
+      data: {
+        byteSize: input.byteSize,
+        displayFilename: input.displayFilename,
+        id: input.uploadId,
+        messageId: message.id,
+        mimeType: mapUploadMimeTypeToPrisma(input.mimeType),
+        roomId: input.roomId,
+        storageKey: input.storageKey,
+        storagePath: input.storagePath,
+        uploaderHandleId: input.authorHandleId,
+        uploaderSessionId: input.roomSessionId,
+      },
+      select: {
+        byteSize: true,
+        createdAt: true,
+        deletedAt: true,
+        displayFilename: true,
+        hiddenAt: true,
+        id: true,
+        kind: true,
+        messageId: true,
+        mimeType: true,
+        moderationState: true,
+        roomId: true,
+        storageKey: true,
+        storagePath: true,
+        updatedAt: true,
+        uploaderHandleId: true,
+        uploaderSessionId: true,
+      },
+    });
+
+    return {
+      message: mapMessageRow(message),
+      upload: mapUploadRow(upload),
+    };
+  });
+};
+
+export const createPrismaChatRepository = (client: PrismaDatabaseClient): ChatRepositoryPort => ({
+  createMessageWithUpload: (input): Promise<CreateChatMessageWithUploadResult> =>
+    createMessageWithUpload(client, input),
+  findSessionById: async (sessionId): Promise<ChatRoomSessionRepositoryRow | null> => {
+    const session = await client.chatRoomSession.findUnique({
+      select: {
+        createdAt: true,
+        expiresAt: true,
+        handleId: true,
+        id: true,
+        joinedAt: true,
+        lastSeenAt: true,
+        leftAt: true,
+        roomId: true,
+        status: true,
+        updatedAt: true,
+      },
+      where: {
+        id: sessionId,
+      },
+    });
+
+    return session ? mapSessionRow(session) : null;
+  },
+  findRoomBySlug: (_query): Promise<ChatRoomRepositoryRow | null> => notImplemented("findRoomBySlug"),
   findHandleByRoomIdAndNormalizedHandle: (_roomId, _normalizedHandle): Promise<ChatHandleRepositoryRow | null> =>
     notImplemented("findHandleByRoomIdAndNormalizedHandle"),
   listMessages: (_query: ChatMessageListQuery): Promise<readonly ChatMessageRepositoryRow[]> =>

--- a/backend/src/bootstrap/container/create-container.test.ts
+++ b/backend/src/bootstrap/container/create-container.test.ts
@@ -15,5 +15,6 @@ describe("bootstrap container", () => {
     expect(typeof container.media.storage.photos.openOriginal).toBe("function");
     expect(typeof container.media.storage.chatUploads.openUpload).toBe("function");
     expect(typeof container.media.storage.chatUploads.writeUpload).toBe("function");
+    expect(typeof container.chat.uploadMessageWithImage.execute).toBe("function");
   });
 });

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -1,5 +1,7 @@
 import { createPrismaPersistenceAdapter } from "@/adapters/outbound/persistence";
 import { createFilesystemMediaStorageAdapter } from "@/adapters/outbound/storage/filesystem";
+import { createUploadChatMessageWithImageUseCase } from "@/modules/chat/application";
+import type { UploadChatMessageWithImagePort } from "@/modules/chat/ports/inbound";
 import {
   createGetPublishedProjectBySlugUseCase,
   createGetPublishedPhotoByIdUseCase,
@@ -22,6 +24,9 @@ import type {
 import { loadBootstrapConfig, type BootstrapConfig } from "../config";
 
 export type BootstrapContainer = Readonly<{
+  chat: Readonly<{
+    uploadMessageWithImage: UploadChatMessageWithImagePort;
+  }>;
   config: BootstrapConfig;
   content: Readonly<{
     getPublishedProjectBySlug: GetPublishedProjectBySlugPort;
@@ -49,6 +54,12 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
   });
 
   return {
+    chat: {
+      uploadMessageWithImage: createUploadChatMessageWithImageUseCase({
+        repository: persistence.chat,
+        storage: storage.chatUploads,
+      }),
+    },
     config,
     content: {
       getPublishedProjectBySlug: createGetPublishedProjectBySlugUseCase({

--- a/backend/src/bootstrap/server.test.ts
+++ b/backend/src/bootstrap/server.test.ts
@@ -4,6 +4,24 @@ import type { BootstrapContainer } from "./container";
 import { createServer } from "./server";
 
 const createTestContainer = (): BootstrapContainer => ({
+  chat: {
+    uploadMessageWithImage: {
+      execute: async () => ({
+        attachment: {
+          byteSize: 0,
+          fileName: "upload.webp",
+          id: "upload_1",
+          kind: "image",
+          mimeType: "image/webp",
+        },
+        authorHandleId: "handle_1",
+        body: "uploaded an image without a caption",
+        id: "message_1",
+        sentAt: "2026-04-24T00:00:00.000Z",
+        tone: null,
+      }),
+    },
+  },
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,

--- a/backend/src/modules/chat/application/index.test.ts
+++ b/backend/src/modules/chat/application/index.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "bun:test";
+
+import { createUploadChatMessageWithImageUseCase } from "./index";
+
+describe("chat upload message with image use case", () => {
+  it("writes the upload and persists message/upload metadata", async () => {
+    const writeCalls: Array<{ body: Uint8Array; storageKey: string }> = [];
+    const repositoryCalls: Array<Record<string, unknown>> = [];
+    const sentAt = new Date("2026-04-24T12:34:56.000Z");
+    const useCase = createUploadChatMessageWithImageUseCase({
+      clock: () => sentAt,
+      createId: (() => {
+        const ids = ["message_1", "upload_1"];
+        return () => ids.shift() ?? "fallback";
+      })(),
+      repository: {
+        findSessionById: async () => ({
+          createdAt: sentAt,
+          expiresAt: null,
+          handleId: "handle_1",
+          id: "session_1",
+          joinedAt: sentAt,
+          lastSeenAt: sentAt,
+          leftAt: null,
+          roomId: "room 123",
+          status: "active",
+          updatedAt: sentAt,
+        }),
+        createMessageWithUpload: async (input) => {
+          repositoryCalls.push(input as unknown as Record<string, unknown>);
+
+          return {
+            message: {
+              authorHandleId: input.authorHandleId,
+              body: input.body,
+              createdAt: sentAt,
+              deletedAt: null,
+              hiddenAt: null,
+              id: input.messageId,
+              moderationState: "visible",
+              roomId: input.roomId,
+              roomSessionId: input.roomSessionId,
+              sentAt,
+              tone: input.tone,
+              updatedAt: sentAt,
+            },
+            upload: {
+              byteSize: input.byteSize,
+              createdAt: sentAt,
+              deletedAt: null,
+              displayFilename: input.displayFilename,
+              hiddenAt: null,
+              id: input.uploadId,
+              kind: "image",
+              messageId: input.messageId,
+              mimeType: input.mimeType,
+              moderationState: "visible",
+              roomId: input.roomId,
+              storageKey: input.storageKey,
+              storagePath: input.storagePath,
+              updatedAt: sentAt,
+              uploaderHandleId: input.authorHandleId,
+              uploaderSessionId: input.roomSessionId,
+            },
+          };
+        },
+      },
+      storage: {
+        deleteUpload: async () => {},
+        openUpload: async () => null,
+        writeUpload: async (input) => {
+          writeCalls.push(input);
+
+          return {
+            byteSize: input.body.byteLength,
+            storageKey: input.storageKey,
+            storagePath: input.storageKey,
+          };
+        },
+      },
+    });
+
+    const output = await useCase.execute({
+      authorHandleId: "handle_1",
+      body: "  post from bunker  ",
+      image: {
+        body: new TextEncoder().encode("upload-bytes"),
+        displayFilename: "bunker.png",
+        mimeType: "image/png",
+      },
+      roomId: "room 123",
+      roomSessionId: "session_1",
+      tone: "cyan",
+    });
+
+    expect(writeCalls).toHaveLength(1);
+    expect(writeCalls[0]?.storageKey).toBe("room_123/upload_1.png");
+    expect(repositoryCalls).toHaveLength(1);
+    expect(repositoryCalls[0]?.storagePath).toBe("room_123/upload_1.png");
+    expect(output).toEqual({
+      attachment: {
+        byteSize: 12,
+        fileName: "bunker.png",
+        id: "upload_1",
+        kind: "image",
+        mimeType: "image/png",
+      },
+      authorHandleId: "handle_1",
+      body: "post from bunker",
+      id: "message_1",
+      sentAt: "2026-04-24T12:34:56.000Z",
+      tone: "cyan",
+    });
+  });
+
+  it("removes the stored upload if metadata persistence fails", async () => {
+    const deletedPaths: string[] = [];
+    const useCase = createUploadChatMessageWithImageUseCase({
+      createId: (() => {
+        const ids = ["message_1", "upload_1"];
+        return () => ids.shift() ?? "fallback";
+      })(),
+      repository: {
+        findSessionById: async () => ({
+          createdAt: new Date("2026-04-24T00:00:00.000Z"),
+          expiresAt: null,
+          handleId: "handle_1",
+          id: "session_1",
+          joinedAt: new Date("2026-04-24T00:00:00.000Z"),
+          lastSeenAt: null,
+          leftAt: null,
+          roomId: "room-1",
+          status: "active",
+          updatedAt: new Date("2026-04-24T00:00:00.000Z"),
+        }),
+        createMessageWithUpload: async () => {
+          throw new Error("database write failed");
+        },
+      },
+      storage: {
+        deleteUpload: async (storagePath) => {
+          deletedPaths.push(storagePath);
+        },
+        openUpload: async () => null,
+        writeUpload: async () => ({
+          byteSize: 4,
+          storageKey: "room_1/upload_1.webp",
+          storagePath: "room_1/upload_1.webp",
+        }),
+      },
+    });
+
+    await expect(
+      useCase.execute({
+        authorHandleId: "handle_1",
+        image: {
+          body: new Uint8Array([1, 2, 3, 4]),
+          displayFilename: "scan.webp",
+          mimeType: "image/webp",
+        },
+        roomId: "room-1",
+        roomSessionId: "session_1",
+      }),
+    ).rejects.toThrow("database write failed");
+    expect(deletedPaths).toEqual(["room_1/upload_1.webp"]);
+  });
+
+  it("rejects uploads when the session does not match the requested room or handle", async () => {
+    const useCase = createUploadChatMessageWithImageUseCase({
+      repository: {
+        createMessageWithUpload: async () => {
+          throw new Error("should not persist");
+        },
+        findSessionById: async () => ({
+          createdAt: new Date("2026-04-24T00:00:00.000Z"),
+          expiresAt: null,
+          handleId: "handle_2",
+          id: "session_1",
+          joinedAt: new Date("2026-04-24T00:00:00.000Z"),
+          lastSeenAt: null,
+          leftAt: null,
+          roomId: "room_2",
+          status: "active",
+          updatedAt: new Date("2026-04-24T00:00:00.000Z"),
+        }),
+      },
+      storage: {
+        deleteUpload: async () => {},
+        openUpload: async () => null,
+        writeUpload: async () => {
+          throw new Error("should not write");
+        },
+      },
+    });
+
+    await expect(
+      useCase.execute({
+        authorHandleId: "handle_1",
+        image: {
+          body: new Uint8Array([1, 2, 3, 4]),
+          displayFilename: "scan.webp",
+          mimeType: "image/webp",
+        },
+        roomId: "room_1",
+        roomSessionId: "session_1",
+      }),
+    ).rejects.toThrow("chat upload actor/session does not match the requested room");
+  });
+});

--- a/backend/src/modules/chat/application/index.ts
+++ b/backend/src/modules/chat/application/index.ts
@@ -1,1 +1,118 @@
-export {};
+import type { ChatUploadStoragePort } from "@/modules/media/ports/outbound";
+import type { ChatRepositoryPort } from "@/modules/chat/ports/outbound";
+import type {
+  ChatUploadMimeType,
+  UploadChatMessageWithImageInput,
+  UploadChatMessageWithImageOutput,
+  UploadChatMessageWithImagePort,
+} from "@/modules/chat/ports/inbound";
+
+const IMAGE_ONLY_FALLBACK_BODY = "uploaded an image without a caption";
+
+export class InvalidChatUploadActorError extends Error {
+  constructor() {
+    super("chat upload actor/session does not match the requested room");
+    this.name = "InvalidChatUploadActorError";
+  }
+}
+
+const MIME_EXTENSION_BY_TYPE: Record<ChatUploadMimeType, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+};
+
+const normalizeBody = (value?: string): string => {
+  const trimmed = value?.trim();
+
+  return trimmed && trimmed.length > 0 ? trimmed : IMAGE_ONLY_FALLBACK_BODY;
+};
+
+const sanitizeStorageSegment = (value: string): string => {
+  const sanitized = value
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]+/g, "_")
+    .replace(/_+/g, "_");
+
+  return sanitized.length > 0 ? sanitized : "room";
+};
+
+const buildStorageKey = (roomId: string, uploadId: string, mimeType: ChatUploadMimeType): string => {
+  return `${sanitizeStorageSegment(roomId)}/${uploadId}.${MIME_EXTENSION_BY_TYPE[mimeType]}`;
+};
+
+export type ChatApplicationDependencies = Readonly<{
+  clock?: () => Date;
+  createId?: () => string;
+  repository: Pick<ChatRepositoryPort, "createMessageWithUpload" | "findSessionById">;
+  storage: ChatUploadStoragePort;
+}>;
+
+export const createUploadChatMessageWithImageUseCase = ({
+  clock = () => new Date(),
+  createId = () => crypto.randomUUID(),
+  repository,
+  storage,
+}: ChatApplicationDependencies): UploadChatMessageWithImagePort => ({
+  execute: async (
+    input: UploadChatMessageWithImageInput,
+  ): Promise<UploadChatMessageWithImageOutput> => {
+    const session = await repository.findSessionById(input.roomSessionId);
+
+    if (
+      !session ||
+      session.status !== "active" ||
+      session.roomId !== input.roomId ||
+      session.handleId !== input.authorHandleId
+    ) {
+      throw new InvalidChatUploadActorError();
+    }
+
+    const messageId = createId();
+    const uploadId = createId();
+    const sentAt = clock();
+    const storageKey = buildStorageKey(input.roomId, uploadId, input.image.mimeType);
+
+    const persistedBody = normalizeBody(input.body);
+    const writtenUpload = await storage.writeUpload({
+      body: input.image.body,
+      storageKey,
+    });
+
+    try {
+      const created = await repository.createMessageWithUpload({
+        authorHandleId: input.authorHandleId,
+        body: persistedBody,
+        byteSize: writtenUpload.byteSize,
+        displayFilename: input.image.displayFilename,
+        messageId,
+        mimeType: input.image.mimeType,
+        roomId: input.roomId,
+        roomSessionId: input.roomSessionId,
+        sentAt,
+        storageKey: writtenUpload.storageKey,
+        storagePath: writtenUpload.storagePath,
+        tone: input.tone ?? null,
+        uploadId,
+      });
+
+      return {
+        attachment: {
+          byteSize: created.upload.byteSize,
+          fileName: created.upload.displayFilename,
+          id: created.upload.id,
+          kind: "image",
+          mimeType: created.upload.mimeType,
+        },
+        authorHandleId: created.message.authorHandleId,
+        body: created.message.body,
+        id: created.message.id,
+        sentAt: created.message.sentAt.toISOString(),
+        tone: created.message.tone,
+      };
+    } catch (error) {
+      await storage.deleteUpload(writtenUpload.storagePath).catch(() => undefined);
+      throw error;
+    }
+  },
+});

--- a/backend/src/modules/chat/ports/inbound/index.ts
+++ b/backend/src/modules/chat/ports/inbound/index.ts
@@ -1,1 +1,38 @@
-export {};
+import type { UseCase } from "@/modules/shared/application/use-case";
+
+export type ChatUploadMimeType = "image/jpeg" | "image/png" | "image/webp";
+
+export type UploadChatMessageImageInput = Readonly<{
+  body: Uint8Array;
+  displayFilename: string;
+  mimeType: ChatUploadMimeType;
+}>;
+
+export type UploadChatMessageWithImageInput = Readonly<{
+  authorHandleId: string;
+  body?: string;
+  image: UploadChatMessageImageInput;
+  roomId: string;
+  roomSessionId: string;
+  tone?: "cyan" | "pink" | "system" | null;
+}>;
+
+export type UploadChatMessageAttachment = Readonly<{
+  byteSize: number;
+  fileName: string;
+  id: string;
+  kind: "image";
+  mimeType: ChatUploadMimeType;
+}>;
+
+export type UploadChatMessageWithImageOutput = Readonly<{
+  attachment: UploadChatMessageAttachment;
+  authorHandleId: string;
+  body: string;
+  id: string;
+  sentAt: string;
+  tone: "cyan" | "pink" | "system" | null;
+}>;
+
+export interface UploadChatMessageWithImagePort
+  extends UseCase<UploadChatMessageWithImageInput, UploadChatMessageWithImageOutput> {}

--- a/backend/src/modules/chat/ports/outbound/index.ts
+++ b/backend/src/modules/chat/ports/outbound/index.ts
@@ -17,6 +17,19 @@ export type ChatHandleRepositoryRow = Readonly<{
   updatedAt: Date;
 }>;
 
+export type ChatRoomSessionRepositoryRow = Readonly<{
+  id: string;
+  roomId: string;
+  handleId: string;
+  status: "active" | "revoked" | "expired";
+  joinedAt: Date;
+  lastSeenAt: Date | null;
+  expiresAt: Date | null;
+  leftAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}>;
+
 export type ChatMessageRepositoryRow = Readonly<{
   id: string;
   roomId: string;
@@ -51,6 +64,27 @@ export type ChatUploadRepositoryRow = Readonly<{
   updatedAt: Date;
 }>;
 
+export type CreateChatMessageWithUploadCommand = Readonly<{
+  authorHandleId: string;
+  body: string;
+  byteSize: number;
+  displayFilename: string;
+  messageId: string;
+  mimeType: "image/jpeg" | "image/png" | "image/webp";
+  roomId: string;
+  roomSessionId: string;
+  sentAt: Date;
+  storageKey: string;
+  storagePath: string;
+  tone: "cyan" | "pink" | "system" | null;
+  uploadId: string;
+}>;
+
+export type CreateChatMessageWithUploadResult = Readonly<{
+  message: ChatMessageRepositoryRow;
+  upload: ChatUploadRepositoryRow;
+}>;
+
 export type ChatRoomQuery = Readonly<{
   slug: string;
 }>;
@@ -63,6 +97,10 @@ export type ChatMessageListQuery = Readonly<{
 }>;
 
 export interface ChatRepositoryPort {
+  createMessageWithUpload(
+    input: CreateChatMessageWithUploadCommand,
+  ): Promise<CreateChatMessageWithUploadResult>;
+  findSessionById(sessionId: string): Promise<ChatRoomSessionRepositoryRow | null>;
   findRoomBySlug(query: ChatRoomQuery): Promise<ChatRoomRepositoryRow | null>;
   findHandleByRoomIdAndNormalizedHandle(roomId: string, normalizedHandle: string): Promise<ChatHandleRepositoryRow | null>;
   listMessages(query: ChatMessageListQuery): Promise<readonly ChatMessageRepositoryRow[]>;


### PR DESCRIPTION
## Summary
- add the chat upload use case, persistence command, and filesystem-backed upload metadata flow
- expose  with MIME/size/count validation and denial mapping for invalid session/handle combinations
- add route, application, repository, container, and server coverage for the new upload path

## Checks
- bun run typecheck
- bun test
- bun run build
- bun run verify

Closes #55