### PR TITLE
[BE-013] Implement public photo media delivery

### DIFF
--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -1,3 +1,5 @@
+import { extname } from "node:path";
+
 import { Hono } from "hono";
 
 import { InvalidChatUploadActorError } from "@/modules/chat/application";
@@ -9,6 +11,17 @@ import { presentThoughtsRssFeed } from "./rss-presenter";
 import { presentSitemapXml } from "./sitemap-presenter";
 
 const serviceName = "vinicius.dev-backend";
+const defaultMediaContentType = "application/octet-stream";
+const mediaContentTypeByExtension: Record<string, string> = {
+  ".avif": "image/avif",
+  ".gif": "image/gif",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".png": "image/png",
+  ".tif": "image/tiff",
+  ".tiff": "image/tiff",
+  ".webp": "image/webp",
+};
 
 type NotImplementedResponse = {
   family: string;
@@ -54,6 +67,9 @@ const parsePositiveInteger = (value: string | undefined): number | undefined => 
 
   return parsed;
 };
+
+const inferMediaContentType = (absolutePath: string): string =>
+  mediaContentTypeByExtension[extname(absolutePath).toLowerCase()] ?? defaultMediaContentType;
 
 const parseThoughtQuery = (query: Record<string, string | undefined>) => {
   const type = query.type;
@@ -670,18 +686,62 @@ export const createHonoHttpAdapter = (container: BootstrapContainer) => {
   mountPlaceholderFamily(app, "/api/admin", "admin");
   mountPlaceholderFamily(app, "/api/auth", "auth");
 
-  app.get("/media/photos/:id/original", (c) =>
-    c.json<NotImplementedResponse>(
-      {
-        family: "photo media",
-        method: c.req.method,
-        route: c.req.path,
-        service: serviceName,
-        status: "not_implemented",
-      },
-      501,
-    ),
-  );
+  app.get(container.config.server.mediaPhotoOriginalPath, async (c) => {
+    const id = c.req.param("id")?.trim();
+
+    if (!id) {
+      return c.json(
+        {
+          error: "invalid_path",
+          field: "id",
+        },
+        400,
+      );
+    }
+
+    const photoMedia = await container.media.repository.findPhotoMediaById(id);
+
+    if (!photoMedia) {
+      return c.json(
+        {
+          error: "not_found",
+          resource: "photo",
+        },
+        404,
+      );
+    }
+
+    const publishedPhoto = await container.content.getPublishedPhotoById.execute({ id });
+
+    if (!publishedPhoto) {
+      return c.json(
+        {
+          error: "denied",
+          resource: "photo",
+        },
+        403,
+      );
+    }
+
+    const originalMedia = await container.media.storage.photos.openOriginal(
+      photoMedia.originalReference,
+    );
+
+    if (!originalMedia) {
+      return c.json(
+        {
+          error: "not_found",
+          resource: "photo",
+        },
+        404,
+      );
+    }
+
+    return c.body(originalMedia.stream, 200, {
+      "Content-Length": String(originalMedia.byteSize),
+      "Content-Type": inferMediaContentType(originalMedia.absolutePath),
+    });
+  });
 
   return app;
 };

--- a/backend/src/adapters/inbound/http/hono/photo-media-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/photo-media-routes.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from "bun:test";
+
+import type { BootstrapContainer } from "@/bootstrap/container";
+
+import { createHonoHttpAdapter } from "./http-adapter";
+
+const encoder = new TextEncoder();
+
+type TestContainerOptions = Readonly<{
+  filesByReference?: Readonly<
+    Record<
+      string,
+      Readonly<{
+        absolutePath: string;
+        body: string;
+      }>
+    >
+  >;
+  mediaById?: Readonly<
+    Record<
+      string,
+      Readonly<{
+        originalReference: string;
+        originalReferencePolicy?: "backend_media_route" | "filesystem_reference";
+      }>
+    >
+  >;
+  publishedPhotoIds?: readonly string[];
+}>;
+
+const createPublishedPhotoDetail = (id: string) => ({
+  camera: "Canon T7+",
+  caption: "Night street frame.",
+  date: "2026-03-22",
+  film: "digital",
+  frame: "014",
+  id,
+  location: "Sao Paulo",
+  originalUrl: `/media/photos/${id}/original`,
+  tags: ["night", "street"],
+  title: "paulista at 02:14",
+  tone: "sunset" as const,
+});
+
+const createTestContainer = (options: TestContainerOptions = {}): BootstrapContainer => {
+  const publishedPhotoIds = new Set(options.publishedPhotoIds ?? ["p-2026-014"]);
+  const mediaById = options.mediaById ?? {
+    "p-2026-014": {
+      originalReference: "published/p-2026-014.jpg",
+    },
+  };
+  const filesByReference = options.filesByReference ?? {
+    "published/p-2026-014.jpg": {
+      absolutePath: "/tmp/photos/p-2026-014.jpg",
+      body: "jpeg-bytes",
+    },
+  };
+
+  return {
+    chat: {
+      uploadMessageWithImage: {
+        execute: async () => ({
+          attachment: {
+            byteSize: 0,
+            fileName: "upload.webp",
+            id: "upload_1",
+            kind: "image",
+            mimeType: "image/webp",
+          },
+          authorHandleId: "handle_1",
+          body: "uploaded an image without a caption",
+          id: "message_1",
+          sentAt: "2026-04-24T00:00:00.000Z",
+          tone: null,
+        }),
+      },
+    },
+    config: {
+      auth: {
+        mfaCodeMaxAgeSeconds: 600,
+        roomPasswordSecret: "test-room-secret",
+        sessionCookieName: "vinicius.dev-session",
+        sessionMaxAgeSeconds: 604800,
+        sessionSecret: "test-session-secret",
+      },
+      cors: {
+        allowCredentials: true,
+        allowedOrigins: [],
+      },
+      media: {
+        chatRoot: "/tmp/chat",
+        chatUploadAllowedMimeTypes: ["image/jpeg", "image/png", "image/webp"],
+        chatUploadMaxBytes: 5 * 1024 * 1024,
+        chatUploadMaxFilesPerMessage: 1,
+        photosRoot: "/tmp/photos",
+        publicUrlBase: "/media",
+      },
+      server: {
+        apiBasePath: "/api",
+        mediaPhotoOriginalPath: "/media/photos/:id/original",
+        nodeEnv: "test",
+        port: 4000,
+      },
+    },
+    content: {
+      getPublishedProjectBySlug: {
+        execute: async () => null,
+      },
+      getPublishedPhotoById: {
+        execute: async ({ id }) => (publishedPhotoIds.has(id) ? createPublishedPhotoDetail(id) : null),
+      },
+      getPublishedThoughtBySlug: {
+        execute: async () => null,
+      },
+      listPublishedPhotos: {
+        execute: async () => ({
+          items: [],
+          pageInfo: {
+            page: 1,
+            pageSize: 24,
+            totalItems: 0,
+            totalPages: 1,
+          },
+        }),
+      },
+      listPublishedProjects: {
+        execute: async () => ({
+          items: [],
+          pageInfo: {
+            page: 1,
+            pageSize: 12,
+            totalItems: 0,
+            totalPages: 1,
+          },
+        }),
+      },
+      listPublishedThoughts: {
+        execute: async () => ({
+          items: [],
+          pageInfo: {
+            nextCursor: null,
+          },
+        }),
+      },
+      listStatusStripEntries: {
+        execute: async () => ({
+          items: [],
+        }),
+      },
+    },
+    media: {
+      repository: {
+        findChatUploadMediaById: async () => null,
+        findPhotoMediaById: async (id) => {
+          const media = mediaById[id];
+
+          if (!media) {
+            return null;
+          }
+
+          return {
+            createdAt: new Date("2026-03-22T00:00:00.000Z"),
+            id,
+            originalReference: media.originalReference,
+            originalReferencePolicy: media.originalReferencePolicy ?? "backend_media_route",
+            title: "paulista at 02:14",
+            updatedAt: new Date("2026-03-23T00:00:00.000Z"),
+          };
+        },
+      },
+      storage: {
+        chatUploads: {
+          deleteUpload: async () => {},
+          openUpload: async () => null,
+          writeUpload: async () => ({
+            byteSize: 0,
+            storageKey: "test-upload",
+            storagePath: "test-upload",
+          }),
+        },
+        photos: {
+          openOriginal: async (reference) => {
+            const file = filesByReference[reference];
+
+            if (!file) {
+              return null;
+            }
+
+            const bytes = encoder.encode(file.body);
+
+            return {
+              absolutePath: file.absolutePath,
+              byteSize: bytes.byteLength,
+              stream: new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.enqueue(bytes);
+                  controller.close();
+                },
+              }),
+            };
+          },
+        },
+      },
+    },
+  };
+};
+
+describe("photo media routes", () => {
+  it("delivers original media for published photos", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/media/photos/p-2026-014/original");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/jpeg");
+    expect(response.headers.get("content-length")).toBe("10");
+    await expect(response.text()).resolves.toBe("jpeg-bytes");
+  });
+
+  it("returns denied for unpublished photos with existing media metadata", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        publishedPhotoIds: [],
+      }),
+    );
+    const response = await app.request("/media/photos/p-2026-014/original");
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "denied",
+      resource: "photo",
+    });
+  });
+
+  it("returns not found when media metadata is missing", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        mediaById: {},
+        publishedPhotoIds: [],
+      }),
+    );
+    const response = await app.request("/media/photos/p-2026-014/original");
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "not_found",
+      resource: "photo",
+    });
+  });
+
+  it("returns not found when photo media storage is missing", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        filesByReference: {},
+      }),
+    );
+    const response = await app.request("/media/photos/p-2026-014/original");
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "not_found",
+      resource: "photo",
+    });
+  });
+
+  it("rejects blank ids", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/media/photos/%20/original");
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_path",
+      field: "id",
+    });
+  });
+});

--- a/backend/src/bootstrap/server.test.ts
+++ b/backend/src/bootstrap/server.test.ts
@@ -354,7 +354,6 @@ describe("backend server scaffold", () => {
       ["/api/chat", "chat"],
       ["/api/admin", "admin"],
       ["/api/auth", "auth"],
-      ["/media/photos/123/original", "photo media"],
     ] as const;
 
     for (const [path, family] of placeholderRoutes) {


### PR DESCRIPTION
## Summary
- replace the photo original placeholder with backend-controlled media delivery for published photos
- enforce id validation, publish-state checks, storage lookup, and content-type inference for original files
- add focused route coverage and align the server scaffold expectations with the live media route

## Checks
- bun run typecheck
- bun test src/adapters/inbound/http/hono/photo-media-routes.test.ts src/bootstrap/server.test.ts src/adapters/inbound/http/hono/photos-routes.test.ts
- bun run build
- bun run verify

Closes #54
