### PR TITLE
[BE-016] Implement chat media retention moderation

### DIFF
--- a/backend/src/adapters/inbound/http/hono/chat-media-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-media-routes.test.ts
@@ -38,6 +38,9 @@ const createTestContainer = ({
   ) => UploadChatMessageWithImageOutput | Promise<UploadChatMessageWithImageOutput>;
 } = {}): BootstrapContainer => ({
   chat: {
+    moderateUploadRetention: {
+      execute: async () => null,
+    },
     openUploadMedia: {
       execute: executeOpenUploadMedia,
     },
@@ -163,15 +166,21 @@ describe("chat media routes", () => {
       }),
     );
 
-    const response = await app.request("/api/chat/uploads/upload_1/media?roomSessionId=session_1");
+    const response = await app.request("/api/chat/uploads/upload_1/media", {
+      headers: {
+        "x-chat-room-session-id": "session_1",
+      },
+    });
 
     expect(captured).toEqual({
       roomSessionId: "session_1",
       uploadId: "upload_1",
     });
     expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
     expect(response.headers.get("content-type")).toBe("image/webp");
     expect(response.headers.get("content-length")).toBe(String(bytes.byteLength));
+    expect(response.headers.get("vary")).toBe("x-chat-room-session-id");
     await expect(response.text()).resolves.toBe("upload-bytes");
   });
 
@@ -184,7 +193,11 @@ describe("chat media routes", () => {
       }),
     );
 
-    const response = await app.request("/api/chat/uploads/upload_1/media?roomSessionId=session_1");
+    const response = await app.request("/api/chat/uploads/upload_1/media", {
+      headers: {
+        "x-chat-room-session-id": "session_1",
+      },
+    });
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
@@ -195,7 +208,11 @@ describe("chat media routes", () => {
 
   it("returns not found when the upload is missing or hidden", async () => {
     const app = createHonoHttpAdapter(createTestContainer());
-    const response = await app.request("/api/chat/uploads/upload_1/media?roomSessionId=session_1");
+    const response = await app.request("/api/chat/uploads/upload_1/media", {
+      headers: {
+        "x-chat-room-session-id": "session_1",
+      },
+    });
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({
@@ -215,14 +232,14 @@ describe("chat media routes", () => {
     });
   });
 
-  it("rejects missing roomSessionId query values", async () => {
+  it("rejects missing room session header values", async () => {
     const app = createHonoHttpAdapter(createTestContainer());
     const response = await app.request("/api/chat/uploads/upload_1/media");
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
-      error: "invalid_query",
-      field: "roomSessionId",
+      error: "invalid_request",
+      field: "x-chat-room-session-id",
     });
   });
 });

--- a/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
@@ -15,6 +15,9 @@ const createTestContainer = (
   ) => UploadChatMessageWithImageOutput | Promise<UploadChatMessageWithImageOutput>,
 ): BootstrapContainer => ({
   chat: {
+    moderateUploadRetention: {
+      execute: async () => null,
+    },
     openUploadMedia: {
       execute: async () => null,
     },

--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -495,13 +495,13 @@ const createChatFamily = (container: BootstrapContainer) => {
       );
     }
 
-    const roomSessionId = c.req.query("roomSessionId")?.trim();
+    const roomSessionId = c.req.header("x-chat-room-session-id")?.trim();
 
     if (!roomSessionId) {
       return c.json(
         {
-          error: "invalid_query",
-          field: "roomSessionId",
+          error: "invalid_request",
+          field: "x-chat-room-session-id",
         },
         400,
       );
@@ -539,8 +539,10 @@ const createChatFamily = (container: BootstrapContainer) => {
     }
 
     return c.body(upload.stream, 200, {
+      "Cache-Control": "private, no-store",
       "Content-Length": String(upload.byteSize),
       "Content-Type": upload.mimeType,
+      Vary: "x-chat-room-session-id",
     });
   });
 

--- a/backend/src/adapters/inbound/http/hono/photo-media-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/photo-media-routes.test.ts
@@ -58,6 +58,9 @@ const createTestContainer = (options: TestContainerOptions = {}): BootstrapConta
 
   return {
     chat: {
+      moderateUploadRetention: {
+        execute: async () => null,
+      },
       openUploadMedia: {
         execute: async () => null,
       },

--- a/backend/src/adapters/inbound/http/hono/photos-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/photos-routes.test.ts
@@ -6,6 +6,9 @@ import { createHonoHttpAdapter } from "./http-adapter";
 
 const createTestContainer = (): BootstrapContainer => ({
   chat: {
+    moderateUploadRetention: {
+      execute: async () => null,
+    },
     openUploadMedia: {
       execute: async () => null,
     },

--- a/backend/src/adapters/inbound/http/hono/projects-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/projects-routes.test.ts
@@ -6,6 +6,9 @@ import { createHonoHttpAdapter } from "./http-adapter";
 
 const createTestContainer = (): BootstrapContainer => ({
   chat: {
+    moderateUploadRetention: {
+      execute: async () => null,
+    },
     openUploadMedia: {
       execute: async () => null,
     },

--- a/backend/src/adapters/inbound/http/hono/rss-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/rss-routes.test.ts
@@ -7,6 +7,9 @@ import { presentThoughtsRssFeed } from "./rss-presenter";
 
 const createTestContainer = (): BootstrapContainer => ({
   chat: {
+    moderateUploadRetention: {
+      execute: async () => null,
+    },
     openUploadMedia: {
       execute: async () => null,
     },

--- a/backend/src/adapters/inbound/http/hono/sitemap-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/sitemap-routes.test.ts
@@ -7,6 +7,9 @@ import { presentSitemapXml } from "./sitemap-presenter";
 
 const createTestContainer = (): BootstrapContainer => ({
   chat: {
+    moderateUploadRetention: {
+      execute: async () => null,
+    },
     openUploadMedia: {
       execute: async () => null,
     },

--- a/backend/src/adapters/inbound/http/hono/status-strip-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/status-strip-routes.test.ts
@@ -6,6 +6,9 @@ import { createHonoHttpAdapter } from "./http-adapter";
 
 const createTestContainer = (): BootstrapContainer => ({
   chat: {
+    moderateUploadRetention: {
+      execute: async () => null,
+    },
     openUploadMedia: {
       execute: async () => null,
     },

--- a/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
@@ -6,6 +6,9 @@ import { createHonoHttpAdapter } from "./http-adapter";
 
 const createTestContainer = (): BootstrapContainer => ({
   chat: {
+    moderateUploadRetention: {
+      execute: async () => null,
+    },
     openUploadMedia: {
       execute: async () => null,
     },

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
@@ -169,4 +169,183 @@ describe("prisma chat repository", () => {
       },
     });
   });
+
+  it("records retention moderation for an upload and linked message", async () => {
+    let capturedAuditData: Record<string, unknown> | null = null;
+    let capturedMessageUpdate: Record<string, unknown> | null = null;
+    let capturedUploadUpdate: Record<string, unknown> | null = null;
+    const occurredAt = new Date("2026-04-24T12:34:56.000Z");
+    const repository = createPrismaChatRepository({
+      $transaction: async <T>(
+        runInTransaction: (tx: {
+          chatMessage: {
+            findUnique: (args: { where: { id: string } }) => Promise<Record<string, unknown> | null>;
+            update: (args: {
+              data: Record<string, unknown>;
+              where: { id: string };
+            }) => Promise<Record<string, unknown>>;
+          };
+          chatModerationAuditRecord: {
+            create: (args: { data: Record<string, unknown> }) => Promise<Record<string, unknown>>;
+          };
+          chatUpload: {
+            findUnique: (args: { where: { id: string } }) => Promise<Record<string, unknown> | null>;
+            update: (args: {
+              data: Record<string, unknown>;
+              where: { id: string };
+            }) => Promise<Record<string, unknown>>;
+          };
+        }) => Promise<T>,
+      ) =>
+        runInTransaction({
+          chatMessage: {
+            findUnique: async () => ({
+              authorHandleId: "handle_1",
+              body: "night drop",
+              createdAt: new Date("2026-04-24T10:00:00.000Z"),
+              deletedAt: null,
+              hiddenAt: null,
+              id: "message_1",
+              moderationState: "visible" as const,
+              roomId: "room_1",
+              roomSessionId: "session_1",
+              sentAt: new Date("2026-04-24T10:00:00.000Z"),
+              tone: "pink" as const,
+              updatedAt: new Date("2026-04-24T10:00:00.000Z"),
+            }),
+            update: async ({ data }) => {
+              capturedMessageUpdate = data;
+
+              return {
+                authorHandleId: "handle_1",
+                body: "night drop",
+                createdAt: new Date("2026-04-24T10:00:00.000Z"),
+                deletedAt: occurredAt,
+                hiddenAt: occurredAt,
+                id: "message_1",
+                moderationState: "deleted" as const,
+                roomId: "room_1",
+                roomSessionId: "session_1",
+                sentAt: new Date("2026-04-24T10:00:00.000Z"),
+                tone: "pink" as const,
+                updatedAt: occurredAt,
+              };
+            },
+          },
+          chatModerationAuditRecord: {
+            create: async ({ data }) => {
+              capturedAuditData = data;
+
+              return {
+                id: "audit_1",
+              };
+            },
+          },
+          chatUpload: {
+            findUnique: async () => ({
+              byteSize: 1234,
+              createdAt: new Date("2026-04-24T10:00:00.000Z"),
+              deletedAt: null,
+              displayFilename: "drop.png",
+              hiddenAt: null,
+              id: "upload_1",
+              kind: "image" as const,
+              messageId: "message_1",
+              mimeType: "image_png" as const,
+              moderationState: "visible" as const,
+              roomId: "room_1",
+              storageKey: "room_1/upload_1.png",
+              storagePath: "room_1/upload_1.png",
+              updatedAt: new Date("2026-04-24T10:00:00.000Z"),
+              uploaderHandleId: "handle_1",
+              uploaderSessionId: "session_1",
+            }),
+            update: async ({ data }) => {
+              capturedUploadUpdate = data;
+
+              return {
+                byteSize: 1234,
+                createdAt: new Date("2026-04-24T10:00:00.000Z"),
+                deletedAt: null,
+                displayFilename: "drop.png",
+                hiddenAt: occurredAt,
+                id: "upload_1",
+                kind: "image" as const,
+                messageId: "message_1",
+                mimeType: "image_png" as const,
+                moderationState: "hidden" as const,
+                roomId: "room_1",
+                storageKey: "room_1/upload_1.png",
+                storagePath: "room_1/upload_1.png",
+                updatedAt: occurredAt,
+                uploaderHandleId: "handle_1",
+                uploaderSessionId: "session_1",
+              };
+            },
+          },
+        }),
+    } as unknown as PrismaDatabaseClient);
+
+    const result = await repository.moderateUploadRetention({
+      action: "delete_message",
+      actorAdminUserId: "admin_1",
+      occurredAt,
+      reason: "remove from room history",
+      uploadId: "upload_1",
+    });
+
+    expect(capturedUploadUpdate).toMatchObject({
+      deletedAt: null,
+      hiddenAt: occurredAt,
+      moderationState: "hidden",
+    });
+    expect(capturedMessageUpdate).toMatchObject({
+      deletedAt: occurredAt,
+      hiddenAt: occurredAt,
+      moderationState: "deleted",
+    });
+    expect(capturedAuditData).toMatchObject({
+      action: "delete_message",
+      actorAdminUserId: "admin_1",
+      reason: "remove from room history",
+      roomId: "room_1",
+      targetMessageId: "message_1",
+      targetUploadId: "upload_1",
+    });
+    expect(result).toEqual({
+      auditId: "audit_1",
+      message: {
+        authorHandleId: "handle_1",
+        body: "night drop",
+        createdAt: new Date("2026-04-24T10:00:00.000Z"),
+        deletedAt: occurredAt,
+        hiddenAt: occurredAt,
+        id: "message_1",
+        moderationState: "deleted",
+        roomId: "room_1",
+        roomSessionId: "session_1",
+        sentAt: new Date("2026-04-24T10:00:00.000Z"),
+        tone: "pink",
+        updatedAt: occurredAt,
+      },
+      upload: {
+        byteSize: 1234,
+        createdAt: new Date("2026-04-24T10:00:00.000Z"),
+        deletedAt: null,
+        displayFilename: "drop.png",
+        hiddenAt: occurredAt,
+        id: "upload_1",
+        kind: "image",
+        messageId: "message_1",
+        mimeType: "image/png",
+        moderationState: "hidden",
+        roomId: "room_1",
+        storageKey: "room_1/upload_1.png",
+        storagePath: "room_1/upload_1.png",
+        updatedAt: occurredAt,
+        uploaderHandleId: "handle_1",
+        uploaderSessionId: "session_1",
+      },
+    });
+  });
 });

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
@@ -8,6 +8,8 @@ import type {
   ChatRoomRepositoryRow,
   ChatRoomSessionRepositoryRow,
   ChatUploadRepositoryRow,
+  ModerateChatUploadRetentionCommand,
+  ModerateChatUploadRetentionResult,
 } from "@/modules/chat/ports/outbound";
 import { ChatUploadMimeType } from "../../../../../generated/prisma/client";
 
@@ -204,9 +206,169 @@ const createMessageWithUpload = async (
   });
 };
 
+const moderateUploadRetention = async (
+  client: PrismaDatabaseClient,
+  input: ModerateChatUploadRetentionCommand,
+): Promise<ModerateChatUploadRetentionResult | null> => {
+  return client.$transaction(async (tx) => {
+    const upload = await tx.chatUpload.findUnique({
+      select: {
+        byteSize: true,
+        createdAt: true,
+        deletedAt: true,
+        displayFilename: true,
+        hiddenAt: true,
+        id: true,
+        kind: true,
+        messageId: true,
+        mimeType: true,
+        moderationState: true,
+        roomId: true,
+        storageKey: true,
+        storagePath: true,
+        updatedAt: true,
+        uploaderHandleId: true,
+        uploaderSessionId: true,
+      },
+      where: {
+        id: input.uploadId,
+      },
+    });
+
+    if (!upload) {
+      return null;
+    }
+
+    const message = upload.messageId
+      ? await tx.chatMessage.findUnique({
+          select: {
+            authorHandleId: true,
+            body: true,
+            createdAt: true,
+            deletedAt: true,
+            hiddenAt: true,
+            id: true,
+            moderationState: true,
+            roomId: true,
+            roomSessionId: true,
+            sentAt: true,
+            tone: true,
+            updatedAt: true,
+          },
+          where: {
+            id: upload.messageId,
+          },
+        })
+      : null;
+
+    const nextUploadHiddenAt = upload.hiddenAt ?? input.occurredAt;
+    const nextUploadDeletedAt = upload.deletedAt;
+    const nextUploadModerationState = "hidden";
+    const nextMessageHiddenAt =
+      message ? (message.hiddenAt ?? input.occurredAt) : null;
+    const nextMessageDeletedAt =
+      message && input.action === "delete_message"
+        ? message.deletedAt ?? input.occurredAt
+        : message?.deletedAt ?? null;
+    const nextMessageModerationState =
+      input.action === "delete_message" ? "deleted" : "hidden";
+
+    const updatedUpload = await tx.chatUpload.update({
+      data: {
+        deletedAt: nextUploadDeletedAt,
+        hiddenAt: nextUploadHiddenAt,
+        moderationState: nextUploadModerationState,
+      },
+      select: {
+        byteSize: true,
+        createdAt: true,
+        deletedAt: true,
+        displayFilename: true,
+        hiddenAt: true,
+        id: true,
+        kind: true,
+        messageId: true,
+        mimeType: true,
+        moderationState: true,
+        roomId: true,
+        storageKey: true,
+        storagePath: true,
+        updatedAt: true,
+        uploaderHandleId: true,
+        uploaderSessionId: true,
+      },
+      where: {
+        id: input.uploadId,
+      },
+    });
+
+    const updatedMessage =
+      message && upload.messageId
+        ? await tx.chatMessage.update({
+            data: {
+              deletedAt: nextMessageDeletedAt,
+              hiddenAt: nextMessageHiddenAt,
+              moderationState: nextMessageModerationState,
+            },
+            select: {
+              authorHandleId: true,
+              body: true,
+              createdAt: true,
+              deletedAt: true,
+              hiddenAt: true,
+              id: true,
+              moderationState: true,
+              roomId: true,
+              roomSessionId: true,
+              sentAt: true,
+              tone: true,
+              updatedAt: true,
+            },
+            where: {
+              id: upload.messageId,
+            },
+          })
+        : null;
+
+    const audit = await tx.chatModerationAuditRecord.create({
+      data: {
+        action: input.action,
+        actorAdminUserId: input.actorAdminUserId,
+        nextState: {
+          messageModerationState: updatedMessage?.moderationState ?? null,
+          uploadModerationState: updatedUpload.moderationState,
+        },
+        previousState: {
+          messageDeletedAt: message?.deletedAt?.toISOString() ?? null,
+          messageHiddenAt: message?.hiddenAt?.toISOString() ?? null,
+          messageModerationState: message?.moderationState ?? null,
+          uploadDeletedAt: upload.deletedAt?.toISOString() ?? null,
+          uploadHiddenAt: upload.hiddenAt?.toISOString() ?? null,
+          uploadModerationState: upload.moderationState,
+        },
+        reason: input.reason,
+        roomId: upload.roomId,
+        targetMessageId: upload.messageId,
+        targetUploadId: upload.id,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    return {
+      auditId: audit.id,
+      message: updatedMessage ? mapMessageRow(updatedMessage) : null,
+      upload: mapUploadRow(updatedUpload),
+    };
+  });
+};
+
 export const createPrismaChatRepository = (client: PrismaDatabaseClient): ChatRepositoryPort => ({
   createMessageWithUpload: (input): Promise<CreateChatMessageWithUploadResult> =>
     createMessageWithUpload(client, input),
+  moderateUploadRetention: (input): Promise<ModerateChatUploadRetentionResult | null> =>
+    moderateUploadRetention(client, input),
   findSessionById: async (sessionId): Promise<ChatRoomSessionRepositoryRow | null> => {
     const session = await client.chatRoomSession.findUnique({
       select: {

--- a/backend/src/bootstrap/container/create-container.test.ts
+++ b/backend/src/bootstrap/container/create-container.test.ts
@@ -10,6 +10,7 @@ describe("bootstrap container", () => {
       NODE_ENV: "test",
     });
 
+    expect(typeof container.chat.moderateUploadRetention.execute).toBe("function");
     expect(typeof container.chat.openUploadMedia.execute).toBe("function");
     expect(typeof container.media.repository.findPhotoMediaById).toBe("function");
     expect(typeof container.media.repository.findChatUploadMediaById).toBe("function");

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -1,10 +1,12 @@
 import { createPrismaPersistenceAdapter } from "@/adapters/outbound/persistence";
 import { createFilesystemMediaStorageAdapter } from "@/adapters/outbound/storage/filesystem";
 import {
+  createModerateChatUploadRetentionUseCase,
   createOpenChatUploadMediaUseCase,
   createUploadChatMessageWithImageUseCase,
 } from "@/modules/chat/application";
 import type {
+  ModerateChatUploadRetentionPort,
   OpenChatUploadMediaPort,
   UploadChatMessageWithImagePort,
 } from "@/modules/chat/ports/inbound";
@@ -31,6 +33,7 @@ import { loadBootstrapConfig, type BootstrapConfig } from "../config";
 
 export type BootstrapContainer = Readonly<{
   chat: Readonly<{
+    moderateUploadRetention: ModerateChatUploadRetentionPort;
     openUploadMedia: OpenChatUploadMediaPort;
     uploadMessageWithImage: UploadChatMessageWithImagePort;
   }>;
@@ -62,6 +65,9 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
 
   return {
     chat: {
+      moderateUploadRetention: createModerateChatUploadRetentionUseCase({
+        repository: persistence.chat,
+      }),
       openUploadMedia: createOpenChatUploadMediaUseCase({
         mediaRepository: persistence.media,
         repository: persistence.chat,

--- a/backend/src/bootstrap/server.test.ts
+++ b/backend/src/bootstrap/server.test.ts
@@ -5,6 +5,9 @@ import { createServer } from "./server";
 
 const createTestContainer = (): BootstrapContainer => ({
   chat: {
+    moderateUploadRetention: {
+      execute: async () => null,
+    },
     openUploadMedia: {
       execute: async () => null,
     },

--- a/backend/src/modules/chat/application/index.test.ts
+++ b/backend/src/modules/chat/application/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+  createModerateChatUploadRetentionUseCase,
   createOpenChatUploadMediaUseCase,
   createUploadChatMessageWithImageUseCase,
   InvalidChatUploadAccessError,
@@ -328,6 +329,98 @@ describe("chat upload media access use case", () => {
       useCase.execute({
         roomSessionId: "session_1",
         uploadId: "upload_1",
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("chat upload retention moderation use case", () => {
+  it("records a hide-media moderation action", async () => {
+    const occurredAt = new Date("2026-04-24T12:34:56.000Z");
+    const capturedCalls: Array<Record<string, unknown>> = [];
+    const useCase = createModerateChatUploadRetentionUseCase({
+      clock: () => occurredAt,
+      repository: {
+        moderateUploadRetention: async (input) => {
+          capturedCalls.push(input as unknown as Record<string, unknown>);
+
+          return {
+            auditId: "audit_1",
+            message: {
+              authorHandleId: "handle_1",
+              body: "night drop",
+              createdAt: occurredAt,
+              deletedAt: null,
+              hiddenAt: occurredAt,
+              id: "message_1",
+              moderationState: "hidden",
+              roomId: "room_1",
+              roomSessionId: "session_1",
+              sentAt: occurredAt,
+              tone: null,
+              updatedAt: occurredAt,
+            },
+            upload: {
+              byteSize: 42,
+              createdAt: occurredAt,
+              deletedAt: null,
+              displayFilename: "scan.webp",
+              hiddenAt: occurredAt,
+              id: "upload_1",
+              kind: "image",
+              messageId: "message_1",
+              mimeType: "image/webp",
+              moderationState: "hidden",
+              roomId: "room_1",
+              storageKey: "room_1/upload_1.webp",
+              storagePath: "room_1/upload_1.webp",
+              updatedAt: occurredAt,
+              uploaderHandleId: "handle_1",
+              uploaderSessionId: "session_1",
+            },
+          };
+        },
+      },
+    });
+
+    const output = await useCase.execute({
+      action: "hide_media_metadata",
+      actorAdminUserId: " admin_1 ",
+      reason: "  remove image from public room view  ",
+      uploadId: "upload_1",
+    });
+
+    expect(capturedCalls).toEqual([
+      {
+        action: "hide_media_metadata",
+        actorAdminUserId: "admin_1",
+        occurredAt,
+        reason: "remove image from public room view",
+        uploadId: "upload_1",
+      },
+    ]);
+    expect(output).toEqual({
+      action: "hide_media_metadata",
+      auditId: "audit_1",
+      messageId: "message_1",
+      messageModerationState: "hidden",
+      uploadId: "upload_1",
+      uploadModerationState: "hidden",
+    });
+  });
+
+  it("returns null when the upload does not exist", async () => {
+    const useCase = createModerateChatUploadRetentionUseCase({
+      repository: {
+        moderateUploadRetention: async () => null,
+      },
+    });
+
+    await expect(
+      useCase.execute({
+        action: "delete_message",
+        actorAdminUserId: "admin_1",
+        uploadId: "upload_404",
       }),
     ).resolves.toBeNull();
   });

--- a/backend/src/modules/chat/application/index.ts
+++ b/backend/src/modules/chat/application/index.ts
@@ -5,6 +5,9 @@ import type {
 import type { ChatRepositoryPort } from "@/modules/chat/ports/outbound";
 import type {
   ChatUploadMimeType,
+  ModerateChatUploadRetentionInput,
+  ModerateChatUploadRetentionOutput,
+  ModerateChatUploadRetentionPort,
   OpenChatUploadMediaInput,
   OpenChatUploadMediaOutput,
   OpenChatUploadMediaPort,
@@ -12,6 +15,7 @@ import type {
   UploadChatMessageWithImageOutput,
   UploadChatMessageWithImagePort,
 } from "@/modules/chat/ports/inbound";
+import type { ModerateChatUploadRetentionAction } from "@/modules/chat/ports/outbound";
 
 const IMAGE_ONLY_FALLBACK_BODY = "uploaded an image without a caption";
 
@@ -65,6 +69,11 @@ export type ChatUploadMediaAccessDependencies = Readonly<{
   repository: Pick<ChatRepositoryPort, "findSessionById">;
   mediaRepository: Pick<MediaRepositoryPort, "findChatUploadMediaById">;
   storage: Pick<ChatUploadStoragePort, "openUpload">;
+}>;
+
+export type ChatUploadRetentionDependencies = Readonly<{
+  clock?: () => Date;
+  repository: Pick<ChatRepositoryPort, "moderateUploadRetention">;
 }>;
 
 export const createUploadChatMessageWithImageUseCase = ({
@@ -170,6 +179,40 @@ export const createOpenChatUploadMediaUseCase = ({
       byteSize: storedObject.byteSize,
       mimeType: upload.mimeType,
       stream: storedObject.stream,
+    };
+  },
+});
+
+const normalizeRetentionAction = (
+  value: ModerateChatUploadRetentionInput["action"],
+): ModerateChatUploadRetentionAction => value;
+
+export const createModerateChatUploadRetentionUseCase = ({
+  clock = () => new Date(),
+  repository,
+}: ChatUploadRetentionDependencies): ModerateChatUploadRetentionPort => ({
+  execute: async (
+    input: ModerateChatUploadRetentionInput,
+  ): Promise<ModerateChatUploadRetentionOutput | null> => {
+    const result = await repository.moderateUploadRetention({
+      action: normalizeRetentionAction(input.action),
+      actorAdminUserId: input.actorAdminUserId.trim(),
+      occurredAt: clock(),
+      reason: input.reason?.trim() || undefined,
+      uploadId: input.uploadId,
+    });
+
+    if (!result) {
+      return null;
+    }
+
+    return {
+      action: input.action,
+      auditId: result.auditId,
+      messageId: result.message?.id ?? null,
+      messageModerationState: result.message?.moderationState ?? null,
+      uploadId: result.upload.id,
+      uploadModerationState: result.upload.moderationState,
     };
   },
 });

--- a/backend/src/modules/chat/ports/inbound/index.ts
+++ b/backend/src/modules/chat/ports/inbound/index.ts
@@ -50,3 +50,22 @@ export type OpenChatUploadMediaOutput = Readonly<{
 
 export interface OpenChatUploadMediaPort
   extends UseCase<OpenChatUploadMediaInput, OpenChatUploadMediaOutput | null> {}
+
+export type ModerateChatUploadRetentionInput = Readonly<{
+  action: "hide_media_metadata" | "delete_message";
+  actorAdminUserId: string;
+  reason?: string;
+  uploadId: string;
+}>;
+
+export type ModerateChatUploadRetentionOutput = Readonly<{
+  action: "hide_media_metadata" | "delete_message";
+  auditId: string;
+  messageId: string | null;
+  messageModerationState: "visible" | "hidden" | "deleted" | null;
+  uploadId: string;
+  uploadModerationState: "visible" | "hidden" | "deleted";
+}>;
+
+export interface ModerateChatUploadRetentionPort
+  extends UseCase<ModerateChatUploadRetentionInput, ModerateChatUploadRetentionOutput | null> {}

--- a/backend/src/modules/chat/ports/outbound/index.ts
+++ b/backend/src/modules/chat/ports/outbound/index.ts
@@ -85,6 +85,22 @@ export type CreateChatMessageWithUploadResult = Readonly<{
   upload: ChatUploadRepositoryRow;
 }>;
 
+export type ModerateChatUploadRetentionAction = "hide_media_metadata" | "delete_message";
+
+export type ModerateChatUploadRetentionCommand = Readonly<{
+  action: ModerateChatUploadRetentionAction;
+  actorAdminUserId: string;
+  occurredAt: Date;
+  reason?: string;
+  uploadId: string;
+}>;
+
+export type ModerateChatUploadRetentionResult = Readonly<{
+  auditId: string;
+  message: ChatMessageRepositoryRow | null;
+  upload: ChatUploadRepositoryRow;
+}>;
+
 export type ChatRoomQuery = Readonly<{
   slug: string;
 }>;
@@ -100,6 +116,9 @@ export interface ChatRepositoryPort {
   createMessageWithUpload(
     input: CreateChatMessageWithUploadCommand,
   ): Promise<CreateChatMessageWithUploadResult>;
+  moderateUploadRetention(
+    input: ModerateChatUploadRetentionCommand,
+  ): Promise<ModerateChatUploadRetentionResult | null>;
   findSessionById(sessionId: string): Promise<ChatRoomSessionRepositoryRow | null>;
   findRoomBySlug(query: ChatRoomQuery): Promise<ChatRoomRepositoryRow | null>;
   findHandleByRoomIdAndNormalizedHandle(roomId: string, normalizedHandle: string): Promise<ChatHandleRepositoryRow | null>;


### PR DESCRIPTION
## Summary
- add the chat upload/message retention moderation use case and persistence transaction for audit-safe hide/delete behavior
- keep delete_message aligned with the accepted rule by deleting the message state while only hiding the related upload metadata
- backport the BE-015 security review fixes by moving the room session credential into a header and making room-gated media responses private/no-store

## Checks
- bun run typecheck
- bun test
- bun run build
- bun run verify

Closes #57
