### PR TITLE
[BE-017] Add media delivery and upload verification hardening

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "prisma:migrate:status": "prisma migrate status",
     "prisma:check": "bun scripts/persistence-check.ts",
     "verify:boundary": "bun scripts/boundary-check.ts",
+    "verify:media": "bun test src/modules/chat/application/index.test.ts src/adapters/inbound/http/hono/chat-routes.test.ts src/adapters/inbound/http/hono/chat-media-routes.test.ts src/adapters/inbound/http/hono/photo-media-routes.test.ts src/adapters/outbound/persistence/prisma/chat-repository.test.ts src/adapters/outbound/persistence/prisma/media-repository.test.ts src/adapters/outbound/storage/filesystem/create-filesystem-media-storage-adapter.test.ts",
     "verify": "bun scripts/verify.ts"
   },
   "dependencies": {

--- a/backend/scripts/verify.ts
+++ b/backend/scripts/verify.ts
@@ -32,6 +32,14 @@ async function runFrontendAnalyzer(): Promise<number> {
   );
 }
 
+async function runMediaVerification(): Promise<number> {
+  return runCommand(
+    ["bun", "run", "verify:media"],
+    BACKEND_ROOT,
+    "Running media verification",
+  );
+}
+
 export async function main(): Promise<number> {
   const violations = await checkBoundaryViolations();
   if (violations.length > 0) {
@@ -49,6 +57,9 @@ export async function main(): Promise<number> {
     "Running persistence verification",
   );
   if (persistenceExitCode !== 0) return persistenceExitCode;
+
+  const mediaVerificationExitCode = await runMediaVerification();
+  if (mediaVerificationExitCode !== 0) return mediaVerificationExitCode;
 
   const analyzerExitCode = await runFrontendAnalyzer();
   if (analyzerExitCode !== 0) return analyzerExitCode;

--- a/backend/src/adapters/inbound/http/hono/chat-media-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-media-routes.test.ts
@@ -200,6 +200,8 @@ describe("chat media routes", () => {
     });
 
     expect(response.status).toBe(403);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("vary")).toBe("x-chat-room-session-id");
     await expect(response.json()).resolves.toEqual({
       error: "denied",
       resource: "chat",
@@ -215,6 +217,8 @@ describe("chat media routes", () => {
     });
 
     expect(response.status).toBe(404);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("vary")).toBe("x-chat-room-session-id");
     await expect(response.json()).resolves.toEqual({
       error: "not_found",
       resource: "chat_upload",
@@ -223,9 +227,15 @@ describe("chat media routes", () => {
 
   it("rejects blank upload ids", async () => {
     const app = createHonoHttpAdapter(createTestContainer());
-    const response = await app.request("/api/chat/uploads/%20/media?roomSessionId=session_1");
+    const response = await app.request("/api/chat/uploads/%20/media", {
+      headers: {
+        "x-chat-room-session-id": "session_1",
+      },
+    });
 
     expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("vary")).toBe("x-chat-room-session-id");
     await expect(response.json()).resolves.toEqual({
       error: "invalid_path",
       field: "id",
@@ -237,6 +247,8 @@ describe("chat media routes", () => {
     const response = await app.request("/api/chat/uploads/upload_1/media");
 
     expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("vary")).toBe("x-chat-room-session-id");
     await expect(response.json()).resolves.toEqual({
       error: "invalid_request",
       field: "x-chat-room-session-id",

--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -483,6 +483,9 @@ const createChatFamily = (container: BootstrapContainer) => {
   const chatApp = new Hono();
 
   chatApp.get("/uploads/:id/media", async (c) => {
+    c.header("Cache-Control", "private, no-store");
+    c.header("Vary", "x-chat-room-session-id");
+
     const id = c.req.param("id")?.trim();
 
     if (!id) {
@@ -539,10 +542,8 @@ const createChatFamily = (container: BootstrapContainer) => {
     }
 
     return c.body(upload.stream, 200, {
-      "Cache-Control": "private, no-store",
       "Content-Length": String(upload.byteSize),
       "Content-Type": upload.mimeType,
-      Vary: "x-chat-room-session-id",
     });
   });
 

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
@@ -348,4 +348,115 @@ describe("prisma chat repository", () => {
       },
     });
   });
+
+  it("preserves deleted moderation state when hide_media_metadata is re-applied", async () => {
+    const repository = createPrismaChatRepository({
+      $transaction: async <T>(
+        runInTransaction: (tx: {
+          chatMessage: {
+            findUnique: (args: { where: { id: string } }) => Promise<Record<string, unknown> | null>;
+            update: (args: {
+              data: Record<string, unknown>;
+              where: { id: string };
+            }) => Promise<Record<string, unknown>>;
+          };
+          chatModerationAuditRecord: {
+            create: (args: { data: Record<string, unknown> }) => Promise<Record<string, unknown>>;
+          };
+          chatUpload: {
+            findUnique: (args: { where: { id: string } }) => Promise<Record<string, unknown> | null>;
+            update: (args: {
+              data: Record<string, unknown>;
+              where: { id: string };
+            }) => Promise<Record<string, unknown>>;
+          };
+        }) => Promise<T>,
+      ) =>
+        runInTransaction({
+          chatMessage: {
+            findUnique: async () => ({
+              authorHandleId: "handle_1",
+              body: "night drop",
+              createdAt: new Date("2026-04-24T10:00:00.000Z"),
+              deletedAt: new Date("2026-04-24T11:00:00.000Z"),
+              hiddenAt: new Date("2026-04-24T11:00:00.000Z"),
+              id: "message_1",
+              moderationState: "deleted" as const,
+              roomId: "room_1",
+              roomSessionId: "session_1",
+              sentAt: new Date("2026-04-24T10:00:00.000Z"),
+              tone: "pink" as const,
+              updatedAt: new Date("2026-04-24T11:00:00.000Z"),
+            }),
+            update: async ({ data }) => ({
+              authorHandleId: "handle_1",
+              body: "night drop",
+              createdAt: new Date("2026-04-24T10:00:00.000Z"),
+              deletedAt: data.deletedAt as Date,
+              hiddenAt: data.hiddenAt as Date,
+              id: "message_1",
+              moderationState: data.moderationState as "deleted",
+              roomId: "room_1",
+              roomSessionId: "session_1",
+              sentAt: new Date("2026-04-24T10:00:00.000Z"),
+              tone: "pink" as const,
+              updatedAt: new Date("2026-04-24T12:34:56.000Z"),
+            }),
+          },
+          chatModerationAuditRecord: {
+            create: async () => ({
+              id: "audit_2",
+            }),
+          },
+          chatUpload: {
+            findUnique: async () => ({
+              byteSize: 1234,
+              createdAt: new Date("2026-04-24T10:00:00.000Z"),
+              deletedAt: new Date("2026-04-24T11:00:00.000Z"),
+              displayFilename: "drop.png",
+              hiddenAt: new Date("2026-04-24T11:00:00.000Z"),
+              id: "upload_1",
+              kind: "image" as const,
+              messageId: "message_1",
+              mimeType: "image_png" as const,
+              moderationState: "deleted" as const,
+              roomId: "room_1",
+              storageKey: "room_1/upload_1.png",
+              storagePath: "room_1/upload_1.png",
+              updatedAt: new Date("2026-04-24T11:00:00.000Z"),
+              uploaderHandleId: "handle_1",
+              uploaderSessionId: "session_1",
+            }),
+            update: async ({ data }) => ({
+              byteSize: 1234,
+              createdAt: new Date("2026-04-24T10:00:00.000Z"),
+              deletedAt: data.deletedAt as Date,
+              displayFilename: "drop.png",
+              hiddenAt: data.hiddenAt as Date,
+              id: "upload_1",
+              kind: "image" as const,
+              messageId: "message_1",
+              mimeType: "image_png" as const,
+              moderationState: data.moderationState as "deleted",
+              roomId: "room_1",
+              storageKey: "room_1/upload_1.png",
+              storagePath: "room_1/upload_1.png",
+              updatedAt: new Date("2026-04-24T12:34:56.000Z"),
+              uploaderHandleId: "handle_1",
+              uploaderSessionId: "session_1",
+            }),
+          },
+        }),
+    } as unknown as PrismaDatabaseClient);
+
+    const result = await repository.moderateUploadRetention({
+      action: "hide_media_metadata",
+      actorAdminUserId: "admin_1",
+      occurredAt: new Date("2026-04-24T12:34:56.000Z"),
+      uploadId: "upload_1",
+    });
+
+    expect(result?.message?.moderationState).toBe("deleted");
+    expect(result?.upload.moderationState).toBe("deleted");
+  });
 });

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
@@ -263,7 +263,10 @@ const moderateUploadRetention = async (
 
     const nextUploadHiddenAt = upload.hiddenAt ?? input.occurredAt;
     const nextUploadDeletedAt = upload.deletedAt;
-    const nextUploadModerationState = "hidden";
+    const nextUploadModerationState =
+      upload.moderationState === "deleted" || upload.deletedAt
+        ? "deleted"
+        : "hidden";
     const nextMessageHiddenAt =
       message ? (message.hiddenAt ?? input.occurredAt) : null;
     const nextMessageDeletedAt =
@@ -271,7 +274,11 @@ const moderateUploadRetention = async (
         ? message.deletedAt ?? input.occurredAt
         : message?.deletedAt ?? null;
     const nextMessageModerationState =
-      input.action === "delete_message" ? "deleted" : "hidden";
+      input.action === "delete_message" ||
+      message?.moderationState === "deleted" ||
+      !!message?.deletedAt
+        ? "deleted"
+        : "hidden";
 
     const updatedUpload = await tx.chatUpload.update({
       data: {

--- a/docs/specs/implementation-playbook.md
+++ b/docs/specs/implementation-playbook.md
@@ -90,20 +90,17 @@ Use:
 - Production releases come from tagged commits on `main`.
 
 ## Current Executable Cluster
-The current executable cluster is `Wave 2 Cluster 4: Media storage and delivery`.
+Wave 2 Clusters 1-4 are complete in the harness. There is no new executable cluster to cut from this playbook until the next planning/status update is approved.
 
-Create these tasks in this order:
-1. Implement shared media repository reads, storage ports, filesystem adapter behavior, and bootstrap wiring.
-2. Implement public photo original delivery on `/media/photos/:id/original`.
-3. Implement chat upload validation and storage flow.
-4. Implement room-gated chat media access.
-5. Implement chat media hide/delete retention behavior.
-6. Add media delivery and upload verification coverage.
+Current follow-up actions:
+1. Commit and merge `BE-017` to `develop`.
+2. Run the cluster-level backend verification pass on `develop` after merge.
+3. Cut the Cluster 4 closeout/spec sync task once merge verification is complete.
 
-Parallelization rule for the current cluster:
-- after the shared media foundation lands, public photo delivery and chat upload/storage may run in parallel
-- room-gated chat media access and media retention follow the chat upload/storage task
-- verification hardening runs last across the merged cluster state
+Parallelization rule for the current state:
+- do not cut a new cluster from this playbook until the harness is explicitly advanced
+- backend-only PRs still run the frontend analyzer as a non-mutating validation check
+- verification hardening remains the last task within Cluster 4 until `BE-017` is merged
 
 ## Cluster-to-Task Rules
 ### Good task split

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -46,10 +46,11 @@
 - The frontend migration wave cleared the previous browser Babel, CDN React, global `window.*`, missing TypeScript, and missing screen blockers.
 
 ## Next Task Queue
-1. Cut Wave 2 Cluster 4 media/storage tasks from approved media, backend, infra, project structure, and verification specs.
-2. Implement shared media foundation first, then public photo delivery and chat-media behavior, then media verification hardening.
-3. Run frontend analyzer as non-mutating validation for backend-only PRs.
-4. Keep one issue, one Project item, one branch, and one acceptance source per implementation task.
+1. Commit and open the `BE-017` media verification hardening PR.
+2. Merge `BE-017` to `develop` and run the cluster-level backend verification pass there.
+3. Cut the Cluster 4 closeout/spec sync task after merge verification is complete.
+4. Run frontend analyzer as non-mutating validation for backend-only PRs.
+5. Keep one issue, one Project item, one branch, and one acceptance source per implementation task.
 
 ## Current Executable Cluster
 ### SPEC-019 Backend Spec Reconciliation
@@ -89,12 +90,20 @@
 - Integrated verification: backend typecheck, tests, build, and `bun run verify` passed on `develop`.
 
 ### Wave 2 Cluster 4 Media Storage And Delivery
-- Status: ready for issue creation and implementation.
+- Status: complete on branch; merge to `develop` pending `BE-017` PR.
 - Primary specs: `SPEC-006`, `SPEC-008`, `SPEC-010`, `SPEC-011`, `SPEC-016`, `SPEC-018`.
 - Scope: filesystem-backed media foundation, public photo original delivery, chat upload validation/storage, room-gated chat media access, moderation-aligned retention behavior, and media-specific verification.
 - Non-scope: admin auth/session behavior, admin dashboard CRUD flows, non-media chat room lifecycle behavior, Docker/Caddy implementation files, and production CI workflow YAML.
 - Tasks: `BE-012`, `BE-013`, `BE-014`, `BE-015`, `BE-016`, and `BE-017`.
 - Required ordering: `BE-012` first; `BE-013` and `BE-014` after `BE-012`; `BE-015` and `BE-016` after `BE-014`; `BE-017` after `BE-013`, `BE-014`, `BE-015`, and `BE-016`.
+- Execution checkpoint:
+- `BE-012` complete and merged via PR `#59`.
+- `BE-013` complete and merged via PR `#61`.
+- `BE-014` complete and merged via PR `#60`.
+- `BE-015` complete and merged via PR `#62`.
+- `BE-016` complete and merged via PR `#63`.
+- `BE-017` implementation and verification are complete on `backend/BE-017-media-verification-hardening`.
+- Integrated verification: `bun run verify:media`, `bun run verify`, `bun test`, `bun run typecheck`, and `bun run build` passed on `backend/BE-017-media-verification-hardening`.
 
 ### Frontend Migration Wave 1
 - Status: complete after FE-010 analyzer reconciliation.

--- a/docs/specs/wave-2-task-clusters.md
+++ b/docs/specs/wave-2-task-clusters.md
@@ -134,7 +134,7 @@ Complete. `BE-006`, `BE-007`, `BE-008`, `BE-009`, `BE-010`, and `BE-011` were im
 Implement the shared media foundation and delivery behavior needed for filesystem-backed photo and chat media, while keeping storage behind outbound adapters and preserving the approved public and room-gated access contracts.
 
 ### Status
-Ready for issue creation and implementation.
+Complete on branch. `BE-012`, `BE-013`, `BE-014`, `BE-015`, `BE-016`, and `BE-017` are implemented and verified, with `BE-017` awaiting PR merge to `develop`.
 
 ### Tasks
 | Task ID | Title | Layer | Base Branch | Branch Name | Merge Target | Source Specs | Acceptance Source |
@@ -153,6 +153,15 @@ Ready for issue creation and implementation.
 - `BE-016` starts only after `BE-014` lands on `develop` because hide/delete retention behavior depends on the chat upload/media persistence flow.
 - `BE-017` starts only after `BE-013`, `BE-014`, `BE-015`, and `BE-016` land on `develop`.
 - Cluster 5 admin/auth and Cluster 6 non-media chat behavior remain blocked until Cluster 4 is merged and validated.
+
+### Execution Checkpoint
+- `BE-012` complete and merged via PR `#59`.
+- `BE-013` complete and merged via PR `#61`.
+- `BE-014` complete and merged via PR `#60`.
+- `BE-015` complete and merged via PR `#62`.
+- `BE-016` complete and merged via PR `#63`.
+- `BE-017` implementation and verification are complete on `backend/BE-017-media-verification-hardening`.
+- Cluster 4 verification passed via `bun run verify:media`, `bun run verify`, `bun test`, `bun run typecheck`, and `bun run build` on the `BE-017` branch.
 
 ### Non-Scope
 - Admin login, MFA, and session lifecycle.


### PR DESCRIPTION
## Summary
- harden backend verification coverage for Cluster 4 media delivery, upload validation, room-gated access, and moderation-aligned retention behavior
- integrate the media verification path into the backend verification entrypoint without changing unrelated contracts
- sync the Cluster 4 tracking docs so BE-017 and Wave 2 Clusters 1-4 are reflected as complete on branch

## Branching
- Base branch: develop
- Merge target: develop

## Acceptance
- Acceptance source: docs/specs/verification.md, docs/specs/ci-cd.md
- Verification performed: bun run verify:media, bun run verify, bun test, bun run typecheck, bun run build
- Required CI status checks: policy-only until workflows exist

## Notes
- Deployment impact: none beyond existing backend verification coverage
- Revert impact: revert the BE-017 task commit if the verification hardening needs to be rolled back
- Follow-up tasks: run the cluster-level backend verification pass on develop after merge, then cut the Cluster 4 closeout/spec sync task

Closes #58
