### PR TITLE
[CHAT-001] Implement chat room password gate and room session join flow

### DIFF
--- a/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
@@ -2,19 +2,66 @@ import { describe, expect, it } from "bun:test";
 
 import type { BootstrapContainer } from "@/bootstrap/container";
 import type {
+  JoinChatRoomSessionInput,
+  JoinChatRoomSessionOutput,
   UploadChatMessageWithImageInput,
   UploadChatMessageWithImageOutput,
 } from "@/modules/chat/ports/inbound";
-import { InvalidChatUploadActorError } from "@/modules/chat/application";
+import {
+  BannedChatHandleError,
+  InvalidChatRoomCredentialsError,
+  InvalidChatUploadActorError,
+} from "@/modules/chat/application";
 
 import { createHonoHttpAdapter } from "./http-adapter";
 
-const createTestContainer = (
-  executeUpload: (
+const defaultUploadResponse: UploadChatMessageWithImageOutput = {
+  attachment: {
+    byteSize: 4,
+    fileName: "scan.png",
+    id: "upload_1",
+    kind: "image",
+    mimeType: "image/png",
+  },
+  authorHandleId: "handle_1",
+  body: "message body",
+  id: "message_1",
+  sentAt: "2026-04-24T12:00:00.000Z",
+  tone: "cyan",
+};
+
+const createTestContainer = ({
+  executeJoin = async (): Promise<JoinChatRoomSessionOutput> => ({
+    participant: {
+      handle: "vinicius",
+      id: "handle_1",
+      status: "online",
+    },
+    room: {
+      id: "room_1",
+      slug: "night-shift",
+    },
+    session: {
+      handleId: "handle_1",
+      id: "session_1",
+      joinedAt: "2026-04-24T12:00:00.000Z",
+      roomId: "room_1",
+      status: "active",
+    },
+  }),
+  executeUpload = async (): Promise<UploadChatMessageWithImageOutput> => defaultUploadResponse,
+}: Readonly<{
+  executeJoin?: (
+    input: JoinChatRoomSessionInput,
+  ) => JoinChatRoomSessionOutput | Promise<JoinChatRoomSessionOutput>;
+  executeUpload?: (
     input: UploadChatMessageWithImageInput,
-  ) => UploadChatMessageWithImageOutput | Promise<UploadChatMessageWithImageOutput>,
-): BootstrapContainer => ({
+  ) => UploadChatMessageWithImageOutput | Promise<UploadChatMessageWithImageOutput>;
+}> = {}): BootstrapContainer => ({
   chat: {
+    joinRoomSession: {
+      execute: executeJoin,
+    },
     moderateUploadRetention: {
       execute: async () => null,
     },
@@ -147,6 +194,156 @@ const createUploadFormData = ({
 };
 
 describe("chat routes", () => {
+  it("maps a valid join request into the chat join use case", async () => {
+    let capturedInput: JoinChatRoomSessionInput | undefined;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeJoin: async (input) => {
+          capturedInput = input;
+
+          return {
+            participant: {
+              handle: "vinicius",
+              id: "handle_1",
+              status: "online",
+            },
+            room: {
+              id: "room_1",
+              slug: "night-shift",
+            },
+            session: {
+              handleId: "handle_1",
+              id: "session_1",
+              joinedAt: "2026-04-24T12:00:00.000Z",
+              roomId: "room_1",
+              status: "active",
+            },
+          };
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/join", {
+      body: JSON.stringify({
+        handle: " vinicius ",
+        password: " open-sesame ",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      participant: {
+        handle: "vinicius",
+        id: "handle_1",
+        status: "online",
+      },
+      room: {
+        id: "room_1",
+        slug: "night-shift",
+      },
+      session: {
+        handleId: "handle_1",
+        id: "session_1",
+        joinedAt: "2026-04-24T12:00:00.000Z",
+        roomId: "room_1",
+        status: "active",
+      },
+    });
+    expect(capturedInput).toEqual({
+      handle: "vinicius",
+      password: "open-sesame",
+      slug: "night-shift",
+    });
+  });
+
+  it("rejects invalid join payloads before calling the core", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeJoin: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/join", {
+      body: JSON.stringify({
+        handle: "vinicius",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_request",
+      field: "password",
+    });
+    expect(called).toBe(false);
+  });
+
+  it("returns denied when chat room credentials are invalid", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeJoin: async () => {
+          throw new InvalidChatRoomCredentialsError();
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/join", {
+      body: JSON.stringify({
+        handle: "vinicius",
+        password: "wrong",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: "denied",
+      resource: "chat",
+    });
+  });
+
+  it("returns denied with reason when handle is banned", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeJoin: async () => {
+          throw new BannedChatHandleError();
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/join", {
+      body: JSON.stringify({
+        handle: "vinicius",
+        password: "open-sesame",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "denied",
+      reason: "handle_banned",
+      resource: "chat",
+    });
+  });
+
   it("maps a valid upload request into the chat upload use case", async () => {
     let capturedAuthorHandleId: string | undefined;
     let capturedMimeType: string | undefined;
@@ -154,27 +351,16 @@ describe("chat routes", () => {
     let capturedRoomSessionId: string | undefined;
     let capturedTone: "cyan" | "pink" | "system" | null | undefined;
     const app = createHonoHttpAdapter(
-      createTestContainer(async (input) => {
-        capturedAuthorHandleId = input.authorHandleId;
-        capturedMimeType = input.image.mimeType;
-        capturedRoomId = input.roomId;
-        capturedRoomSessionId = input.roomSessionId;
-        capturedTone = input.tone;
+      createTestContainer({
+        executeUpload: async (input) => {
+          capturedAuthorHandleId = input.authorHandleId;
+          capturedMimeType = input.image.mimeType;
+          capturedRoomId = input.roomId;
+          capturedRoomSessionId = input.roomSessionId;
+          capturedTone = input.tone;
 
-        return {
-          attachment: {
-            byteSize: 4,
-            fileName: "scan.png",
-            id: "upload_1",
-            kind: "image",
-            mimeType: "image/png",
-          },
-          authorHandleId: "handle_1",
-          body: "message body",
-          id: "message_1",
-          sentAt: "2026-04-24T12:00:00.000Z",
-          tone: "cyan",
-        };
+          return defaultUploadResponse;
+        },
       }),
     );
 
@@ -210,9 +396,11 @@ describe("chat routes", () => {
   it("rejects invalid MIME types before reaching the core", async () => {
     let called = false;
     const app = createHonoHttpAdapter(
-      createTestContainer(async () => {
-        called = true;
-        throw new Error("should not run");
+      createTestContainer({
+        executeUpload: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
       }),
     );
 
@@ -236,9 +424,11 @@ describe("chat routes", () => {
   it("rejects oversized uploads before reaching the core", async () => {
     let called = false;
     const app = createHonoHttpAdapter(
-      createTestContainer(async () => {
-        called = true;
-        throw new Error("should not run");
+      createTestContainer({
+        executeUpload: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
       }),
     );
 
@@ -259,9 +449,11 @@ describe("chat routes", () => {
   it("rejects multiple upload files per message", async () => {
     let called = false;
     const app = createHonoHttpAdapter(
-      createTestContainer(async () => {
-        called = true;
-        throw new Error("should not run");
+      createTestContainer({
+        executeUpload: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
       }),
     );
     const formData = createUploadFormData();
@@ -283,8 +475,10 @@ describe("chat routes", () => {
 
   it("returns denied when the room session and author ids do not match", async () => {
     const app = createHonoHttpAdapter(
-      createTestContainer(async () => {
-        throw new InvalidChatUploadActorError();
+      createTestContainer({
+        executeUpload: async () => {
+          throw new InvalidChatUploadActorError();
+        },
       }),
     );
 

--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -9,6 +9,8 @@ import {
 } from "@/modules/auth/application";
 import { InvalidAdminPhotoMetadataDateError } from "@/modules/admin/application";
 import {
+  BannedChatHandleError,
+  InvalidChatRoomCredentialsError,
   InvalidChatUploadAccessError,
   InvalidChatUploadActorError,
 } from "@/modules/chat/application";
@@ -549,6 +551,84 @@ const readRequiredJsonString = (
 
 const createChatFamily = (container: BootstrapContainer) => {
   const chatApp = new Hono();
+
+  chatApp.post("/rooms/:slug/join", async (c) => {
+    if (!container.chat.joinRoomSession) {
+      return c.json<NotImplementedResponse>(
+        {
+          family: "chat",
+          method: c.req.method,
+          route: c.req.path,
+          service: serviceName,
+          status: "not_implemented",
+        },
+        501,
+      );
+    }
+
+    const slug = c.req.param("slug")?.trim();
+
+    if (!slug) {
+      return c.json(
+        {
+          error: "invalid_path",
+          field: "slug",
+        },
+        400,
+      );
+    }
+
+    const parsedBody = await readJsonObject(c.req.raw);
+
+    if ("error" in parsedBody) {
+      return c.json(parsedBody.error, 400);
+    }
+
+    const handle = readRequiredJsonString(parsedBody.value, "handle");
+
+    if ("error" in handle) {
+      return c.json(handle.error, 400);
+    }
+
+    const password = readRequiredJsonString(parsedBody.value, "password");
+
+    if ("error" in password) {
+      return c.json(password.error, 400);
+    }
+
+    try {
+      const response = await container.chat.joinRoomSession.execute({
+        handle: handle.value,
+        password: password.value,
+        slug,
+      });
+
+      return c.json(response);
+    } catch (error) {
+      if (error instanceof InvalidChatRoomCredentialsError) {
+        return c.json(
+          {
+            error: "denied",
+            resource: "chat",
+          },
+          401,
+        );
+      }
+
+      if (error instanceof BannedChatHandleError) {
+        return c.json(
+          {
+            error: "denied",
+            reason: "handle_banned",
+            resource: "chat",
+          },
+          403,
+        );
+      }
+
+      throw error;
+    }
+  });
 
   chatApp.get("/uploads/:id/media", async (c) => {
     c.header("Cache-Control", "private, no-store");

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
@@ -36,6 +36,165 @@ describe("prisma chat repository", () => {
     });
   });
 
+  it("maps a room row for slug-based join lookup", async () => {
+    const repository = createPrismaChatRepository({
+      chatRoom: {
+        findUnique: async () => ({
+          createdAt: new Date("2026-04-24T10:00:00.000Z"),
+          id: "room_1",
+          passwordHash: "hash:open-sesame",
+          passwordRotatedAt: new Date("2026-04-20T08:00:00.000Z"),
+          passwordVersion: 3,
+          slug: "night-shift",
+          updatedAt: new Date("2026-04-24T10:05:00.000Z"),
+        }),
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    await expect(repository.findRoomBySlug({ slug: "night-shift" })).resolves.toEqual({
+      createdAt: new Date("2026-04-24T10:00:00.000Z"),
+      id: "room_1",
+      passwordHash: "hash:open-sesame",
+      passwordRotatedAt: new Date("2026-04-20T08:00:00.000Z"),
+      passwordVersion: 3,
+      slug: "night-shift",
+      updatedAt: new Date("2026-04-24T10:05:00.000Z"),
+    });
+  });
+
+  it("maps handle lookup by room and normalized handle", async () => {
+    const repository = createPrismaChatRepository({
+      chatHandle: {
+        findUnique: async () => ({
+          createdAt: new Date("2026-04-24T10:00:00.000Z"),
+          handle: "Vinicius",
+          id: "handle_1",
+          normalizedHandle: "vinicius",
+          roomId: "room_1",
+          status: "active" as const,
+          updatedAt: new Date("2026-04-24T10:05:00.000Z"),
+        }),
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    await expect(
+      repository.findHandleByRoomIdAndNormalizedHandle("room_1", "vinicius"),
+    ).resolves.toEqual({
+      createdAt: new Date("2026-04-24T10:00:00.000Z"),
+      handle: "Vinicius",
+      id: "handle_1",
+      normalizedHandle: "vinicius",
+      roomId: "room_1",
+      status: "active",
+      updatedAt: new Date("2026-04-24T10:05:00.000Z"),
+    });
+  });
+
+  it("creates and maps a chat handle row", async () => {
+    let capturedData: Record<string, unknown> | null = null;
+    const repository = createPrismaChatRepository({
+      chatHandle: {
+        create: async ({ data }: { data: Record<string, unknown> }) => {
+          capturedData = data;
+
+          return {
+            createdAt: new Date("2026-04-24T10:00:00.000Z"),
+            handle: "Vinicius",
+            id: "handle_1",
+            normalizedHandle: "vinicius",
+            roomId: "room_1",
+            status: "active" as const,
+            updatedAt: new Date("2026-04-24T10:05:00.000Z"),
+          };
+        },
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    const result = await repository.createHandle({
+      handle: "Vinicius",
+      normalizedHandle: "vinicius",
+      roomId: "room_1",
+      status: "active",
+    });
+
+    expect(capturedData).not.toBeNull();
+    expect(capturedData!).toEqual({
+      handle: "Vinicius",
+      normalizedHandle: "vinicius",
+      roomId: "room_1",
+      status: "active",
+    });
+    expect(result).toEqual({
+      createdAt: new Date("2026-04-24T10:00:00.000Z"),
+      handle: "Vinicius",
+      id: "handle_1",
+      normalizedHandle: "vinicius",
+      roomId: "room_1",
+      status: "active",
+      updatedAt: new Date("2026-04-24T10:05:00.000Z"),
+    });
+  });
+
+  it("creates and maps a room session row", async () => {
+    let capturedData: Record<string, unknown> | null = null;
+    const repository = createPrismaChatRepository({
+      chatRoomSession: {
+        create: async ({ data }: { data: Record<string, unknown> }) => {
+          capturedData = data;
+
+          return {
+            createdAt: new Date("2026-04-24T10:00:00.000Z"),
+            expiresAt: null,
+            handleId: "handle_1",
+            id: "session_1",
+            joinedAt: new Date("2026-04-24T10:00:00.000Z"),
+            lastSeenAt: new Date("2026-04-24T10:00:00.000Z"),
+            leftAt: null,
+            roomId: "room_1",
+            status: "active" as const,
+            updatedAt: new Date("2026-04-24T10:05:00.000Z"),
+          };
+        },
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    const joinedAt = new Date("2026-04-24T10:00:00.000Z");
+    const result = await repository.createSession({
+      expiresAt: null,
+      handleId: "handle_1",
+      joinedAt,
+      lastSeenAt: joinedAt,
+      leftAt: null,
+      roomId: "room_1",
+      sessionTokenHash: "hash:session-token",
+      status: "active",
+    });
+
+    expect(capturedData).not.toBeNull();
+    expect(capturedData!).toEqual({
+      expiresAt: null,
+      handleId: "handle_1",
+      joinedAt,
+      lastSeenAt: joinedAt,
+      leftAt: null,
+      roomId: "room_1",
+      sessionTokenHash: "hash:session-token",
+      status: "active",
+    });
+    expect(result).toEqual({
+      createdAt: new Date("2026-04-24T10:00:00.000Z"),
+      expiresAt: null,
+      handleId: "handle_1",
+      id: "session_1",
+      joinedAt: new Date("2026-04-24T10:00:00.000Z"),
+      lastSeenAt: new Date("2026-04-24T10:00:00.000Z"),
+      leftAt: null,
+      roomId: "room_1",
+      status: "active",
+      updatedAt: new Date("2026-04-24T10:05:00.000Z"),
+    });
+  });
+
   it("persists and maps a message with upload metadata in one transaction", async () => {
     let capturedMessageData: Record<string, unknown> | null = null;
     let capturedUploadData: Record<string, unknown> | null = null;

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
@@ -1,6 +1,4 @@
 import type {
-  CreateChatMessageWithUploadCommand,
-  CreateChatMessageWithUploadResult,
   ChatHandleRepositoryRow,
   ChatMessageListQuery,
   ChatMessageRepositoryRow,
@@ -8,6 +6,10 @@ import type {
   ChatRoomRepositoryRow,
   ChatRoomSessionRepositoryRow,
   ChatUploadRepositoryRow,
+  CreateChatHandleCommand,
+  CreateChatMessageWithUploadCommand,
+  CreateChatMessageWithUploadResult,
+  CreateChatRoomSessionCommand,
   ModerateChatUploadRetentionCommand,
   ModerateChatUploadRetentionResult,
 } from "@/modules/chat/ports/outbound";
@@ -94,6 +96,42 @@ const mapSessionRow = (row: {
   joinedAt: row.joinedAt,
   lastSeenAt: row.lastSeenAt,
   leftAt: row.leftAt,
+  roomId: row.roomId,
+  status: row.status,
+  updatedAt: row.updatedAt,
+});
+
+const mapRoomRow = (row: {
+  createdAt: Date;
+  id: string;
+  passwordHash: string;
+  passwordRotatedAt: Date | null;
+  passwordVersion: number;
+  slug: string;
+  updatedAt: Date;
+}): ChatRoomRepositoryRow => ({
+  createdAt: row.createdAt,
+  id: row.id,
+  passwordHash: row.passwordHash,
+  passwordRotatedAt: row.passwordRotatedAt,
+  passwordVersion: row.passwordVersion,
+  slug: row.slug,
+  updatedAt: row.updatedAt,
+});
+
+const mapHandleRow = (row: {
+  createdAt: Date;
+  handle: string;
+  id: string;
+  normalizedHandle: string;
+  roomId: string;
+  status: "active" | "banned";
+  updatedAt: Date;
+}): ChatHandleRepositoryRow => ({
+  createdAt: row.createdAt,
+  handle: row.handle,
+  id: row.id,
+  normalizedHandle: row.normalizedHandle,
   roomId: row.roomId,
   status: row.status,
   updatedAt: row.updatedAt,
@@ -204,6 +242,63 @@ const createMessageWithUpload = async (
       upload: mapUploadRow(upload),
     };
   });
+};
+
+const createHandle = async (
+  client: PrismaDatabaseClient,
+  input: CreateChatHandleCommand,
+): Promise<ChatHandleRepositoryRow> => {
+  const handle = await client.chatHandle.create({
+    data: {
+      handle: input.handle,
+      normalizedHandle: input.normalizedHandle,
+      roomId: input.roomId,
+      status: input.status,
+    },
+    select: {
+      createdAt: true,
+      handle: true,
+      id: true,
+      normalizedHandle: true,
+      roomId: true,
+      status: true,
+      updatedAt: true,
+    },
+  });
+
+  return mapHandleRow(handle);
+};
+
+const createSession = async (
+  client: PrismaDatabaseClient,
+  input: CreateChatRoomSessionCommand,
+): Promise<ChatRoomSessionRepositoryRow> => {
+  const session = await client.chatRoomSession.create({
+    data: {
+      expiresAt: input.expiresAt,
+      handleId: input.handleId,
+      joinedAt: input.joinedAt,
+      lastSeenAt: input.lastSeenAt,
+      leftAt: input.leftAt,
+      roomId: input.roomId,
+      sessionTokenHash: input.sessionTokenHash,
+      status: input.status,
+    },
+    select: {
+      createdAt: true,
+      expiresAt: true,
+      handleId: true,
+      id: true,
+      joinedAt: true,
+      lastSeenAt: true,
+      leftAt: true,
+      roomId: true,
+      status: true,
+      updatedAt: true,
+    },
+  });
+
+  return mapSessionRow(session);
 };
 
 const moderateUploadRetention = async (
@@ -372,8 +467,10 @@ const moderateUploadRetention = async (
 };
 
 export const createPrismaChatRepository = (client: PrismaDatabaseClient): ChatRepositoryPort => ({
+  createHandle: (input): Promise<ChatHandleRepositoryRow> => createHandle(client, input),
   createMessageWithUpload: (input): Promise<CreateChatMessageWithUploadResult> =>
     createMessageWithUpload(client, input),
+  createSession: (input): Promise<ChatRoomSessionRepositoryRow> => createSession(client, input),
   moderateUploadRetention: (input): Promise<ModerateChatUploadRetentionResult | null> =>
     moderateUploadRetention(client, input),
   findSessionById: async (sessionId): Promise<ChatRoomSessionRepositoryRow | null> => {
@@ -397,9 +494,48 @@ export const createPrismaChatRepository = (client: PrismaDatabaseClient): ChatRe
 
     return session ? mapSessionRow(session) : null;
   },
-  findRoomBySlug: (_query): Promise<ChatRoomRepositoryRow | null> => notImplemented("findRoomBySlug"),
-  findHandleByRoomIdAndNormalizedHandle: (_roomId, _normalizedHandle): Promise<ChatHandleRepositoryRow | null> =>
-    notImplemented("findHandleByRoomIdAndNormalizedHandle"),
+  findRoomBySlug: async (query): Promise<ChatRoomRepositoryRow | null> => {
+    const room = await client.chatRoom.findUnique({
+      select: {
+        createdAt: true,
+        id: true,
+        passwordHash: true,
+        passwordRotatedAt: true,
+        passwordVersion: true,
+        slug: true,
+        updatedAt: true,
+      },
+      where: {
+        slug: query.slug,
+      },
+    });
+
+    return room ? mapRoomRow(room) : null;
+  },
+  findHandleByRoomIdAndNormalizedHandle: async (
+    roomId,
+    normalizedHandle,
+  ): Promise<ChatHandleRepositoryRow | null> => {
+    const handle = await client.chatHandle.findUnique({
+      select: {
+        createdAt: true,
+        handle: true,
+        id: true,
+        normalizedHandle: true,
+        roomId: true,
+        status: true,
+        updatedAt: true,
+      },
+      where: {
+        roomId_normalizedHandle: {
+          normalizedHandle,
+          roomId,
+        },
+      },
+    });
+
+    return handle ? mapHandleRow(handle) : null;
+  },
   listMessages: (_query: ChatMessageListQuery): Promise<readonly ChatMessageRepositoryRow[]> =>
     notImplemented("listMessages"),
   findUploadById: (_uploadId: string): Promise<ChatUploadRepositoryRow | null> =>

--- a/backend/src/bootstrap/container/create-container.test.ts
+++ b/backend/src/bootstrap/container/create-container.test.ts
@@ -12,6 +12,7 @@ describe("bootstrap container", () => {
 
     expect(typeof container.chat.moderateUploadRetention.execute).toBe("function");
     expect(typeof container.chat.openUploadMedia.execute).toBe("function");
+    expect(typeof container.chat.joinRoomSession?.execute).toBe("function");
     expect(typeof container.media.repository.findPhotoMediaById).toBe("function");
     expect(typeof container.media.repository.findChatUploadMediaById).toBe("function");
     expect(typeof container.media.storage.photos.openOriginal).toBe("function");

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -47,11 +47,13 @@ import type {
   VerifyMfaChallengePort,
 } from "@/modules/auth/ports/inbound";
 import {
+  createJoinChatRoomSessionUseCase,
   createModerateChatUploadRetentionUseCase,
   createOpenChatUploadMediaUseCase,
   createUploadChatMessageWithImageUseCase,
 } from "@/modules/chat/application";
 import type {
+  JoinChatRoomSessionPort,
   ModerateChatUploadRetentionPort,
   OpenChatUploadMediaPort,
   UploadChatMessageWithImagePort,
@@ -98,6 +100,7 @@ export type BootstrapContainer = Readonly<{
     verifyMfaChallenge: VerifyMfaChallengePort;
   }>;
   chat: Readonly<{
+    joinRoomSession?: JoinChatRoomSessionPort;
     moderateUploadRetention: ModerateChatUploadRetentionPort;
     openUploadMedia: OpenChatUploadMediaPort;
     uploadMessageWithImage: UploadChatMessageWithImagePort;
@@ -138,6 +141,9 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
   const authClock = createSystemAuthClock();
   const authMfaCodeHasher = createBunMfaCodeHashPort();
   const authSessionTokenHasher = createHmacSessionTokenHashPort(config.auth.sessionSecret);
+  const chatSessionTokenHasher = createHmacSessionTokenHashPort(config.auth.roomPasswordSecret);
+  const chatPasswordHasher = createBunPasswordHashPort();
+  const chatSessionTokenGenerator = createCryptoSessionTokenGenerator();
 
   return {
     admin: {
@@ -214,6 +220,18 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
       }),
     },
     chat: {
+      joinRoomSession: createJoinChatRoomSessionUseCase({
+        createSessionToken: () => chatSessionTokenGenerator.create(),
+        hashSessionToken: (token) => chatSessionTokenHasher.hash(token),
+        repository: persistence.chat,
+        verifyRoomPassword: ({ passwordHash, plainText }) =>
+          chatPasswordHasher.verify({
+            passwordHash,
+            passwordHashAlgorithm: "bun-password",
+            passwordHashParams: null,
+            plainText,
+          }),
+      }),
       moderateUploadRetention: createModerateChatUploadRetentionUseCase({
         repository: persistence.chat,
       }),

--- a/backend/src/modules/chat/application/index.test.ts
+++ b/backend/src/modules/chat/application/index.test.ts
@@ -1,11 +1,179 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+  BannedChatHandleError,
+  createJoinChatRoomSessionUseCase,
   createModerateChatUploadRetentionUseCase,
   createOpenChatUploadMediaUseCase,
   createUploadChatMessageWithImageUseCase,
+  InvalidChatRoomCredentialsError,
   InvalidChatUploadAccessError,
 } from "./index";
+
+describe("chat room join use case", () => {
+  it("verifies room credentials, creates handle when needed, and issues an active room session", async () => {
+    const now = new Date("2026-04-28T10:00:00.000Z");
+    let capturedCreateHandle: Record<string, unknown> | undefined;
+    let capturedCreateSession: Record<string, unknown> | undefined;
+    const useCase = createJoinChatRoomSessionUseCase({
+      clock: () => now,
+      createSessionToken: () => "session-token-1",
+      hashSessionToken: async (token) => `hash:${token}`,
+      repository: {
+        createHandle: async (input) => {
+          capturedCreateHandle = input as unknown as Record<string, unknown>;
+
+          return {
+            createdAt: now,
+            handle: "Vinicius",
+            id: "handle_1",
+            normalizedHandle: input.normalizedHandle,
+            roomId: input.roomId,
+            status: "active",
+            updatedAt: now,
+          };
+        },
+        createSession: async (input) => {
+          capturedCreateSession = input as unknown as Record<string, unknown>;
+
+          return {
+            createdAt: now,
+            expiresAt: null,
+            handleId: input.handleId,
+            id: "session_1",
+            joinedAt: input.joinedAt,
+            lastSeenAt: input.lastSeenAt,
+            leftAt: null,
+            roomId: input.roomId,
+            status: "active",
+            updatedAt: now,
+          };
+        },
+        findHandleByRoomIdAndNormalizedHandle: async () => null,
+        findRoomBySlug: async () => ({
+          createdAt: now,
+          id: "room_1",
+          passwordHash: "hash:open-sesame",
+          passwordRotatedAt: null,
+          passwordVersion: 1,
+          slug: "night-shift",
+          updatedAt: now,
+        }),
+      },
+      verifyRoomPassword: async ({ passwordHash, plainText }) =>
+        passwordHash === `hash:${plainText}`,
+    });
+
+    const result = await useCase.execute({
+      handle: "  Vinicius  ",
+      password: "open-sesame",
+      slug: "night-shift",
+    });
+
+    expect(capturedCreateHandle).toMatchObject({
+      handle: "Vinicius",
+      normalizedHandle: "vinicius",
+      roomId: "room_1",
+      status: "active",
+    });
+    expect(capturedCreateSession).toMatchObject({
+      handleId: "handle_1",
+      roomId: "room_1",
+      sessionTokenHash: "hash:session-token-1",
+      status: "active",
+    });
+    expect(result).toEqual({
+      participant: {
+        handle: "Vinicius",
+        id: "handle_1",
+        status: "online",
+      },
+      room: {
+        id: "room_1",
+        slug: "night-shift",
+      },
+      session: {
+        handleId: "handle_1",
+        id: "session_1",
+        joinedAt: "2026-04-28T10:00:00.000Z",
+        roomId: "room_1",
+        status: "active",
+      },
+    });
+  });
+
+  it("rejects room join with invalid credentials", async () => {
+    const useCase = createJoinChatRoomSessionUseCase({
+      repository: {
+        createHandle: async () => {
+          throw new Error("should not create handle");
+        },
+        createSession: async () => {
+          throw new Error("should not create session");
+        },
+        findHandleByRoomIdAndNormalizedHandle: async () => null,
+        findRoomBySlug: async () => ({
+          createdAt: new Date("2026-04-28T10:00:00.000Z"),
+          id: "room_1",
+          passwordHash: "hash:open-sesame",
+          passwordRotatedAt: null,
+          passwordVersion: 1,
+          slug: "night-shift",
+          updatedAt: new Date("2026-04-28T10:00:00.000Z"),
+        }),
+      },
+      verifyRoomPassword: async () => false,
+    });
+
+    await expect(
+      useCase.execute({
+        handle: "vinicius",
+        password: "wrong-password",
+        slug: "night-shift",
+      }),
+    ).rejects.toBeInstanceOf(InvalidChatRoomCredentialsError);
+  });
+
+  it("rejects room join when handle is banned", async () => {
+    const useCase = createJoinChatRoomSessionUseCase({
+      repository: {
+        createHandle: async () => {
+          throw new Error("should not create handle");
+        },
+        createSession: async () => {
+          throw new Error("should not create session");
+        },
+        findHandleByRoomIdAndNormalizedHandle: async () => ({
+          createdAt: new Date("2026-04-28T10:00:00.000Z"),
+          handle: "vinicius",
+          id: "handle_1",
+          normalizedHandle: "vinicius",
+          roomId: "room_1",
+          status: "banned",
+          updatedAt: new Date("2026-04-28T10:00:00.000Z"),
+        }),
+        findRoomBySlug: async () => ({
+          createdAt: new Date("2026-04-28T10:00:00.000Z"),
+          id: "room_1",
+          passwordHash: "hash:open-sesame",
+          passwordRotatedAt: null,
+          passwordVersion: 1,
+          slug: "night-shift",
+          updatedAt: new Date("2026-04-28T10:00:00.000Z"),
+        }),
+      },
+      verifyRoomPassword: async () => true,
+    });
+
+    await expect(
+      useCase.execute({
+        handle: "vinicius",
+        password: "open-sesame",
+        slug: "night-shift",
+      }),
+    ).rejects.toBeInstanceOf(BannedChatHandleError);
+  });
+});
 
 describe("chat upload message with image use case", () => {
   it("writes the upload and persists message/upload metadata", async () => {

--- a/backend/src/modules/chat/application/index.ts
+++ b/backend/src/modules/chat/application/index.ts
@@ -5,6 +5,9 @@ import type {
 import type { ChatRepositoryPort } from "@/modules/chat/ports/outbound";
 import type {
   ChatUploadMimeType,
+  JoinChatRoomSessionInput,
+  JoinChatRoomSessionOutput,
+  JoinChatRoomSessionPort,
   ModerateChatUploadRetentionInput,
   ModerateChatUploadRetentionOutput,
   ModerateChatUploadRetentionPort,
@@ -18,6 +21,20 @@ import type {
 import type { ModerateChatUploadRetentionAction } from "@/modules/chat/ports/outbound";
 
 const IMAGE_ONLY_FALLBACK_BODY = "uploaded an image without a caption";
+
+export class InvalidChatRoomCredentialsError extends Error {
+  constructor() {
+    super("chat room credentials are invalid");
+    this.name = "InvalidChatRoomCredentialsError";
+  }
+}
+
+export class BannedChatHandleError extends Error {
+  constructor() {
+    super("chat handle is banned");
+    this.name = "BannedChatHandleError";
+  }
+}
 
 export class InvalidChatUploadActorError extends Error {
   constructor() {
@@ -58,11 +75,40 @@ const buildStorageKey = (roomId: string, uploadId: string, mimeType: ChatUploadM
   return `${sanitizeStorageSegment(roomId)}/${uploadId}.${MIME_EXTENSION_BY_TYPE[mimeType]}`;
 };
 
+const collapseWhitespace = (value: string): string => value.trim().replace(/\s+/g, " ");
+
+const normalizeHandle = (value: string): string => collapseWhitespace(value).toLowerCase();
+
+const defaultSessionToken = (): string => crypto.randomUUID();
+
+const hashToken = async (token: string): Promise<string> => {
+  const bytes = new TextEncoder().encode(token);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+
+  return Array.from(new Uint8Array(digest))
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("");
+};
+
 export type ChatApplicationDependencies = Readonly<{
   clock?: () => Date;
   createId?: () => string;
   repository: Pick<ChatRepositoryPort, "createMessageWithUpload" | "findSessionById">;
   storage: ChatUploadStoragePort;
+}>;
+
+export type JoinChatRoomSessionDependencies = Readonly<{
+  clock?: () => Date;
+  createSessionToken?: () => string;
+  hashSessionToken?: (token: string) => Promise<string>;
+  repository: Pick<
+    ChatRepositoryPort,
+    | "createHandle"
+    | "createSession"
+    | "findHandleByRoomIdAndNormalizedHandle"
+    | "findRoomBySlug"
+  >;
+  verifyRoomPassword?: (input: Readonly<{ passwordHash: string; plainText: string }>) => Promise<boolean>;
 }>;
 
 export type ChatUploadMediaAccessDependencies = Readonly<{
@@ -75,6 +121,91 @@ export type ChatUploadRetentionDependencies = Readonly<{
   clock?: () => Date;
   repository: Pick<ChatRepositoryPort, "moderateUploadRetention">;
 }>;
+
+export const createJoinChatRoomSessionUseCase = ({
+  clock = () => new Date(),
+  createSessionToken = defaultSessionToken,
+  hashSessionToken = hashToken,
+  repository,
+  verifyRoomPassword = async ({ passwordHash, plainText }) => {
+    try {
+      return await Bun.password.verify(plainText, passwordHash);
+    } catch (_error) {
+      return false;
+    }
+  },
+}: JoinChatRoomSessionDependencies): JoinChatRoomSessionPort => ({
+  execute: async (
+    input: JoinChatRoomSessionInput,
+  ): Promise<JoinChatRoomSessionOutput> => {
+    const room = await repository.findRoomBySlug({
+      slug: input.slug.trim(),
+    });
+
+    if (!room) {
+      throw new InvalidChatRoomCredentialsError();
+    }
+
+    const validPassword = await verifyRoomPassword({
+      passwordHash: room.passwordHash,
+      plainText: input.password,
+    });
+
+    if (!validPassword) {
+      throw new InvalidChatRoomCredentialsError();
+    }
+
+    const normalizedHandle = normalizeHandle(input.handle);
+    let participant = await repository.findHandleByRoomIdAndNormalizedHandle(
+      room.id,
+      normalizedHandle,
+    );
+
+    if (participant?.status === "banned") {
+      throw new BannedChatHandleError();
+    }
+
+    if (!participant) {
+      participant = await repository.createHandle({
+        handle: collapseWhitespace(input.handle),
+        normalizedHandle,
+        roomId: room.id,
+        status: "active",
+      });
+    }
+
+    const joinedAt = clock();
+    const session = await repository.createSession({
+      expiresAt: null,
+      handleId: participant.id,
+      joinedAt,
+      lastSeenAt: joinedAt,
+      leftAt: null,
+      roomId: room.id,
+      sessionTokenHash: await hashSessionToken(createSessionToken()),
+      status: "active",
+    });
+
+    return {
+      participant: {
+        handle: participant.handle,
+        id: participant.id,
+        status: "online",
+      },
+      room: {
+        id: room.id,
+        slug: room.slug,
+      },
+      session: {
+        handleId: session.handleId,
+        id: session.id,
+        joinedAt: session.joinedAt.toISOString(),
+        roomId: session.roomId,
+        status: session.status,
+      },
+    };
+  },
+});
 
 export const createUploadChatMessageWithImageUseCase = ({
   clock = () => new Date(),

--- a/backend/src/modules/chat/ports/inbound/index.ts
+++ b/backend/src/modules/chat/ports/inbound/index.ts
@@ -2,6 +2,34 @@ import type { UseCase } from "@/modules/shared/application/use-case";
 
 export type ChatUploadMimeType = "image/jpeg" | "image/png" | "image/webp";
 
+export type JoinChatRoomSessionInput = Readonly<{
+  handle: string;
+  password: string;
+  slug: string;
+}>;
+
+export type JoinChatRoomSessionOutput = Readonly<{
+  participant: Readonly<{
+    handle: string;
+    id: string;
+    status: "online";
+  }>;
+  room: Readonly<{
+    id: string;
+    slug: string;
+  }>;
+  session: Readonly<{
+    handleId: string;
+    id: string;
+    joinedAt: string;
+    roomId: string;
+    status: "active" | "revoked" | "expired";
+  }>;
+}>;
+
+export interface JoinChatRoomSessionPort
+  extends UseCase<JoinChatRoomSessionInput, JoinChatRoomSessionOutput> {}
+
 export type UploadChatMessageImageInput = Readonly<{
   body: Uint8Array;
   displayFilename: string;

--- a/backend/src/modules/chat/ports/outbound/index.ts
+++ b/backend/src/modules/chat/ports/outbound/index.ts
@@ -1,5 +1,6 @@
 export type ChatRoomRepositoryRow = Readonly<{
   id: string;
+  passwordHash: string;
   slug: string;
   passwordVersion: number;
   passwordRotatedAt: Date | null;
@@ -80,6 +81,24 @@ export type CreateChatMessageWithUploadCommand = Readonly<{
   uploadId: string;
 }>;
 
+export type CreateChatHandleCommand = Readonly<{
+  handle: string;
+  normalizedHandle: string;
+  roomId: string;
+  status: "active" | "banned";
+}>;
+
+export type CreateChatRoomSessionCommand = Readonly<{
+  expiresAt: Date | null;
+  handleId: string;
+  joinedAt: Date;
+  lastSeenAt: Date | null;
+  leftAt: Date | null;
+  roomId: string;
+  sessionTokenHash: string;
+  status: "active" | "revoked" | "expired";
+}>;
+
 export type CreateChatMessageWithUploadResult = Readonly<{
   message: ChatMessageRepositoryRow;
   upload: ChatUploadRepositoryRow;
@@ -113,9 +132,11 @@ export type ChatMessageListQuery = Readonly<{
 }>;
 
 export interface ChatRepositoryPort {
+  createHandle(input: CreateChatHandleCommand): Promise<ChatHandleRepositoryRow>;
   createMessageWithUpload(
     input: CreateChatMessageWithUploadCommand,
   ): Promise<CreateChatMessageWithUploadResult>;
+  createSession(input: CreateChatRoomSessionCommand): Promise<ChatRoomSessionRepositoryRow>;
   moderateUploadRetention(
     input: ModerateChatUploadRetentionCommand,
   ): Promise<ModerateChatUploadRetentionResult | null>;


### PR DESCRIPTION
## Summary
- implement CHAT-001 room join/session backend flow in the chat module
- add `POST /api/chat/rooms/:slug/join` with validation plus denied/banned error mapping
- implement Prisma chat repository room/handle/session methods and wire join use case in container
- keep existing upload/media chat contract intact while introducing join/session creation

## Files and Areas
- `backend/src/modules/chat/**` join port + use case + tests
- `backend/src/adapters/outbound/persistence/prisma/chat-repository.ts` + tests
- `backend/src/adapters/inbound/http/hono/http-adapter.ts` chat join route
- `backend/src/adapters/inbound/http/hono/chat-routes.test.ts` join route coverage
- `backend/src/bootstrap/container/create-container.ts` wiring

## Verification
- `bun run --cwd backend typecheck`
- `bun run --cwd backend test`
- `bun run --cwd backend verify`

Closes #71
