### PR TITLE
[CHAT-002] Implement chat participant handle registration and presence state

### DIFF
--- a/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
@@ -4,11 +4,14 @@ import type { BootstrapContainer } from "@/bootstrap/container";
 import type {
   JoinChatRoomSessionInput,
   JoinChatRoomSessionOutput,
+  ListChatRoomParticipantsInput,
+  ListChatRoomParticipantsOutput,
   UploadChatMessageWithImageInput,
   UploadChatMessageWithImageOutput,
 } from "@/modules/chat/ports/inbound";
 import {
   BannedChatHandleError,
+  InvalidChatParticipantAccessError,
   InvalidChatRoomCredentialsError,
   InvalidChatUploadActorError,
 } from "@/modules/chat/application";
@@ -30,6 +33,15 @@ const defaultUploadResponse: UploadChatMessageWithImageOutput = {
   tone: "cyan",
 };
 
+const defaultParticipantsResponse: ListChatRoomParticipantsOutput = {
+  items: [
+    {
+      handle: "vinicius",
+      status: "online",
+    },
+  ],
+};
+
 const createTestContainer = ({
   executeJoin = async (): Promise<JoinChatRoomSessionOutput> => ({
     participant: {
@@ -49,11 +61,16 @@ const createTestContainer = ({
       status: "active",
     },
   }),
+  executeParticipants = async (): Promise<ListChatRoomParticipantsOutput> =>
+    defaultParticipantsResponse,
   executeUpload = async (): Promise<UploadChatMessageWithImageOutput> => defaultUploadResponse,
 }: Readonly<{
   executeJoin?: (
     input: JoinChatRoomSessionInput,
   ) => JoinChatRoomSessionOutput | Promise<JoinChatRoomSessionOutput>;
+  executeParticipants?: (
+    input: ListChatRoomParticipantsInput,
+  ) => ListChatRoomParticipantsOutput | Promise<ListChatRoomParticipantsOutput>;
   executeUpload?: (
     input: UploadChatMessageWithImageInput,
   ) => UploadChatMessageWithImageOutput | Promise<UploadChatMessageWithImageOutput>;
@@ -61,6 +78,9 @@ const createTestContainer = ({
   chat: {
     joinRoomSession: {
       execute: executeJoin,
+    },
+    listRoomParticipants: {
+      execute: executeParticipants,
     },
     moderateUploadRetention: {
       execute: async () => null,
@@ -340,6 +360,101 @@ describe("chat routes", () => {
     await expect(response.json()).resolves.toEqual({
       error: "denied",
       reason: "handle_banned",
+      resource: "chat",
+    });
+  });
+
+  it("maps a valid participants request into the participants use case", async () => {
+    let capturedInput: ListChatRoomParticipantsInput | undefined;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeParticipants: async (input) => {
+          capturedInput = input;
+
+          return {
+            items: [
+              {
+                handle: "vinicius",
+                status: "online",
+              },
+              {
+                handle: "guest",
+                status: "idle",
+              },
+            ],
+          };
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/participants", {
+      headers: {
+        "x-chat-room-session-id": " session_1 ",
+      },
+      method: "GET",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      items: [
+        {
+          handle: "vinicius",
+          status: "online",
+        },
+        {
+          handle: "guest",
+          status: "idle",
+        },
+      ],
+    });
+    expect(capturedInput).toEqual({
+      roomSessionId: "session_1",
+      slug: "night-shift",
+    });
+  });
+
+  it("rejects participants requests missing room session header", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeParticipants: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/participants", {
+      method: "GET",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_request",
+      field: "x-chat-room-session-id",
+    });
+    expect(called).toBe(false);
+  });
+
+  it("returns denied when participants access is invalid for the room session", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeParticipants: async () => {
+          throw new InvalidChatParticipantAccessError();
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/participants", {
+      headers: {
+        "x-chat-room-session-id": "session_1",
+      },
+      method: "GET",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "denied",
       resource: "chat",
     });
   });

--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -10,6 +10,7 @@ import {
 import { InvalidAdminPhotoMetadataDateError } from "@/modules/admin/application";
 import {
   BannedChatHandleError,
+  InvalidChatParticipantAccessError,
   InvalidChatRoomCredentialsError,
   InvalidChatUploadAccessError,
   InvalidChatUploadActorError,
@@ -620,6 +621,66 @@ const createChatFamily = (container: BootstrapContainer) => {
           {
             error: "denied",
             reason: "handle_banned",
+            resource: "chat",
+          },
+          403,
+        );
+      }
+
+      throw error;
+    }
+  });
+
+  chatApp.get("/rooms/:slug/participants", async (c) => {
+    if (!container.chat.listRoomParticipants) {
+      return c.json<NotImplementedResponse>(
+        {
+          family: "chat",
+          method: c.req.method,
+          route: c.req.path,
+          service: serviceName,
+          status: "not_implemented",
+        },
+        501,
+      );
+    }
+
+    const slug = c.req.param("slug")?.trim();
+
+    if (!slug) {
+      return c.json(
+        {
+          error: "invalid_path",
+          field: "slug",
+        },
+        400,
+      );
+    }
+
+    const roomSessionId = c.req.header("x-chat-room-session-id")?.trim();
+
+    if (!roomSessionId) {
+      return c.json(
+        {
+          error: "invalid_request",
+          field: "x-chat-room-session-id",
+        },
+        400,
+      );
+    }
+
+    try {
+      const response = await container.chat.listRoomParticipants.execute({
+        roomSessionId,
+        slug,
+      });
+
+      return c.json(response);
+    } catch (error) {
+      if (error instanceof InvalidChatParticipantAccessError) {
+        return c.json(
+          {
+            error: "denied",
             resource: "chat",
           },
           403,

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
@@ -90,6 +90,46 @@ describe("prisma chat repository", () => {
     });
   });
 
+  it("maps room participants with online/idle status", async () => {
+    let capturedWhere: Record<string, unknown> | null = null;
+    const repository = createPrismaChatRepository({
+      chatHandle: {
+        findMany: async ({ where }: { where: Record<string, unknown> }) => {
+          capturedWhere = where;
+
+          return [
+            {
+              handle: "guest",
+              sessions: [],
+            },
+            {
+              handle: "vinicius",
+              sessions: [{ id: "session_1" }],
+            },
+          ];
+        },
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    const result = await repository.listParticipantsByRoomId("room_1");
+
+    expect(capturedWhere).not.toBeNull();
+    expect(capturedWhere!).toEqual({
+      roomId: "room_1",
+      status: "active",
+    });
+    expect(result).toEqual([
+      {
+        handle: "guest",
+        status: "idle",
+      },
+      {
+        handle: "vinicius",
+        status: "online",
+      },
+    ]);
+  });
+
   it("creates and maps a chat handle row", async () => {
     let capturedData: Record<string, unknown> | null = null;
     const repository = createPrismaChatRepository({

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
@@ -2,6 +2,7 @@ import type {
   ChatHandleRepositoryRow,
   ChatMessageListQuery,
   ChatMessageRepositoryRow,
+  ChatRoomParticipantRepositoryRow,
   ChatRepositoryPort,
   ChatRoomRepositoryRow,
   ChatRoomSessionRepositoryRow,
@@ -466,6 +467,40 @@ const moderateUploadRetention = async (
   });
 };
 
+const listParticipantsByRoomId = async (
+  client: PrismaDatabaseClient,
+  roomId: string,
+): Promise<readonly ChatRoomParticipantRepositoryRow[]> => {
+  const handles = await client.chatHandle.findMany({
+    orderBy: {
+      normalizedHandle: "asc",
+    },
+    select: {
+      handle: true,
+      sessions: {
+        select: {
+          id: true,
+        },
+        take: 1,
+        where: {
+          leftAt: null,
+          roomId,
+          status: "active",
+        },
+      },
+    },
+    where: {
+      roomId,
+      status: "active",
+    },
+  });
+
+  return handles.map((handle) => ({
+    handle: handle.handle,
+    status: handle.sessions.length > 0 ? "online" : "idle",
+  }));
+};
+
 export const createPrismaChatRepository = (client: PrismaDatabaseClient): ChatRepositoryPort => ({
   createHandle: (input): Promise<ChatHandleRepositoryRow> => createHandle(client, input),
   createMessageWithUpload: (input): Promise<CreateChatMessageWithUploadResult> =>
@@ -536,6 +571,8 @@ export const createPrismaChatRepository = (client: PrismaDatabaseClient): ChatRe
 
     return handle ? mapHandleRow(handle) : null;
   },
+  listParticipantsByRoomId: (roomId): Promise<readonly ChatRoomParticipantRepositoryRow[]> =>
+    listParticipantsByRoomId(client, roomId),
   listMessages: (_query: ChatMessageListQuery): Promise<readonly ChatMessageRepositoryRow[]> =>
     notImplemented("listMessages"),
   findUploadById: (_uploadId: string): Promise<ChatUploadRepositoryRow | null> =>

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -48,12 +48,14 @@ import type {
 } from "@/modules/auth/ports/inbound";
 import {
   createJoinChatRoomSessionUseCase,
+  createListChatRoomParticipantsUseCase,
   createModerateChatUploadRetentionUseCase,
   createOpenChatUploadMediaUseCase,
   createUploadChatMessageWithImageUseCase,
 } from "@/modules/chat/application";
 import type {
   JoinChatRoomSessionPort,
+  ListChatRoomParticipantsPort,
   ModerateChatUploadRetentionPort,
   OpenChatUploadMediaPort,
   UploadChatMessageWithImagePort,
@@ -101,6 +103,7 @@ export type BootstrapContainer = Readonly<{
   }>;
   chat: Readonly<{
     joinRoomSession?: JoinChatRoomSessionPort;
+    listRoomParticipants?: ListChatRoomParticipantsPort;
     moderateUploadRetention: ModerateChatUploadRetentionPort;
     openUploadMedia: OpenChatUploadMediaPort;
     uploadMessageWithImage: UploadChatMessageWithImagePort;
@@ -231,6 +234,9 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
             passwordHashParams: null,
             plainText,
           }),
+      }),
+      listRoomParticipants: createListChatRoomParticipantsUseCase({
+        repository: persistence.chat,
       }),
       moderateUploadRetention: createModerateChatUploadRetentionUseCase({
         repository: persistence.chat,

--- a/backend/src/modules/chat/application/index.test.ts
+++ b/backend/src/modules/chat/application/index.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from "bun:test";
 import {
   BannedChatHandleError,
   createJoinChatRoomSessionUseCase,
+  createListChatRoomParticipantsUseCase,
   createModerateChatUploadRetentionUseCase,
   createOpenChatUploadMediaUseCase,
   createUploadChatMessageWithImageUseCase,
+  InvalidChatParticipantAccessError,
   InvalidChatRoomCredentialsError,
   InvalidChatUploadAccessError,
 } from "./index";
@@ -172,6 +174,102 @@ describe("chat room join use case", () => {
         slug: "night-shift",
       }),
     ).rejects.toBeInstanceOf(BannedChatHandleError);
+  });
+});
+
+describe("chat participants list use case", () => {
+  it("returns participants only when session is active and bound to the room slug", async () => {
+    const useCase = createListChatRoomParticipantsUseCase({
+      repository: {
+        findRoomBySlug: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          id: "room_1",
+          passwordHash: "hash",
+          passwordRotatedAt: null,
+          passwordVersion: 1,
+          slug: "night-shift",
+          updatedAt: new Date("2026-04-28T12:00:00.000Z"),
+        }),
+        findSessionById: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          expiresAt: null,
+          handleId: "handle_1",
+          id: "session_1",
+          joinedAt: new Date("2026-04-28T12:00:00.000Z"),
+          lastSeenAt: new Date("2026-04-28T12:01:00.000Z"),
+          leftAt: null,
+          roomId: "room_1",
+          status: "active",
+          updatedAt: new Date("2026-04-28T12:01:00.000Z"),
+        }),
+        listParticipantsByRoomId: async (roomId) => [
+          {
+            handle: roomId === "room_1" ? "vinicius" : "unknown",
+            status: "online",
+          },
+          {
+            handle: "guest",
+            status: "idle",
+          },
+        ],
+      },
+    });
+
+    await expect(
+      useCase.execute({
+        roomSessionId: "session_1",
+        slug: "night-shift",
+      }),
+    ).resolves.toEqual({
+      items: [
+        {
+          handle: "vinicius",
+          status: "online",
+        },
+        {
+          handle: "guest",
+          status: "idle",
+        },
+      ],
+    });
+  });
+
+  it("rejects participants access when room session is invalid for the room slug", async () => {
+    const useCase = createListChatRoomParticipantsUseCase({
+      repository: {
+        findRoomBySlug: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          id: "room_1",
+          passwordHash: "hash",
+          passwordRotatedAt: null,
+          passwordVersion: 1,
+          slug: "night-shift",
+          updatedAt: new Date("2026-04-28T12:00:00.000Z"),
+        }),
+        findSessionById: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          expiresAt: null,
+          handleId: "handle_1",
+          id: "session_1",
+          joinedAt: new Date("2026-04-28T12:00:00.000Z"),
+          lastSeenAt: new Date("2026-04-28T12:01:00.000Z"),
+          leftAt: null,
+          roomId: "room_2",
+          status: "active",
+          updatedAt: new Date("2026-04-28T12:01:00.000Z"),
+        }),
+        listParticipantsByRoomId: async () => {
+          throw new Error("should not list participants");
+        },
+      },
+    });
+
+    await expect(
+      useCase.execute({
+        roomSessionId: "session_1",
+        slug: "night-shift",
+      }),
+    ).rejects.toBeInstanceOf(InvalidChatParticipantAccessError);
   });
 });
 

--- a/backend/src/modules/chat/application/index.ts
+++ b/backend/src/modules/chat/application/index.ts
@@ -8,6 +8,9 @@ import type {
   JoinChatRoomSessionInput,
   JoinChatRoomSessionOutput,
   JoinChatRoomSessionPort,
+  ListChatRoomParticipantsInput,
+  ListChatRoomParticipantsOutput,
+  ListChatRoomParticipantsPort,
   ModerateChatUploadRetentionInput,
   ModerateChatUploadRetentionOutput,
   ModerateChatUploadRetentionPort,
@@ -47,6 +50,13 @@ export class InvalidChatUploadAccessError extends Error {
   constructor() {
     super("chat upload access requires an active room session");
     this.name = "InvalidChatUploadAccessError";
+  }
+}
+
+export class InvalidChatParticipantAccessError extends Error {
+  constructor() {
+    super("chat participants access requires an active room session bound to the room");
+    this.name = "InvalidChatParticipantAccessError";
   }
 }
 
@@ -109,6 +119,13 @@ export type JoinChatRoomSessionDependencies = Readonly<{
     | "findRoomBySlug"
   >;
   verifyRoomPassword?: (input: Readonly<{ passwordHash: string; plainText: string }>) => Promise<boolean>;
+}>;
+
+export type ListChatRoomParticipantsDependencies = Readonly<{
+  repository: Pick<
+    ChatRepositoryPort,
+    "findRoomBySlug" | "findSessionById" | "listParticipantsByRoomId"
+  >;
 }>;
 
 export type ChatUploadMediaAccessDependencies = Readonly<{
@@ -203,6 +220,34 @@ export const createJoinChatRoomSessionUseCase = ({
         roomId: session.roomId,
         status: session.status,
       },
+    };
+  },
+});
+
+export const createListChatRoomParticipantsUseCase = ({
+  repository,
+}: ListChatRoomParticipantsDependencies): ListChatRoomParticipantsPort => ({
+  execute: async (
+    input: ListChatRoomParticipantsInput,
+  ): Promise<ListChatRoomParticipantsOutput> => {
+    const room = await repository.findRoomBySlug({
+      slug: input.slug.trim(),
+    });
+
+    if (!room) {
+      throw new InvalidChatParticipantAccessError();
+    }
+
+    const session = await repository.findSessionById(input.roomSessionId);
+
+    if (!session || session.status !== "active" || session.roomId !== room.id) {
+      throw new InvalidChatParticipantAccessError();
+    }
+
+    const items = await repository.listParticipantsByRoomId(room.id);
+
+    return {
+      items,
     };
   },
 });

--- a/backend/src/modules/chat/ports/inbound/index.ts
+++ b/backend/src/modules/chat/ports/inbound/index.ts
@@ -30,6 +30,23 @@ export type JoinChatRoomSessionOutput = Readonly<{
 export interface JoinChatRoomSessionPort
   extends UseCase<JoinChatRoomSessionInput, JoinChatRoomSessionOutput> {}
 
+export type ListChatRoomParticipantsInput = Readonly<{
+  roomSessionId: string;
+  slug: string;
+}>;
+
+export type ChatRoomParticipantOutput = Readonly<{
+  handle: string;
+  status: "online" | "idle";
+}>;
+
+export type ListChatRoomParticipantsOutput = Readonly<{
+  items: readonly ChatRoomParticipantOutput[];
+}>;
+
+export interface ListChatRoomParticipantsPort
+  extends UseCase<ListChatRoomParticipantsInput, ListChatRoomParticipantsOutput> {}
+
 export type UploadChatMessageImageInput = Readonly<{
   body: Uint8Array;
   displayFilename: string;

--- a/backend/src/modules/chat/ports/outbound/index.ts
+++ b/backend/src/modules/chat/ports/outbound/index.ts
@@ -31,6 +31,11 @@ export type ChatRoomSessionRepositoryRow = Readonly<{
   updatedAt: Date;
 }>;
 
+export type ChatRoomParticipantRepositoryRow = Readonly<{
+  handle: string;
+  status: "online" | "idle";
+}>;
+
 export type ChatMessageRepositoryRow = Readonly<{
   id: string;
   roomId: string;
@@ -143,6 +148,7 @@ export interface ChatRepositoryPort {
   findSessionById(sessionId: string): Promise<ChatRoomSessionRepositoryRow | null>;
   findRoomBySlug(query: ChatRoomQuery): Promise<ChatRoomRepositoryRow | null>;
   findHandleByRoomIdAndNormalizedHandle(roomId: string, normalizedHandle: string): Promise<ChatHandleRepositoryRow | null>;
+  listParticipantsByRoomId(roomId: string): Promise<readonly ChatRoomParticipantRepositoryRow[]>;
   listMessages(query: ChatMessageListQuery): Promise<readonly ChatMessageRepositoryRow[]>;
   findUploadById(uploadId: string): Promise<ChatUploadRepositoryRow | null>;
 }


### PR DESCRIPTION
## Summary
- implement CHAT-002 participants presence backend flow in the chat module
- add `GET /api/chat/rooms/:slug/participants` with `x-chat-room-session-id` guard and denied mapping
- add chat participant read-model use case and Prisma participant query
- preserve existing CHAT-001 join/session and chat upload/media behavior

## Files and Areas
- `backend/src/modules/chat/**` participants port + use case + tests
- `backend/src/adapters/outbound/persistence/prisma/chat-repository.ts` + tests
- `backend/src/adapters/inbound/http/hono/http-adapter.ts` participants route
- `backend/src/adapters/inbound/http/hono/chat-routes.test.ts` participants route coverage
- `backend/src/bootstrap/container/create-container.ts` wiring

## Verification
- `bun test backend/src/modules/chat/application/index.test.ts backend/src/adapters/inbound/http/hono/chat-routes.test.ts backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts`
- `bun run --cwd backend typecheck`
- `bun run --cwd backend test`
- `bun run --cwd backend verify`

Closes #72
