### PR TITLE
[CHAT-003] Implement chat message archive list and pagination contracts

### DIFF
--- a/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
@@ -4,6 +4,8 @@ import type { BootstrapContainer } from "@/bootstrap/container";
 import type {
   JoinChatRoomSessionInput,
   JoinChatRoomSessionOutput,
+  ListChatRoomMessagesInput,
+  ListChatRoomMessagesOutput,
   ListChatRoomParticipantsInput,
   ListChatRoomParticipantsOutput,
   UploadChatMessageWithImageInput,
@@ -11,6 +13,8 @@ import type {
 } from "@/modules/chat/ports/inbound";
 import {
   BannedChatHandleError,
+  InvalidChatMessageAccessError,
+  InvalidChatMessageCursorError,
   InvalidChatParticipantAccessError,
   InvalidChatRoomCredentialsError,
   InvalidChatUploadActorError,
@@ -42,6 +46,21 @@ const defaultParticipantsResponse: ListChatRoomParticipantsOutput = {
   ],
 };
 
+const defaultMessagesResponse: ListChatRoomMessagesOutput = {
+  items: [
+    {
+      author: "vinicius",
+      body: "late-night check-in",
+      id: "message_1",
+      sentAt: "2026-04-24T12:00:00.000Z",
+      tone: "pink",
+    },
+  ],
+  pageInfo: {
+    nextCursor: null,
+  },
+};
+
 const createTestContainer = ({
   executeJoin = async (): Promise<JoinChatRoomSessionOutput> => ({
     participant: {
@@ -63,6 +82,8 @@ const createTestContainer = ({
   }),
   executeParticipants = async (): Promise<ListChatRoomParticipantsOutput> =>
     defaultParticipantsResponse,
+  executeMessages = async (): Promise<ListChatRoomMessagesOutput> =>
+    defaultMessagesResponse,
   executeUpload = async (): Promise<UploadChatMessageWithImageOutput> => defaultUploadResponse,
 }: Readonly<{
   executeJoin?: (
@@ -71,6 +92,9 @@ const createTestContainer = ({
   executeParticipants?: (
     input: ListChatRoomParticipantsInput,
   ) => ListChatRoomParticipantsOutput | Promise<ListChatRoomParticipantsOutput>;
+  executeMessages?: (
+    input: ListChatRoomMessagesInput,
+  ) => ListChatRoomMessagesOutput | Promise<ListChatRoomMessagesOutput>;
   executeUpload?: (
     input: UploadChatMessageWithImageInput,
   ) => UploadChatMessageWithImageOutput | Promise<UploadChatMessageWithImageOutput>;
@@ -82,6 +106,9 @@ const createTestContainer = ({
     listRoomParticipants: {
       execute: executeParticipants,
     },
+    listRoomMessages: {
+      execute: executeMessages,
+    },
     moderateUploadRetention: {
       execute: async () => null,
     },
@@ -91,6 +118,12 @@ const createTestContainer = ({
     uploadMessageWithImage: {
       execute: executeUpload,
     },
+  } as BootstrapContainer["chat"] & {
+    listRoomMessages: {
+      execute: (
+        input: ListChatRoomMessagesInput,
+      ) => ListChatRoomMessagesOutput | Promise<ListChatRoomMessagesOutput>;
+    };
   },
   config: {
     auth: {
@@ -456,6 +489,185 @@ describe("chat routes", () => {
     await expect(response.json()).resolves.toEqual({
       error: "denied",
       resource: "chat",
+    });
+  });
+
+  it("maps a valid message archive request into the chat messages use case", async () => {
+    let capturedInput: ListChatRoomMessagesInput | undefined;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeMessages: async (input) => {
+          capturedInput = input;
+
+          return {
+            items: [
+              {
+                author: "vinicius",
+                body: "late-night check-in",
+                id: "message_2",
+                sentAt: "2026-04-24T12:02:00.000Z",
+                tone: "pink",
+              },
+              {
+                attachment: {
+                  byteSize: 1234,
+                  fileName: "scan.png",
+                  id: "upload_1",
+                  kind: "image",
+                  mimeType: "image/png",
+                },
+                author: "ghost-operator",
+                body: "drop archived",
+                id: "message_1",
+                sentAt: "2026-04-24T12:01:00.000Z",
+              },
+            ],
+            pageInfo: {
+              nextCursor: "cursor_1",
+            },
+          };
+        },
+      }),
+    );
+
+    const response = await app.request(
+      "/api/chat/rooms/night-shift/messages?cursor=cursor_0&limit=20",
+      {
+        headers: {
+          "x-chat-room-session-id": " session_1 ",
+        },
+        method: "GET",
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      items: [
+        {
+          author: "vinicius",
+          body: "late-night check-in",
+          id: "message_2",
+          sentAt: "2026-04-24T12:02:00.000Z",
+          tone: "pink",
+        },
+        {
+          attachment: {
+            byteSize: 1234,
+            fileName: "scan.png",
+            id: "upload_1",
+            kind: "image",
+            mimeType: "image/png",
+          },
+          author: "ghost-operator",
+          body: "drop archived",
+          id: "message_1",
+          sentAt: "2026-04-24T12:01:00.000Z",
+        },
+      ],
+      pageInfo: {
+        nextCursor: "cursor_1",
+      },
+    });
+    expect(capturedInput).toEqual({
+      cursor: "cursor_0",
+      limit: 20,
+      roomSessionId: "session_1",
+      slug: "night-shift",
+    });
+  });
+
+  it("rejects message archive requests with invalid limit query before calling the core", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeMessages: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/messages?limit=0", {
+      headers: {
+        "x-chat-room-session-id": "session_1",
+      },
+      method: "GET",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_query",
+      field: "limit",
+    });
+    expect(called).toBe(false);
+  });
+
+  it("rejects message archive requests missing room session header", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeMessages: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/messages", {
+      method: "GET",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_request",
+      field: "x-chat-room-session-id",
+    });
+    expect(called).toBe(false);
+  });
+
+  it("returns denied when archive access is invalid for the room session", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeMessages: async () => {
+          throw new InvalidChatMessageAccessError();
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/messages", {
+      headers: {
+        "x-chat-room-session-id": "session_1",
+      },
+      method: "GET",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "denied",
+      resource: "chat",
+    });
+  });
+
+  it("maps malformed archive cursor errors to invalid_query", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeMessages: async () => {
+          throw new InvalidChatMessageCursorError();
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/messages?cursor=bad", {
+      headers: {
+        "x-chat-room-session-id": "session_1",
+      },
+      method: "GET",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_query",
+      field: "cursor",
     });
   });
 

--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -10,13 +10,18 @@ import {
 import { InvalidAdminPhotoMetadataDateError } from "@/modules/admin/application";
 import {
   BannedChatHandleError,
+  InvalidChatMessageAccessError,
+  InvalidChatMessageCursorError,
   InvalidChatParticipantAccessError,
   InvalidChatRoomCredentialsError,
   InvalidChatUploadAccessError,
   InvalidChatUploadActorError,
 } from "@/modules/chat/application";
 import { InvalidThoughtCursorError } from "@/modules/content/application";
-import type { ChatUploadMimeType } from "@/modules/chat/ports/inbound";
+import type {
+  ChatUploadMimeType,
+  ListChatRoomMessagesPort,
+} from "@/modules/chat/ports/inbound";
 import type { ReplaceAdminStatusStripEntriesInput } from "@/modules/admin/ports/inbound";
 import type { BootstrapContainer } from "@/bootstrap/container";
 
@@ -552,6 +557,9 @@ const readRequiredJsonString = (
 
 const createChatFamily = (container: BootstrapContainer) => {
   const chatApp = new Hono();
+  const listRoomMessagesUseCase = (container.chat as {
+    listRoomMessages?: ListChatRoomMessagesPort;
+  }).listRoomMessages;
 
   chatApp.post("/rooms/:slug/join", async (c) => {
     if (!container.chat.joinRoomSession) {
@@ -684,6 +692,91 @@ const createChatFamily = (container: BootstrapContainer) => {
             resource: "chat",
           },
           403,
+        );
+      }
+
+      throw error;
+    }
+  });
+
+  chatApp.get("/rooms/:slug/messages", async (c) => {
+    if (!listRoomMessagesUseCase) {
+      return c.json<NotImplementedResponse>(
+        {
+          family: "chat",
+          method: c.req.method,
+          route: c.req.path,
+          service: serviceName,
+          status: "not_implemented",
+        },
+        501,
+      );
+    }
+
+    const slug = c.req.param("slug")?.trim();
+
+    if (!slug) {
+      return c.json(
+        {
+          error: "invalid_path",
+          field: "slug",
+        },
+        400,
+      );
+    }
+
+    const roomSessionId = c.req.header("x-chat-room-session-id")?.trim();
+
+    if (!roomSessionId) {
+      return c.json(
+        {
+          error: "invalid_request",
+          field: "x-chat-room-session-id",
+        },
+        400,
+      );
+    }
+
+    const { cursor, limit: rawLimit } = c.req.query();
+    const limit = parsePositiveInteger(rawLimit);
+
+    if (typeof rawLimit !== "undefined" && typeof limit === "undefined") {
+      return c.json(
+        {
+          error: "invalid_query",
+          field: "limit",
+        },
+        400,
+      );
+    }
+
+    try {
+      const response = await listRoomMessagesUseCase.execute({
+        cursor,
+        limit,
+        roomSessionId,
+        slug,
+      });
+
+      return c.json(response);
+    } catch (error) {
+      if (error instanceof InvalidChatMessageAccessError) {
+        return c.json(
+          {
+            error: "denied",
+            resource: "chat",
+          },
+          403,
+        );
+      }
+
+      if (error instanceof InvalidChatMessageCursorError) {
+        return c.json(
+          {
+            error: "invalid_query",
+            field: "cursor",
+          },
+          400,
         );
       }
 

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
@@ -130,6 +130,129 @@ describe("prisma chat repository", () => {
     ]);
   });
 
+  it("maps room message archive rows with cursor pagination and attachment metadata", async () => {
+    let capturedTake = -1;
+    let capturedWhere: Record<string, unknown> = {};
+    const repository = createPrismaChatRepository({
+      chatMessage: {
+        findMany: async ({
+          take,
+          where,
+        }: {
+          take: number;
+          where: Record<string, unknown>;
+        }) => {
+          capturedTake = take;
+          capturedWhere = where;
+
+          return [
+            {
+              authorHandle: {
+                handle: "vinicius",
+              },
+              body: "late-night check-in",
+              id: "message_3",
+              sentAt: new Date("2026-04-24T10:03:00.000Z"),
+              tone: "pink" as const,
+              upload: {
+                byteSize: 2048,
+                displayFilename: "drop.png",
+                id: "upload_1",
+                kind: "image" as const,
+                mimeType: "image_png" as const,
+                moderationState: "visible" as const,
+              },
+            },
+            {
+              authorHandle: {
+                handle: "ghost-operator",
+              },
+              body: "signal copy",
+              id: "message_2",
+              sentAt: new Date("2026-04-24T10:02:00.000Z"),
+              tone: null,
+              upload: {
+                byteSize: 1024,
+                displayFilename: "hidden.png",
+                id: "upload_hidden",
+                kind: "image" as const,
+                mimeType: "image_png" as const,
+                moderationState: "hidden" as const,
+              },
+            },
+            {
+              authorHandle: {
+                handle: "system",
+              },
+              body: "older row",
+              id: "message_1",
+              sentAt: new Date("2026-04-24T10:01:00.000Z"),
+              tone: "system" as const,
+              upload: null,
+            },
+          ];
+        },
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    const page = await repository.listMessages({
+      cursor: {
+        id: "message_5",
+        sentAt: new Date("2026-04-24T10:05:00.000Z"),
+      },
+      limit: 2,
+      roomId: "room_1",
+    });
+
+    expect(capturedTake).toBe(3);
+    expect(capturedWhere).toEqual({
+      OR: [
+        {
+          sentAt: {
+            lt: new Date("2026-04-24T10:05:00.000Z"),
+          },
+        },
+        {
+          id: {
+            lt: "message_5",
+          },
+          sentAt: new Date("2026-04-24T10:05:00.000Z"),
+        },
+      ],
+      moderationState: "visible",
+      roomId: "room_1",
+    });
+    expect(page).toEqual({
+      items: [
+        {
+          attachment: {
+            byteSize: 2048,
+            fileName: "drop.png",
+            id: "upload_1",
+            kind: "image",
+            mimeType: "image/png",
+          },
+          author: "vinicius",
+          body: "late-night check-in",
+          id: "message_3",
+          sentAt: new Date("2026-04-24T10:03:00.000Z"),
+          tone: "pink",
+        },
+        {
+          author: "ghost-operator",
+          body: "signal copy",
+          id: "message_2",
+          sentAt: new Date("2026-04-24T10:02:00.000Z"),
+          tone: null,
+        },
+      ],
+      nextCursor: {
+        id: "message_2",
+        sentAt: new Date("2026-04-24T10:02:00.000Z"),
+      },
+    });
+  });
+
   it("creates and maps a chat handle row", async () => {
     let capturedData: Record<string, unknown> | null = null;
     const repository = createPrismaChatRepository({

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
@@ -1,5 +1,7 @@
 import type {
   ChatHandleRepositoryRow,
+  ChatMessageListItemRepositoryRow,
+  ChatMessageListPage,
   ChatMessageListQuery,
   ChatMessageRepositoryRow,
   ChatRoomParticipantRepositoryRow,
@@ -501,6 +503,122 @@ const listParticipantsByRoomId = async (
   }));
 };
 
+const buildMessageCursorWhere = (
+  query: ChatMessageListQuery,
+):
+  | {
+      OR: Array<
+        | { sentAt: { lt: Date } }
+        | { id: { lt: string }; sentAt: Date }
+      >;
+    }
+  | undefined => {
+  if (!query.cursor) {
+    return undefined;
+  }
+
+  return {
+    OR: [
+      {
+        sentAt: {
+          lt: query.cursor.sentAt,
+        },
+      },
+      {
+        id: {
+          lt: query.cursor.id,
+        },
+        sentAt: query.cursor.sentAt,
+      },
+    ],
+  };
+};
+
+const mapMessageListRow = (row: {
+  authorHandle: {
+    handle: string;
+  };
+  body: string;
+  id: string;
+  sentAt: Date;
+  tone: "cyan" | "pink" | "system" | null;
+  upload: null | {
+    byteSize: number;
+    displayFilename: string;
+    id: string;
+    kind: "image";
+    mimeType: ChatUploadMimeType;
+    moderationState: "visible" | "hidden" | "deleted";
+  };
+}): ChatMessageListItemRepositoryRow => ({
+  ...(row.upload && row.upload.moderationState === "visible"
+    ? {
+        attachment: {
+          byteSize: row.upload.byteSize,
+          fileName: row.upload.displayFilename,
+          id: row.upload.id,
+          kind: row.upload.kind,
+          mimeType: mapUploadMimeTypeFromPrisma(row.upload.mimeType),
+        },
+      }
+    : {}),
+  author: row.authorHandle.handle,
+  body: row.body,
+  id: row.id,
+  sentAt: row.sentAt,
+  tone: row.tone,
+});
+
+const listMessages = async (
+  client: PrismaDatabaseClient,
+  query: ChatMessageListQuery,
+): Promise<ChatMessageListPage> => {
+  const rows = await client.chatMessage.findMany({
+    orderBy: [{ sentAt: "desc" }, { id: "desc" }],
+    select: {
+      authorHandle: {
+        select: {
+          handle: true,
+        },
+      },
+      body: true,
+      id: true,
+      sentAt: true,
+      tone: true,
+      upload: {
+        select: {
+          byteSize: true,
+          displayFilename: true,
+          id: true,
+          kind: true,
+          mimeType: true,
+          moderationState: true,
+        },
+      },
+    },
+    take: query.limit + 1,
+    where: {
+      ...buildMessageCursorWhere(query),
+      moderationState: "visible",
+      roomId: query.roomId,
+    },
+  });
+
+  const pageRows = rows.slice(0, query.limit);
+  const hasNextPage = rows.length > query.limit;
+  const nextCursorRow = pageRows.at(pageRows.length - 1);
+
+  return {
+    items: pageRows.map(mapMessageListRow),
+    nextCursor: hasNextPage && nextCursorRow
+      ? {
+          id: nextCursorRow.id,
+          sentAt: nextCursorRow.sentAt,
+        }
+      : null,
+  };
+};
+
 export const createPrismaChatRepository = (client: PrismaDatabaseClient): ChatRepositoryPort => ({
   createHandle: (input): Promise<ChatHandleRepositoryRow> => createHandle(client, input),
   createMessageWithUpload: (input): Promise<CreateChatMessageWithUploadResult> =>
@@ -573,8 +691,8 @@ export const createPrismaChatRepository = (client: PrismaDatabaseClient): ChatRe
   },
   listParticipantsByRoomId: (roomId): Promise<readonly ChatRoomParticipantRepositoryRow[]> =>
     listParticipantsByRoomId(client, roomId),
-  listMessages: (_query: ChatMessageListQuery): Promise<readonly ChatMessageRepositoryRow[]> =>
-    notImplemented("listMessages"),
+  listMessages: (query: ChatMessageListQuery): Promise<ChatMessageListPage> =>
+    listMessages(client, query),
   findUploadById: (_uploadId: string): Promise<ChatUploadRepositoryRow | null> =>
     notImplemented("findUploadById"),
 });

--- a/backend/src/bootstrap/container/create-container.test.ts
+++ b/backend/src/bootstrap/container/create-container.test.ts
@@ -13,6 +13,7 @@ describe("bootstrap container", () => {
     expect(typeof container.chat.moderateUploadRetention.execute).toBe("function");
     expect(typeof container.chat.openUploadMedia.execute).toBe("function");
     expect(typeof container.chat.joinRoomSession?.execute).toBe("function");
+    expect(typeof container.chat.listRoomMessages?.execute).toBe("function");
     expect(typeof container.media.repository.findPhotoMediaById).toBe("function");
     expect(typeof container.media.repository.findChatUploadMediaById).toBe("function");
     expect(typeof container.media.storage.photos.openOriginal).toBe("function");

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -48,6 +48,7 @@ import type {
 } from "@/modules/auth/ports/inbound";
 import {
   createJoinChatRoomSessionUseCase,
+  createListChatRoomMessagesUseCase,
   createListChatRoomParticipantsUseCase,
   createModerateChatUploadRetentionUseCase,
   createOpenChatUploadMediaUseCase,
@@ -55,6 +56,7 @@ import {
 } from "@/modules/chat/application";
 import type {
   JoinChatRoomSessionPort,
+  ListChatRoomMessagesPort,
   ListChatRoomParticipantsPort,
   ModerateChatUploadRetentionPort,
   OpenChatUploadMediaPort,
@@ -103,6 +105,7 @@ export type BootstrapContainer = Readonly<{
   }>;
   chat: Readonly<{
     joinRoomSession?: JoinChatRoomSessionPort;
+    listRoomMessages?: ListChatRoomMessagesPort;
     listRoomParticipants?: ListChatRoomParticipantsPort;
     moderateUploadRetention: ModerateChatUploadRetentionPort;
     openUploadMedia: OpenChatUploadMediaPort;
@@ -236,6 +239,9 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
           }),
       }),
       listRoomParticipants: createListChatRoomParticipantsUseCase({
+        repository: persistence.chat,
+      }),
+      listRoomMessages: createListChatRoomMessagesUseCase({
         repository: persistence.chat,
       }),
       moderateUploadRetention: createModerateChatUploadRetentionUseCase({

--- a/backend/src/modules/chat/application/index.test.ts
+++ b/backend/src/modules/chat/application/index.test.ts
@@ -3,10 +3,13 @@ import { describe, expect, it } from "bun:test";
 import {
   BannedChatHandleError,
   createJoinChatRoomSessionUseCase,
+  createListChatRoomMessagesUseCase,
   createListChatRoomParticipantsUseCase,
   createModerateChatUploadRetentionUseCase,
   createOpenChatUploadMediaUseCase,
   createUploadChatMessageWithImageUseCase,
+  InvalidChatMessageAccessError,
+  InvalidChatMessageCursorError,
   InvalidChatParticipantAccessError,
   InvalidChatRoomCredentialsError,
   InvalidChatUploadAccessError,
@@ -270,6 +273,196 @@ describe("chat participants list use case", () => {
         slug: "night-shift",
       }),
     ).rejects.toBeInstanceOf(InvalidChatParticipantAccessError);
+  });
+});
+
+describe("chat message archive list use case", () => {
+  it("returns cursor-paginated messages for an active room session bound to the room slug", async () => {
+    let capturedLimit: number | undefined;
+    const useCase = createListChatRoomMessagesUseCase({
+      repository: {
+        findRoomBySlug: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          id: "room_1",
+          passwordHash: "hash",
+          passwordRotatedAt: null,
+          passwordVersion: 1,
+          slug: "night-shift",
+          updatedAt: new Date("2026-04-28T12:00:00.000Z"),
+        }),
+        findSessionById: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          expiresAt: null,
+          handleId: "handle_1",
+          id: "session_1",
+          joinedAt: new Date("2026-04-28T12:00:00.000Z"),
+          lastSeenAt: new Date("2026-04-28T12:01:00.000Z"),
+          leftAt: null,
+          roomId: "room_1",
+          status: "active",
+          updatedAt: new Date("2026-04-28T12:01:00.000Z"),
+        }),
+        listMessages: async (input) => {
+          capturedLimit = input.limit;
+
+          return {
+            items: [
+              {
+                attachment: {
+                  byteSize: 2048,
+                  fileName: "bunker.jpg",
+                  id: "upload_1",
+                  kind: "image",
+                  mimeType: "image/jpeg",
+                },
+                author: "vinicius",
+                body: "late-night check-in",
+                id: "message_2",
+                sentAt: new Date("2026-04-28T12:03:00.000Z"),
+                tone: "pink",
+              },
+              {
+                author: "ghost-operator",
+                body: "channel stable",
+                id: "message_1",
+                sentAt: new Date("2026-04-28T12:02:00.000Z"),
+                tone: null,
+              },
+            ],
+            nextCursor: {
+              id: "message_0",
+              sentAt: new Date("2026-04-28T12:01:00.000Z"),
+            },
+          };
+        },
+      },
+    });
+
+    const result = await useCase.execute({
+      cursor: Buffer.from(
+        JSON.stringify({
+          id: "message_4",
+          sentAt: "2026-04-28T12:10:00.000Z",
+        }),
+        "utf8",
+      ).toString("base64url"),
+      limit: 2,
+      roomSessionId: "session_1",
+      slug: "night-shift",
+    });
+
+    expect(capturedLimit).toBe(2);
+    expect(result).toEqual({
+      items: [
+        {
+          attachment: {
+            byteSize: 2048,
+            fileName: "bunker.jpg",
+            id: "upload_1",
+            kind: "image",
+            mimeType: "image/jpeg",
+          },
+          author: "vinicius",
+          body: "late-night check-in",
+          id: "message_2",
+          sentAt: "2026-04-28T12:03:00.000Z",
+          tone: "pink",
+        },
+        {
+          author: "ghost-operator",
+          body: "channel stable",
+          id: "message_1",
+          sentAt: "2026-04-28T12:02:00.000Z",
+        },
+      ],
+      pageInfo: {
+        nextCursor: Buffer.from(
+          JSON.stringify({
+            id: "message_0",
+            sentAt: "2026-04-28T12:01:00.000Z",
+          }),
+          "utf8",
+        ).toString("base64url"),
+      },
+    });
+  });
+
+  it("rejects archive access when room session is invalid for the room slug", async () => {
+    const useCase = createListChatRoomMessagesUseCase({
+      repository: {
+        findRoomBySlug: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          id: "room_1",
+          passwordHash: "hash",
+          passwordRotatedAt: null,
+          passwordVersion: 1,
+          slug: "night-shift",
+          updatedAt: new Date("2026-04-28T12:00:00.000Z"),
+        }),
+        findSessionById: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          expiresAt: null,
+          handleId: "handle_1",
+          id: "session_1",
+          joinedAt: new Date("2026-04-28T12:00:00.000Z"),
+          lastSeenAt: new Date("2026-04-28T12:01:00.000Z"),
+          leftAt: null,
+          roomId: "room_2",
+          status: "active",
+          updatedAt: new Date("2026-04-28T12:01:00.000Z"),
+        }),
+        listMessages: async () => {
+          throw new Error("should not list messages");
+        },
+      },
+    });
+
+    await expect(
+      useCase.execute({
+        roomSessionId: "session_1",
+        slug: "night-shift",
+      }),
+    ).rejects.toBeInstanceOf(InvalidChatMessageAccessError);
+  });
+
+  it("rejects archive access when cursor is malformed", async () => {
+    const useCase = createListChatRoomMessagesUseCase({
+      repository: {
+        findRoomBySlug: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          id: "room_1",
+          passwordHash: "hash",
+          passwordRotatedAt: null,
+          passwordVersion: 1,
+          slug: "night-shift",
+          updatedAt: new Date("2026-04-28T12:00:00.000Z"),
+        }),
+        findSessionById: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          expiresAt: null,
+          handleId: "handle_1",
+          id: "session_1",
+          joinedAt: new Date("2026-04-28T12:00:00.000Z"),
+          lastSeenAt: new Date("2026-04-28T12:01:00.000Z"),
+          leftAt: null,
+          roomId: "room_1",
+          status: "active",
+          updatedAt: new Date("2026-04-28T12:01:00.000Z"),
+        }),
+        listMessages: async () => ({
+          items: [],
+          nextCursor: null,
+        }),
+      },
+    });
+
+    await expect(
+      useCase.execute({
+        cursor: "invalid-cursor",
+        roomSessionId: "session_1",
+        slug: "night-shift",
+      }),
+    ).rejects.toBeInstanceOf(InvalidChatMessageCursorError);
   });
 });
 

--- a/backend/src/modules/chat/application/index.ts
+++ b/backend/src/modules/chat/application/index.ts
@@ -5,9 +5,13 @@ import type {
 import type { ChatRepositoryPort } from "@/modules/chat/ports/outbound";
 import type {
   ChatUploadMimeType,
+  ChatRoomMessageOutput,
   JoinChatRoomSessionInput,
   JoinChatRoomSessionOutput,
   JoinChatRoomSessionPort,
+  ListChatRoomMessagesInput,
+  ListChatRoomMessagesOutput,
+  ListChatRoomMessagesPort,
   ListChatRoomParticipantsInput,
   ListChatRoomParticipantsOutput,
   ListChatRoomParticipantsPort,
@@ -60,6 +64,20 @@ export class InvalidChatParticipantAccessError extends Error {
   }
 }
 
+export class InvalidChatMessageAccessError extends Error {
+  constructor() {
+    super("chat message access requires an active room session bound to the room");
+    this.name = "InvalidChatMessageAccessError";
+  }
+}
+
+export class InvalidChatMessageCursorError extends Error {
+  constructor() {
+    super("chat message cursor is invalid");
+    this.name = "InvalidChatMessageCursorError";
+  }
+}
+
 const MIME_EXTENSION_BY_TYPE: Record<ChatUploadMimeType, string> = {
   "image/jpeg": "jpg",
   "image/png": "png",
@@ -88,6 +106,9 @@ const buildStorageKey = (roomId: string, uploadId: string, mimeType: ChatUploadM
 const collapseWhitespace = (value: string): string => value.trim().replace(/\s+/g, " ");
 
 const normalizeHandle = (value: string): string => collapseWhitespace(value).toLowerCase();
+
+const DEFAULT_CHAT_MESSAGES_PAGE_SIZE = 30;
+const MAX_CHAT_MESSAGES_PAGE_SIZE = 80;
 
 const defaultSessionToken = (): string => crypto.randomUUID();
 
@@ -128,6 +149,10 @@ export type ListChatRoomParticipantsDependencies = Readonly<{
   >;
 }>;
 
+export type ListChatRoomMessagesDependencies = Readonly<{
+  repository: Pick<ChatRepositoryPort, "findRoomBySlug" | "findSessionById" | "listMessages">;
+}>;
+
 export type ChatUploadMediaAccessDependencies = Readonly<{
   repository: Pick<ChatRepositoryPort, "findSessionById">;
   mediaRepository: Pick<MediaRepositoryPort, "findChatUploadMediaById">;
@@ -138,6 +163,80 @@ export type ChatUploadRetentionDependencies = Readonly<{
   clock?: () => Date;
   repository: Pick<ChatRepositoryPort, "moderateUploadRetention">;
 }>;
+
+const normalizeListMessagesLimit = (inputLimit: number | undefined): number => {
+  if (typeof inputLimit !== "number" || Number.isNaN(inputLimit)) {
+    return DEFAULT_CHAT_MESSAGES_PAGE_SIZE;
+  }
+
+  return Math.min(Math.max(Math.trunc(inputLimit), 1), MAX_CHAT_MESSAGES_PAGE_SIZE);
+};
+
+const encodeChatMessageCursor = (cursor: Readonly<{ id: string; sentAt: Date }>): string => {
+  return Buffer.from(
+    JSON.stringify({
+      id: cursor.id,
+      sentAt: cursor.sentAt.toISOString(),
+    }),
+    "utf8",
+  ).toString("base64url");
+};
+
+const decodeChatMessageCursor = (input: string): Readonly<{ id: string; sentAt: Date }> => {
+  try {
+    const parsed = JSON.parse(Buffer.from(input, "base64url").toString("utf8")) as {
+      id?: unknown;
+      sentAt?: unknown;
+    };
+
+    if (typeof parsed.id !== "string" || typeof parsed.sentAt !== "string") {
+      throw new InvalidChatMessageCursorError();
+    }
+
+    const sentAt = new Date(parsed.sentAt);
+
+    if (Number.isNaN(sentAt.getTime())) {
+      throw new InvalidChatMessageCursorError();
+    }
+
+    return {
+      id: parsed.id,
+      sentAt,
+    };
+  } catch (_error) {
+    throw new InvalidChatMessageCursorError();
+  }
+};
+
+const mapChatMessageOutput = (input: Readonly<{
+  attachment?: Readonly<{
+    byteSize: number;
+    fileName: string;
+    id: string;
+    kind: "image";
+    mimeType: ChatUploadMimeType;
+  }>;
+  author: string;
+  body: string;
+  id: string;
+  sentAt: Date;
+  tone: "cyan" | "pink" | "system" | null;
+}>): ChatRoomMessageOutput => ({
+  ...(input.attachment
+    ? {
+        attachment: input.attachment,
+      }
+    : {}),
+  ...(input.tone
+    ? {
+        tone: input.tone,
+      }
+    : {}),
+  author: input.author,
+  body: input.body,
+  id: input.id,
+  sentAt: input.sentAt.toISOString(),
+});
 
 export const createJoinChatRoomSessionUseCase = ({
   clock = () => new Date(),
@@ -248,6 +347,41 @@ export const createListChatRoomParticipantsUseCase = ({
 
     return {
       items,
+    };
+  },
+});
+
+export const createListChatRoomMessagesUseCase = ({
+  repository,
+}: ListChatRoomMessagesDependencies): ListChatRoomMessagesPort => ({
+  execute: async (
+    input: ListChatRoomMessagesInput,
+  ): Promise<ListChatRoomMessagesOutput> => {
+    const room = await repository.findRoomBySlug({
+      slug: input.slug.trim(),
+    });
+
+    if (!room) {
+      throw new InvalidChatMessageAccessError();
+    }
+
+    const session = await repository.findSessionById(input.roomSessionId);
+
+    if (!session || session.status !== "active" || session.roomId !== room.id) {
+      throw new InvalidChatMessageAccessError();
+    }
+
+    const page = await repository.listMessages({
+      cursor: input.cursor ? decodeChatMessageCursor(input.cursor) : undefined,
+      limit: normalizeListMessagesLimit(input.limit),
+      roomId: room.id,
+    });
+
+    return {
+      items: page.items.map((item) => mapChatMessageOutput(item)),
+      pageInfo: {
+        nextCursor: page.nextCursor ? encodeChatMessageCursor(page.nextCursor) : null,
+      },
     };
   },
 });

--- a/backend/src/modules/chat/ports/inbound/index.ts
+++ b/backend/src/modules/chat/ports/inbound/index.ts
@@ -47,6 +47,40 @@ export type ListChatRoomParticipantsOutput = Readonly<{
 export interface ListChatRoomParticipantsPort
   extends UseCase<ListChatRoomParticipantsInput, ListChatRoomParticipantsOutput> {}
 
+export type ListChatRoomMessagesInput = Readonly<{
+  cursor?: string;
+  limit?: number;
+  roomSessionId: string;
+  slug: string;
+}>;
+
+export type ChatMessageAttachmentOutput = Readonly<{
+  byteSize: number;
+  fileName: string;
+  id: string;
+  kind: "image";
+  mimeType: ChatUploadMimeType;
+}>;
+
+export type ChatRoomMessageOutput = Readonly<{
+  attachment?: ChatMessageAttachmentOutput;
+  author: string;
+  body: string;
+  id: string;
+  sentAt: string;
+  tone?: "cyan" | "pink" | "system";
+}>;
+
+export type ListChatRoomMessagesOutput = Readonly<{
+  items: readonly ChatRoomMessageOutput[];
+  pageInfo: Readonly<{
+    nextCursor: string | null;
+  }>;
+}>;
+
+export interface ListChatRoomMessagesPort
+  extends UseCase<ListChatRoomMessagesInput, ListChatRoomMessagesOutput> {}
+
 export type UploadChatMessageImageInput = Readonly<{
   body: Uint8Array;
   displayFilename: string;
@@ -62,16 +96,8 @@ export type UploadChatMessageWithImageInput = Readonly<{
   tone?: "cyan" | "pink" | "system" | null;
 }>;
 
-export type UploadChatMessageAttachment = Readonly<{
-  byteSize: number;
-  fileName: string;
-  id: string;
-  kind: "image";
-  mimeType: ChatUploadMimeType;
-}>;
-
 export type UploadChatMessageWithImageOutput = Readonly<{
-  attachment: UploadChatMessageAttachment;
+  attachment: ChatMessageAttachmentOutput;
   authorHandleId: string;
   body: string;
   id: string;

--- a/backend/src/modules/chat/ports/outbound/index.ts
+++ b/backend/src/modules/chat/ports/outbound/index.ts
@@ -51,6 +51,28 @@ export type ChatMessageRepositoryRow = Readonly<{
   updatedAt: Date;
 }>;
 
+export type ChatMessageAttachmentRepositoryRow = Readonly<{
+  byteSize: number;
+  fileName: string;
+  id: string;
+  kind: "image";
+  mimeType: "image/jpeg" | "image/png" | "image/webp";
+}>;
+
+export type ChatMessageListItemRepositoryRow = Readonly<{
+  attachment?: ChatMessageAttachmentRepositoryRow;
+  author: string;
+  body: string;
+  id: string;
+  sentAt: Date;
+  tone: "cyan" | "pink" | "system" | null;
+}>;
+
+export type ChatMessageCursor = Readonly<{
+  id: string;
+  sentAt: Date;
+}>;
+
 export type ChatUploadRepositoryRow = Readonly<{
   id: string;
   roomId: string;
@@ -130,10 +152,14 @@ export type ChatRoomQuery = Readonly<{
 }>;
 
 export type ChatMessageListQuery = Readonly<{
+  cursor?: ChatMessageCursor;
+  limit: number;
   roomId: string;
-  roomSessionId?: string;
-  cursor?: string;
-  limit?: number;
+}>;
+
+export type ChatMessageListPage = Readonly<{
+  items: readonly ChatMessageListItemRepositoryRow[];
+  nextCursor: ChatMessageCursor | null;
 }>;
 
 export interface ChatRepositoryPort {
@@ -149,6 +175,6 @@ export interface ChatRepositoryPort {
   findRoomBySlug(query: ChatRoomQuery): Promise<ChatRoomRepositoryRow | null>;
   findHandleByRoomIdAndNormalizedHandle(roomId: string, normalizedHandle: string): Promise<ChatHandleRepositoryRow | null>;
   listParticipantsByRoomId(roomId: string): Promise<readonly ChatRoomParticipantRepositoryRow[]>;
-  listMessages(query: ChatMessageListQuery): Promise<readonly ChatMessageRepositoryRow[]>;
+  listMessages(query: ChatMessageListQuery): Promise<ChatMessageListPage>;
   findUploadById(uploadId: string): Promise<ChatUploadRepositoryRow | null>;
 }


### PR DESCRIPTION
## Summary
- implement CHAT-003 room message archive list + cursor pagination backend flow
- add `GET /api/chat/rooms/:slug/messages` guarded by `x-chat-room-session-id`
- add chat message archive use case + cursor encode/decode and validation
- implement Prisma room message pagination query and message/attachment mapping
- preserve existing CHAT-001/CHAT-002 behavior for join, participants, upload, and media

## Files and Areas
- `backend/src/modules/chat/**` message archive ports + use case + tests
- `backend/src/adapters/outbound/persistence/prisma/chat-repository.ts` + tests
- `backend/src/adapters/inbound/http/hono/http-adapter.ts` message archive route
- `backend/src/adapters/inbound/http/hono/chat-routes.test.ts` archive route coverage
- `backend/src/bootstrap/container/create-container.ts` wiring

## Verification
- `bun test backend/src/modules/chat/application/index.test.ts backend/src/adapters/inbound/http/hono/chat-routes.test.ts backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts backend/src/bootstrap/container/create-container.test.ts`
- `bun run --cwd backend typecheck`
- `bun run --cwd backend test`
- `bun run --cwd backend verify`

Closes #73
