### PR TITLE
[CHAT-004] Implement chat text message send flow

### DIFF
--- a/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
@@ -8,6 +8,8 @@ import type {
   ListChatRoomMessagesOutput,
   ListChatRoomParticipantsInput,
   ListChatRoomParticipantsOutput,
+  SendChatRoomTextMessageInput,
+  SendChatRoomTextMessageOutput,
   UploadChatMessageWithImageInput,
   UploadChatMessageWithImageOutput,
 } from "@/modules/chat/ports/inbound";
@@ -61,6 +63,14 @@ const defaultMessagesResponse: ListChatRoomMessagesOutput = {
   },
 };
 
+const defaultTextMessageResponse: SendChatRoomTextMessageOutput = {
+  author: "vinicius",
+  body: "message body",
+  id: "message_2",
+  sentAt: "2026-04-24T12:01:00.000Z",
+  tone: "cyan",
+};
+
 const createTestContainer = ({
   executeJoin = async (): Promise<JoinChatRoomSessionOutput> => ({
     participant: {
@@ -84,6 +94,8 @@ const createTestContainer = ({
     defaultParticipantsResponse,
   executeMessages = async (): Promise<ListChatRoomMessagesOutput> =>
     defaultMessagesResponse,
+  executeSendText = async (): Promise<SendChatRoomTextMessageOutput> =>
+    defaultTextMessageResponse,
   executeUpload = async (): Promise<UploadChatMessageWithImageOutput> => defaultUploadResponse,
 }: Readonly<{
   executeJoin?: (
@@ -95,6 +107,9 @@ const createTestContainer = ({
   executeMessages?: (
     input: ListChatRoomMessagesInput,
   ) => ListChatRoomMessagesOutput | Promise<ListChatRoomMessagesOutput>;
+  executeSendText?: (
+    input: SendChatRoomTextMessageInput,
+  ) => SendChatRoomTextMessageOutput | Promise<SendChatRoomTextMessageOutput>;
   executeUpload?: (
     input: UploadChatMessageWithImageInput,
   ) => UploadChatMessageWithImageOutput | Promise<UploadChatMessageWithImageOutput>;
@@ -108,6 +123,9 @@ const createTestContainer = ({
     },
     listRoomMessages: {
       execute: executeMessages,
+    },
+    sendRoomTextMessage: {
+      execute: executeSendText,
     },
     moderateUploadRetention: {
       execute: async () => null,
@@ -123,6 +141,11 @@ const createTestContainer = ({
       execute: (
         input: ListChatRoomMessagesInput,
       ) => ListChatRoomMessagesOutput | Promise<ListChatRoomMessagesOutput>;
+    };
+    sendRoomTextMessage: {
+      execute: (
+        input: SendChatRoomTextMessageInput,
+      ) => SendChatRoomTextMessageOutput | Promise<SendChatRoomTextMessageOutput>;
     };
   },
   config: {
@@ -668,6 +691,141 @@ describe("chat routes", () => {
     await expect(response.json()).resolves.toEqual({
       error: "invalid_query",
       field: "cursor",
+    });
+  });
+
+  it("maps a valid text message request into the send-text use case", async () => {
+    let capturedInput: SendChatRoomTextMessageInput | undefined;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeSendText: async (input) => {
+          capturedInput = input;
+
+          return {
+            author: "vinicius",
+            body: "from the bunker",
+            id: "message_3",
+            sentAt: "2026-04-24T12:03:00.000Z",
+            tone: "system",
+          };
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/messages", {
+      body: JSON.stringify({
+        body: "  from the bunker  ",
+        tone: "system",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-chat-room-session-id": " session_1 ",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      item: {
+        author: "vinicius",
+        body: "from the bunker",
+        id: "message_3",
+        sentAt: "2026-04-24T12:03:00.000Z",
+        tone: "system",
+      },
+    });
+    expect(capturedInput).toEqual({
+      body: "from the bunker",
+      roomSessionId: "session_1",
+      slug: "night-shift",
+      tone: "system",
+    });
+  });
+
+  it("rejects text message requests missing room session header", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeSendText: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/messages", {
+      body: JSON.stringify({
+        body: "message body",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_request",
+      field: "x-chat-room-session-id",
+    });
+    expect(called).toBe(false);
+  });
+
+  it("rejects text message requests with invalid tone before calling the core", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeSendText: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/messages", {
+      body: JSON.stringify({
+        body: "message body",
+        tone: "violet",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-chat-room-session-id": "session_1",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_request",
+      field: "tone",
+    });
+    expect(called).toBe(false);
+  });
+
+  it("returns denied when text message access is invalid for the room session", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeSendText: async () => {
+          throw new InvalidChatMessageAccessError();
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/messages", {
+      body: JSON.stringify({
+        body: "message body",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-chat-room-session-id": "session_1",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "denied",
+      resource: "chat",
     });
   });
 

--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -21,6 +21,7 @@ import { InvalidThoughtCursorError } from "@/modules/content/application";
 import type {
   ChatUploadMimeType,
   ListChatRoomMessagesPort,
+  SendChatRoomTextMessagePort,
 } from "@/modules/chat/ports/inbound";
 import type { ReplaceAdminStatusStripEntriesInput } from "@/modules/admin/ports/inbound";
 import type { BootstrapContainer } from "@/bootstrap/container";
@@ -560,6 +561,9 @@ const createChatFamily = (container: BootstrapContainer) => {
   const listRoomMessagesUseCase = (container.chat as {
     listRoomMessages?: ListChatRoomMessagesPort;
   }).listRoomMessages;
+  const sendRoomTextMessageUseCase = (container.chat as {
+    sendRoomTextMessage?: SendChatRoomTextMessagePort;
+  }).sendRoomTextMessage;
 
   chatApp.post("/rooms/:slug/join", async (c) => {
     if (!container.chat.joinRoomSession) {
@@ -777,6 +781,102 @@ const createChatFamily = (container: BootstrapContainer) => {
             field: "cursor",
           },
           400,
+        );
+      }
+
+      throw error;
+    }
+  });
+
+  chatApp.post("/rooms/:slug/messages", async (c) => {
+    if (!sendRoomTextMessageUseCase) {
+      return c.json<NotImplementedResponse>(
+        {
+          family: "chat",
+          method: c.req.method,
+          route: c.req.path,
+          service: serviceName,
+          status: "not_implemented",
+        },
+        501,
+      );
+    }
+
+    const slug = c.req.param("slug")?.trim();
+
+    if (!slug) {
+      return c.json(
+        {
+          error: "invalid_path",
+          field: "slug",
+        },
+        400,
+      );
+    }
+
+    const roomSessionId = c.req.header("x-chat-room-session-id")?.trim();
+
+    if (!roomSessionId) {
+      return c.json(
+        {
+          error: "invalid_request",
+          field: "x-chat-room-session-id",
+        },
+        400,
+      );
+    }
+
+    const parsedBody = await readJsonObject(c.req.raw);
+
+    if ("error" in parsedBody) {
+      return c.json(parsedBody.error, 400);
+    }
+
+    const body = readRequiredJsonString(parsedBody.value, "body");
+
+    if ("error" in body) {
+      return c.json(body.error, 400);
+    }
+
+    const toneInput = parsedBody.value.tone;
+
+    if (
+      typeof toneInput !== "undefined" &&
+      toneInput !== "cyan" &&
+      toneInput !== "pink" &&
+      toneInput !== "system"
+    ) {
+      return c.json(
+        {
+          error: "invalid_request",
+          field: "tone",
+        },
+        400,
+      );
+    }
+
+    try {
+      const response = await sendRoomTextMessageUseCase.execute({
+        body: body.value,
+        roomSessionId,
+        slug,
+        tone: toneInput,
+      });
+
+      return c.json(
+        {
+          item: response,
+        },
+        201,
+      );
+    } catch (error) {
+      if (error instanceof InvalidChatMessageAccessError) {
+        return c.json(
+          {
+            error: "denied",
+            resource: "chat",
+          },
+          403,
         );
       }
 

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
@@ -90,6 +90,32 @@ describe("prisma chat repository", () => {
     });
   });
 
+  it("maps handle lookup by id", async () => {
+    const repository = createPrismaChatRepository({
+      chatHandle: {
+        findUnique: async () => ({
+          createdAt: new Date("2026-04-24T10:00:00.000Z"),
+          handle: "Vinicius",
+          id: "handle_1",
+          normalizedHandle: "vinicius",
+          roomId: "room_1",
+          status: "active" as const,
+          updatedAt: new Date("2026-04-24T10:05:00.000Z"),
+        }),
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    await expect(repository.findHandleById("handle_1")).resolves.toEqual({
+      createdAt: new Date("2026-04-24T10:00:00.000Z"),
+      handle: "Vinicius",
+      id: "handle_1",
+      normalizedHandle: "vinicius",
+      roomId: "room_1",
+      status: "active",
+      updatedAt: new Date("2026-04-24T10:05:00.000Z"),
+    });
+  });
+
   it("maps room participants with online/idle status", async () => {
     let capturedWhere: Record<string, unknown> | null = null;
     const repository = createPrismaChatRepository({
@@ -355,6 +381,66 @@ describe("prisma chat repository", () => {
       roomId: "room_1",
       status: "active",
       updatedAt: new Date("2026-04-24T10:05:00.000Z"),
+    });
+  });
+
+  it("creates and maps a text chat message row", async () => {
+    let capturedData: Record<string, unknown> | null = null;
+    const repository = createPrismaChatRepository({
+      chatMessage: {
+        create: async ({ data }: { data: Record<string, unknown> }) => {
+          capturedData = data;
+
+          return {
+            authorHandleId: "handle_1",
+            body: "from the bunker",
+            createdAt: new Date("2026-04-24T10:00:00.000Z"),
+            deletedAt: null,
+            hiddenAt: null,
+            id: "message_2",
+            moderationState: "visible" as const,
+            roomId: "room_1",
+            roomSessionId: "session_1",
+            sentAt: new Date("2026-04-24T10:00:00.000Z"),
+            tone: "system" as const,
+            updatedAt: new Date("2026-04-24T10:00:00.000Z"),
+          };
+        },
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    const sentAt = new Date("2026-04-24T10:00:00.000Z");
+    const result = await repository.createTextMessage({
+      authorHandleId: "handle_1",
+      body: "from the bunker",
+      roomId: "room_1",
+      roomSessionId: "session_1",
+      sentAt,
+      tone: "system",
+    });
+
+    expect(capturedData).not.toBeNull();
+    expect(capturedData!).toEqual({
+      authorHandleId: "handle_1",
+      body: "from the bunker",
+      roomId: "room_1",
+      roomSessionId: "session_1",
+      sentAt,
+      tone: "system",
+    });
+    expect(result).toEqual({
+      authorHandleId: "handle_1",
+      body: "from the bunker",
+      createdAt: new Date("2026-04-24T10:00:00.000Z"),
+      deletedAt: null,
+      hiddenAt: null,
+      id: "message_2",
+      moderationState: "visible",
+      roomId: "room_1",
+      roomSessionId: "session_1",
+      sentAt,
+      tone: "system",
+      updatedAt: new Date("2026-04-24T10:00:00.000Z"),
     });
   });
 

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
@@ -10,6 +10,7 @@ import type {
   ChatRoomSessionRepositoryRow,
   ChatUploadRepositoryRow,
   CreateChatHandleCommand,
+  CreateChatTextMessageCommand,
   CreateChatMessageWithUploadCommand,
   CreateChatMessageWithUploadResult,
   CreateChatRoomSessionCommand,
@@ -245,6 +246,38 @@ const createMessageWithUpload = async (
       upload: mapUploadRow(upload),
     };
   });
+};
+
+const createTextMessage = async (
+  client: PrismaDatabaseClient,
+  input: CreateChatTextMessageCommand,
+): Promise<ChatMessageRepositoryRow> => {
+  const message = await client.chatMessage.create({
+    data: {
+      authorHandleId: input.authorHandleId,
+      body: input.body,
+      roomId: input.roomId,
+      roomSessionId: input.roomSessionId,
+      sentAt: input.sentAt,
+      tone: input.tone,
+    },
+    select: {
+      authorHandleId: true,
+      body: true,
+      createdAt: true,
+      deletedAt: true,
+      hiddenAt: true,
+      id: true,
+      moderationState: true,
+      roomId: true,
+      roomSessionId: true,
+      sentAt: true,
+      tone: true,
+      updatedAt: true,
+    },
+  });
+
+  return mapMessageRow(message);
 };
 
 const createHandle = async (
@@ -621,6 +654,8 @@ const listMessages = async (
 
 export const createPrismaChatRepository = (client: PrismaDatabaseClient): ChatRepositoryPort => ({
   createHandle: (input): Promise<ChatHandleRepositoryRow> => createHandle(client, input),
+  createTextMessage: (input): Promise<ChatMessageRepositoryRow> =>
+    createTextMessage(client, input),
   createMessageWithUpload: (input): Promise<CreateChatMessageWithUploadResult> =>
     createMessageWithUpload(client, input),
   createSession: (input): Promise<ChatRoomSessionRepositoryRow> => createSession(client, input),
@@ -664,6 +699,24 @@ export const createPrismaChatRepository = (client: PrismaDatabaseClient): ChatRe
     });
 
     return room ? mapRoomRow(room) : null;
+  },
+  findHandleById: async (handleId): Promise<ChatHandleRepositoryRow | null> => {
+    const handle = await client.chatHandle.findUnique({
+      select: {
+        createdAt: true,
+        handle: true,
+        id: true,
+        normalizedHandle: true,
+        roomId: true,
+        status: true,
+        updatedAt: true,
+      },
+      where: {
+        id: handleId,
+      },
+    });
+
+    return handle ? mapHandleRow(handle) : null;
   },
   findHandleByRoomIdAndNormalizedHandle: async (
     roomId,

--- a/backend/src/bootstrap/container/create-container.test.ts
+++ b/backend/src/bootstrap/container/create-container.test.ts
@@ -14,6 +14,7 @@ describe("bootstrap container", () => {
     expect(typeof container.chat.openUploadMedia.execute).toBe("function");
     expect(typeof container.chat.joinRoomSession?.execute).toBe("function");
     expect(typeof container.chat.listRoomMessages?.execute).toBe("function");
+    expect(typeof container.chat.sendRoomTextMessage?.execute).toBe("function");
     expect(typeof container.media.repository.findPhotoMediaById).toBe("function");
     expect(typeof container.media.repository.findChatUploadMediaById).toBe("function");
     expect(typeof container.media.storage.photos.openOriginal).toBe("function");

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -52,6 +52,7 @@ import {
   createListChatRoomParticipantsUseCase,
   createModerateChatUploadRetentionUseCase,
   createOpenChatUploadMediaUseCase,
+  createSendChatRoomTextMessageUseCase,
   createUploadChatMessageWithImageUseCase,
 } from "@/modules/chat/application";
 import type {
@@ -60,6 +61,7 @@ import type {
   ListChatRoomParticipantsPort,
   ModerateChatUploadRetentionPort,
   OpenChatUploadMediaPort,
+  SendChatRoomTextMessagePort,
   UploadChatMessageWithImagePort,
 } from "@/modules/chat/ports/inbound";
 import {
@@ -109,6 +111,7 @@ export type BootstrapContainer = Readonly<{
     listRoomParticipants?: ListChatRoomParticipantsPort;
     moderateUploadRetention: ModerateChatUploadRetentionPort;
     openUploadMedia: OpenChatUploadMediaPort;
+    sendRoomTextMessage?: SendChatRoomTextMessagePort;
     uploadMessageWithImage: UploadChatMessageWithImagePort;
   }>;
   config: BootstrapConfig;
@@ -251,6 +254,9 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
         mediaRepository: persistence.media,
         repository: persistence.chat,
         storage: storage.chatUploads,
+      }),
+      sendRoomTextMessage: createSendChatRoomTextMessageUseCase({
+        repository: persistence.chat,
       }),
       uploadMessageWithImage: createUploadChatMessageWithImageUseCase({
         repository: persistence.chat,

--- a/backend/src/modules/chat/application/index.test.ts
+++ b/backend/src/modules/chat/application/index.test.ts
@@ -7,6 +7,7 @@ import {
   createListChatRoomParticipantsUseCase,
   createModerateChatUploadRetentionUseCase,
   createOpenChatUploadMediaUseCase,
+  createSendChatRoomTextMessageUseCase,
   createUploadChatMessageWithImageUseCase,
   InvalidChatMessageAccessError,
   InvalidChatMessageCursorError,
@@ -463,6 +464,137 @@ describe("chat message archive list use case", () => {
         slug: "night-shift",
       }),
     ).rejects.toBeInstanceOf(InvalidChatMessageCursorError);
+  });
+});
+
+describe("chat text message send use case", () => {
+  it("creates a text message for an active room session bound to the room slug", async () => {
+    const now = new Date("2026-04-28T12:05:00.000Z");
+    let capturedCreateInput: Record<string, unknown> | undefined;
+    const useCase = createSendChatRoomTextMessageUseCase({
+      clock: () => now,
+      repository: {
+        createTextMessage: async (input) => {
+          capturedCreateInput = input as unknown as Record<string, unknown>;
+
+          return {
+            authorHandleId: input.authorHandleId,
+            body: input.body,
+            createdAt: now,
+            deletedAt: null,
+            hiddenAt: null,
+            id: "message_1",
+            moderationState: "visible",
+            roomId: input.roomId,
+            roomSessionId: input.roomSessionId,
+            sentAt: now,
+            tone: input.tone,
+            updatedAt: now,
+          };
+        },
+        findHandleById: async () => ({
+          createdAt: now,
+          handle: "vinicius",
+          id: "handle_1",
+          normalizedHandle: "vinicius",
+          roomId: "room_1",
+          status: "active",
+          updatedAt: now,
+        }),
+        findRoomBySlug: async () => ({
+          createdAt: now,
+          id: "room_1",
+          passwordHash: "hash",
+          passwordRotatedAt: null,
+          passwordVersion: 1,
+          slug: "night-shift",
+          updatedAt: now,
+        }),
+        findSessionById: async () => ({
+          createdAt: now,
+          expiresAt: null,
+          handleId: "handle_1",
+          id: "session_1",
+          joinedAt: now,
+          lastSeenAt: now,
+          leftAt: null,
+          roomId: "room_1",
+          status: "active",
+          updatedAt: now,
+        }),
+      },
+    });
+
+    const result = await useCase.execute({
+      body: "  message from   bunker  ",
+      roomSessionId: "session_1",
+      slug: "night-shift",
+      tone: "pink",
+    });
+
+    expect(capturedCreateInput).toEqual({
+      authorHandleId: "handle_1",
+      body: "message from bunker",
+      roomId: "room_1",
+      roomSessionId: "session_1",
+      sentAt: now,
+      tone: "pink",
+    });
+    expect(result).toEqual({
+      author: "vinicius",
+      body: "message from bunker",
+      id: "message_1",
+      sentAt: "2026-04-28T12:05:00.000Z",
+      tone: "pink",
+    });
+  });
+
+  it("rejects text message send when room session is invalid for the room slug", async () => {
+    const useCase = createSendChatRoomTextMessageUseCase({
+      repository: {
+        createTextMessage: async () => {
+          throw new Error("should not create message");
+        },
+        findHandleById: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          handle: "vinicius",
+          id: "handle_1",
+          normalizedHandle: "vinicius",
+          roomId: "room_1",
+          status: "active",
+          updatedAt: new Date("2026-04-28T12:00:00.000Z"),
+        }),
+        findRoomBySlug: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          id: "room_1",
+          passwordHash: "hash",
+          passwordRotatedAt: null,
+          passwordVersion: 1,
+          slug: "night-shift",
+          updatedAt: new Date("2026-04-28T12:00:00.000Z"),
+        }),
+        findSessionById: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          expiresAt: null,
+          handleId: "handle_1",
+          id: "session_1",
+          joinedAt: new Date("2026-04-28T12:00:00.000Z"),
+          lastSeenAt: new Date("2026-04-28T12:00:00.000Z"),
+          leftAt: null,
+          roomId: "room_2",
+          status: "active",
+          updatedAt: new Date("2026-04-28T12:00:00.000Z"),
+        }),
+      },
+    });
+
+    await expect(
+      useCase.execute({
+        body: "message body",
+        roomSessionId: "session_1",
+        slug: "night-shift",
+      }),
+    ).rejects.toBeInstanceOf(InvalidChatMessageAccessError);
   });
 });
 

--- a/backend/src/modules/chat/application/index.ts
+++ b/backend/src/modules/chat/application/index.ts
@@ -21,6 +21,9 @@ import type {
   OpenChatUploadMediaInput,
   OpenChatUploadMediaOutput,
   OpenChatUploadMediaPort,
+  SendChatRoomTextMessageInput,
+  SendChatRoomTextMessageOutput,
+  SendChatRoomTextMessagePort,
   UploadChatMessageWithImageInput,
   UploadChatMessageWithImageOutput,
   UploadChatMessageWithImagePort,
@@ -151,6 +154,14 @@ export type ListChatRoomParticipantsDependencies = Readonly<{
 
 export type ListChatRoomMessagesDependencies = Readonly<{
   repository: Pick<ChatRepositoryPort, "findRoomBySlug" | "findSessionById" | "listMessages">;
+}>;
+
+export type SendChatRoomTextMessageDependencies = Readonly<{
+  clock?: () => Date;
+  repository: Pick<
+    ChatRepositoryPort,
+    "createTextMessage" | "findHandleById" | "findRoomBySlug" | "findSessionById"
+  >;
 }>;
 
 export type ChatUploadMediaAccessDependencies = Readonly<{
@@ -383,6 +394,56 @@ export const createListChatRoomMessagesUseCase = ({
         nextCursor: page.nextCursor ? encodeChatMessageCursor(page.nextCursor) : null,
       },
     };
+  },
+});
+
+export const createSendChatRoomTextMessageUseCase = ({
+  clock = () => new Date(),
+  repository,
+}: SendChatRoomTextMessageDependencies): SendChatRoomTextMessagePort => ({
+  execute: async (
+    input: SendChatRoomTextMessageInput,
+  ): Promise<SendChatRoomTextMessageOutput> => {
+    const room = await repository.findRoomBySlug({
+      slug: input.slug.trim(),
+    });
+
+    if (!room) {
+      throw new InvalidChatMessageAccessError();
+    }
+
+    const session = await repository.findSessionById(input.roomSessionId);
+
+    if (!session || session.status !== "active" || session.roomId !== room.id) {
+      throw new InvalidChatMessageAccessError();
+    }
+
+    const authorHandle = await repository.findHandleById(session.handleId);
+
+    if (
+      !authorHandle ||
+      authorHandle.status !== "active" ||
+      authorHandle.roomId !== room.id
+    ) {
+      throw new InvalidChatMessageAccessError();
+    }
+
+    const message = await repository.createTextMessage({
+      authorHandleId: authorHandle.id,
+      body: collapseWhitespace(input.body),
+      roomId: room.id,
+      roomSessionId: session.id,
+      sentAt: clock(),
+      tone: input.tone ?? null,
+    });
+
+    return mapChatMessageOutput({
+      author: authorHandle.handle,
+      body: message.body,
+      id: message.id,
+      sentAt: message.sentAt,
+      tone: message.tone,
+    });
   },
 });
 

--- a/backend/src/modules/chat/ports/inbound/index.ts
+++ b/backend/src/modules/chat/ports/inbound/index.ts
@@ -81,6 +81,18 @@ export type ListChatRoomMessagesOutput = Readonly<{
 export interface ListChatRoomMessagesPort
   extends UseCase<ListChatRoomMessagesInput, ListChatRoomMessagesOutput> {}
 
+export type SendChatRoomTextMessageInput = Readonly<{
+  body: string;
+  roomSessionId: string;
+  slug: string;
+  tone?: "cyan" | "pink" | "system";
+}>;
+
+export type SendChatRoomTextMessageOutput = ChatRoomMessageOutput;
+
+export interface SendChatRoomTextMessagePort
+  extends UseCase<SendChatRoomTextMessageInput, SendChatRoomTextMessageOutput> {}
+
 export type UploadChatMessageImageInput = Readonly<{
   body: Uint8Array;
   displayFilename: string;

--- a/backend/src/modules/chat/ports/outbound/index.ts
+++ b/backend/src/modules/chat/ports/outbound/index.ts
@@ -126,6 +126,15 @@ export type CreateChatRoomSessionCommand = Readonly<{
   status: "active" | "revoked" | "expired";
 }>;
 
+export type CreateChatTextMessageCommand = Readonly<{
+  authorHandleId: string;
+  body: string;
+  roomId: string;
+  roomSessionId: string;
+  sentAt: Date;
+  tone: "cyan" | "pink" | "system" | null;
+}>;
+
 export type CreateChatMessageWithUploadResult = Readonly<{
   message: ChatMessageRepositoryRow;
   upload: ChatUploadRepositoryRow;
@@ -164,6 +173,7 @@ export type ChatMessageListPage = Readonly<{
 
 export interface ChatRepositoryPort {
   createHandle(input: CreateChatHandleCommand): Promise<ChatHandleRepositoryRow>;
+  createTextMessage(input: CreateChatTextMessageCommand): Promise<ChatMessageRepositoryRow>;
   createMessageWithUpload(
     input: CreateChatMessageWithUploadCommand,
   ): Promise<CreateChatMessageWithUploadResult>;
@@ -171,6 +181,7 @@ export interface ChatRepositoryPort {
   moderateUploadRetention(
     input: ModerateChatUploadRetentionCommand,
   ): Promise<ModerateChatUploadRetentionResult | null>;
+  findHandleById(handleId: string): Promise<ChatHandleRepositoryRow | null>;
   findSessionById(sessionId: string): Promise<ChatRoomSessionRepositoryRow | null>;
   findRoomBySlug(query: ChatRoomQuery): Promise<ChatRoomRepositoryRow | null>;
   findHandleByRoomIdAndNormalizedHandle(roomId: string, normalizedHandle: string): Promise<ChatHandleRepositoryRow | null>;


### PR DESCRIPTION
## Summary
- implement CHAT-004 room text-message send backend flow
- add `POST /api/chat/rooms/:slug/messages` guarded by `x-chat-room-session-id`
- add chat send-text use case and repository create method
- keep existing join/participants/message-list/upload/media contracts intact

## Files and Areas
- `backend/src/modules/chat/**` send-text ports + use case + tests
- `backend/src/adapters/outbound/persistence/prisma/chat-repository.ts` + tests
- `backend/src/adapters/inbound/http/hono/http-adapter.ts` send-text route
- `backend/src/adapters/inbound/http/hono/chat-routes.test.ts` send-text route coverage
- `backend/src/bootstrap/container/create-container.ts` wiring

## Verification
- `bun test backend/src/modules/chat/application/index.test.ts backend/src/adapters/inbound/http/hono/chat-routes.test.ts backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts backend/src/bootstrap/container/create-container.test.ts`
- `bun run --cwd backend typecheck`
- `bun run --cwd backend test`
- `bun run --cwd backend verify`

Closes #74
