### PR TITLE
[CHAT-005] Implement moderation commands and admin chat routes

### DIFF
--- a/backend/src/adapters/inbound/http/hono/admin-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/admin-routes.test.ts
@@ -3,6 +3,14 @@ import { describe, expect, it } from "bun:test";
 import type { BootstrapContainer } from "@/bootstrap/container";
 import { InvalidAdminPhotoMetadataDateError } from "@/modules/admin/application";
 import { InvalidAuthSessionError } from "@/modules/auth/application";
+import type {
+  BanChatRoomHandleInput,
+  BanChatRoomHandleOutput,
+  ModerateChatRoomMessageInput,
+  ModerateChatRoomMessageOutput,
+  RotateChatRoomPasswordInput,
+  RotateChatRoomPasswordOutput,
+} from "@/modules/chat/ports/inbound";
 
 import { createHonoHttpAdapter } from "./http-adapter";
 
@@ -73,6 +81,23 @@ const createAuthStub = (
 
 const createTestContainer = (
   options: Readonly<{
+    executeBanHandle?: (
+      input: BanChatRoomHandleInput,
+    ) => BanChatRoomHandleOutput | Promise<BanChatRoomHandleOutput> | null | Promise<null>;
+    executeModerateMessage?: (
+      input: ModerateChatRoomMessageInput,
+    ) =>
+      | ModerateChatRoomMessageOutput
+      | Promise<ModerateChatRoomMessageOutput>
+      | null
+      | Promise<null>;
+    executeRotateRoomPassword?: (
+      input: RotateChatRoomPasswordInput,
+    ) =>
+      | RotateChatRoomPasswordOutput
+      | Promise<RotateChatRoomPasswordOutput>
+      | null
+      | Promise<null>;
     resolveDenied?: boolean;
     thoughtNotFound?: boolean;
   }> = {},
@@ -218,11 +243,20 @@ const createTestContainer = (
     }
   }),
   chat: {
+    banRoomHandle: {
+      execute: options.executeBanHandle ?? (async () => null),
+    },
+    moderateRoomMessage: {
+      execute: options.executeModerateMessage ?? (async () => null),
+    },
     moderateUploadRetention: {
       execute: async () => null,
     },
     openUploadMedia: {
       execute: async () => null,
+    },
+    rotateRoomPassword: {
+      execute: options.executeRotateRoomPassword ?? (async () => null),
     },
     uploadMessageWithImage: {
       execute: async () => ({
@@ -240,6 +274,30 @@ const createTestContainer = (
         tone: null,
       }),
     },
+  } as BootstrapContainer["chat"] & {
+    banRoomHandle: {
+      execute: (
+        input: BanChatRoomHandleInput,
+      ) => BanChatRoomHandleOutput | Promise<BanChatRoomHandleOutput> | null | Promise<null>;
+    };
+    moderateRoomMessage: {
+      execute: (
+        input: ModerateChatRoomMessageInput,
+      ) =>
+        | ModerateChatRoomMessageOutput
+        | Promise<ModerateChatRoomMessageOutput>
+        | null
+        | Promise<null>;
+    };
+    rotateRoomPassword: {
+      execute: (
+        input: RotateChatRoomPasswordInput,
+      ) =>
+        | RotateChatRoomPasswordOutput
+        | Promise<RotateChatRoomPasswordOutput>
+        | null
+        | Promise<null>;
+    };
   },
   config: {
     auth: {
@@ -383,6 +441,267 @@ describe("admin routes", () => {
       error: "denied",
       resource: "auth",
     });
+  });
+
+  it("maps a valid chat message moderation request into the moderation use case", async () => {
+    let capturedInput: ModerateChatRoomMessageInput | undefined;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeModerateMessage: async (input) => {
+          capturedInput = input;
+
+          return {
+            action: "hide_message",
+            auditId: "audit_1",
+            messageId: "message_1",
+            messageModerationState: "hidden",
+            uploadId: "upload_1",
+            uploadModerationState: "hidden",
+          };
+        },
+      }),
+    );
+
+    const response = await app.request("/api/admin/chat/messages/message_1/moderation", {
+      body: JSON.stringify({
+        action: "hide_message",
+        reason: "  redact from room  ",
+      }),
+      headers: {
+        "content-type": "application/json",
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      action: "hide_message",
+      auditId: "audit_1",
+      messageId: "message_1",
+      messageModerationState: "hidden",
+      uploadId: "upload_1",
+      uploadModerationState: "hidden",
+    });
+    expect(capturedInput).toEqual({
+      action: "hide_message",
+      actorAdminUserId: "admin_1",
+      messageId: "message_1",
+      reason: "redact from room",
+    });
+  });
+
+  it("rejects invalid chat moderation action values", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeModerateMessage: async () => {
+          called = true;
+
+          return {
+            action: "hide_message",
+            auditId: "audit_1",
+            messageId: "message_1",
+            messageModerationState: "hidden",
+            uploadId: null,
+            uploadModerationState: null,
+          };
+        },
+      }),
+    );
+
+    const response = await app.request("/api/admin/chat/messages/message_1/moderation", {
+      body: JSON.stringify({
+        action: "hide_media",
+      }),
+      headers: {
+        "content-type": "application/json",
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_request",
+      field: "action",
+    });
+    expect(called).toBe(false);
+  });
+
+  it("returns not_found when chat moderation target message does not exist", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeModerateMessage: async () => null,
+      }),
+    );
+
+    const response = await app.request("/api/admin/chat/messages/message_404/moderation", {
+      body: JSON.stringify({
+        action: "delete_message",
+      }),
+      headers: {
+        "content-type": "application/json",
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "not_found",
+      resource: "chat_message",
+    });
+  });
+
+  it("maps a valid handle ban request into the ban use case", async () => {
+    let capturedInput: BanChatRoomHandleInput | undefined;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeBanHandle: async (input) => {
+          capturedInput = input;
+
+          return {
+            auditId: "audit_2",
+            banId: "ban_1",
+            handleId: "handle_1",
+            revokedSessionCount: 2,
+            roomId: "room_1",
+            status: "banned",
+          };
+        },
+      }),
+    );
+
+    const response = await app.request("/api/admin/chat/handles/handle_1/ban", {
+      body: JSON.stringify({
+        reason: "  repeated abuse  ",
+      }),
+      headers: {
+        "content-type": "application/json",
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      auditId: "audit_2",
+      banId: "ban_1",
+      handleId: "handle_1",
+      revokedSessionCount: 2,
+      roomId: "room_1",
+      status: "banned",
+    });
+    expect(capturedInput).toEqual({
+      actorAdminUserId: "admin_1",
+      handleId: "handle_1",
+      reason: "repeated abuse",
+    });
+  });
+
+  it("maps a valid room password rotation request into the rotation use case", async () => {
+    let capturedInput: RotateChatRoomPasswordInput | undefined;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeRotateRoomPassword: async (input) => {
+          capturedInput = input;
+
+          return {
+            auditId: "audit_3",
+            revokedSessionCount: 3,
+            room: {
+              id: "room_1",
+              passwordRotatedAt: "2026-04-28T12:08:00.000Z",
+              passwordVersion: 4,
+              slug: "night-shift",
+            },
+            rotation: {
+              id: "rotation_1",
+              rotatedAt: "2026-04-28T12:08:00.000Z",
+            },
+          };
+        },
+      }),
+    );
+
+    const response = await app.request("/api/admin/chat/rooms/night-shift/password-rotation", {
+      body: JSON.stringify({
+        nextPassword: "  new-secret  ",
+        reason: "  leaked credentials  ",
+      }),
+      headers: {
+        "content-type": "application/json",
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      auditId: "audit_3",
+      revokedSessionCount: 3,
+      room: {
+        id: "room_1",
+        passwordRotatedAt: "2026-04-28T12:08:00.000Z",
+        passwordVersion: 4,
+        slug: "night-shift",
+      },
+      rotation: {
+        id: "rotation_1",
+        rotatedAt: "2026-04-28T12:08:00.000Z",
+      },
+    });
+    expect(capturedInput).toEqual({
+      actorAdminUserId: "admin_1",
+      nextPassword: "new-secret",
+      reason: "leaked credentials",
+      slug: "night-shift",
+    });
+  });
+
+  it("rejects room password rotation requests missing nextPassword", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeRotateRoomPassword: async () => {
+          called = true;
+
+          return {
+            auditId: "audit_3",
+            revokedSessionCount: 0,
+            room: {
+              id: "room_1",
+              passwordRotatedAt: "2026-04-28T12:08:00.000Z",
+              passwordVersion: 4,
+              slug: "night-shift",
+            },
+            rotation: {
+              id: "rotation_1",
+              rotatedAt: "2026-04-28T12:08:00.000Z",
+            },
+          };
+        },
+      }),
+    );
+
+    const response = await app.request("/api/admin/chat/rooms/night-shift/password-rotation", {
+      body: JSON.stringify({
+        reason: "leaked credentials",
+      }),
+      headers: {
+        "content-type": "application/json",
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_request",
+      field: "nextPassword",
+    });
+    expect(called).toBe(false);
   });
 
   it("rejects invalid thoughts query parameters", async () => {

--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -19,8 +19,11 @@ import {
 } from "@/modules/chat/application";
 import { InvalidThoughtCursorError } from "@/modules/content/application";
 import type {
+  BanChatRoomHandlePort,
   ChatUploadMimeType,
   ListChatRoomMessagesPort,
+  ModerateChatRoomMessagePort,
+  RotateChatRoomPasswordPort,
   SendChatRoomTextMessagePort,
 } from "@/modules/chat/ports/inbound";
 import type { ReplaceAdminStatusStripEntriesInput } from "@/modules/admin/ports/inbound";
@@ -553,6 +556,34 @@ const readRequiredJsonString = (
 
   return {
     value: trimmed,
+  };
+};
+
+const readOptionalJsonString = (
+  payload: Record<string, unknown>,
+  field: string,
+): { value: string | undefined } | { error: { error: "invalid_request"; field: string } } => {
+  const value = payload[field];
+
+  if (typeof value === "undefined") {
+    return {
+      value: undefined,
+    };
+  }
+
+  if (typeof value !== "string") {
+    return {
+      error: {
+        error: "invalid_request",
+        field,
+      },
+    };
+  }
+
+  const trimmed = value.trim();
+
+  return {
+    value: trimmed.length > 0 ? trimmed : undefined,
   };
 };
 
@@ -1465,6 +1496,15 @@ const createAdminFamily = (container: BootstrapContainer) => {
   }
 
   const adminApp = new Hono();
+  const moderateRoomMessageUseCase = (container.chat as {
+    moderateRoomMessage?: ModerateChatRoomMessagePort;
+  }).moderateRoomMessage;
+  const banRoomHandleUseCase = (container.chat as {
+    banRoomHandle?: BanChatRoomHandlePort;
+  }).banRoomHandle;
+  const rotateRoomPasswordUseCase = (container.chat as {
+    rotateRoomPassword?: RotateChatRoomPasswordPort;
+  }).rotateRoomPassword;
 
   const resolveSession = async (c: Context) => {
     const sessionToken = readSessionTokenFromCookie(
@@ -1485,11 +1525,14 @@ const createAdminFamily = (container: BootstrapContainer) => {
     }
 
     try {
-      await auth.resolveAdminSession.execute({
+      const resolved = await auth.resolveAdminSession.execute({
         sessionToken,
       });
 
-      return { ok: true } as const;
+      return {
+        adminUserId: resolved.admin.id,
+        ok: true,
+      } as const;
     } catch (error) {
       if (error instanceof InvalidAuthSessionError) {
         return {
@@ -1885,6 +1928,173 @@ const createAdminFamily = (container: BootstrapContainer) => {
 
       throw error;
     }
+  });
+
+  adminApp.post("/chat/messages/:id/moderation", async (c) => {
+    const session = await resolveSession(c);
+
+    if ("error" in session) {
+      return session.error;
+    }
+
+    if (!moderateRoomMessageUseCase) {
+      return c.json<NotImplementedResponse>(
+        {
+          family: "admin",
+          method: c.req.method,
+          route: c.req.path,
+          service: serviceName,
+          status: "not_implemented",
+        },
+        501,
+      );
+    }
+
+    const id = c.req.param("id")?.trim();
+
+    if (!id) {
+      return c.json({ error: "invalid_path", field: "id" }, 400);
+    }
+
+    const parsedBody = await readJsonObject(c.req.raw);
+
+    if ("error" in parsedBody) {
+      return c.json(parsedBody.error, 400);
+    }
+
+    const action = parsedBody.value.action;
+
+    if (action !== "hide_message" && action !== "delete_message") {
+      return c.json({ error: "invalid_request", field: "action" }, 400);
+    }
+
+    const reason = readOptionalJsonString(parsedBody.value, "reason");
+
+    if ("error" in reason) {
+      return c.json(reason.error, 400);
+    }
+
+    const result = await moderateRoomMessageUseCase.execute({
+      action,
+      actorAdminUserId: session.adminUserId,
+      messageId: id,
+      reason: reason.value,
+    });
+
+    if (!result) {
+      return c.json({ error: "not_found", resource: "chat_message" }, 404);
+    }
+
+    return c.json(result);
+  });
+
+  adminApp.post("/chat/handles/:id/ban", async (c) => {
+    const session = await resolveSession(c);
+
+    if ("error" in session) {
+      return session.error;
+    }
+
+    if (!banRoomHandleUseCase) {
+      return c.json<NotImplementedResponse>(
+        {
+          family: "admin",
+          method: c.req.method,
+          route: c.req.path,
+          service: serviceName,
+          status: "not_implemented",
+        },
+        501,
+      );
+    }
+
+    const id = c.req.param("id")?.trim();
+
+    if (!id) {
+      return c.json({ error: "invalid_path", field: "id" }, 400);
+    }
+
+    const parsedBody = await readJsonObject(c.req.raw);
+
+    if ("error" in parsedBody) {
+      return c.json(parsedBody.error, 400);
+    }
+
+    const reason = readOptionalJsonString(parsedBody.value, "reason");
+
+    if ("error" in reason) {
+      return c.json(reason.error, 400);
+    }
+
+    const result = await banRoomHandleUseCase.execute({
+      actorAdminUserId: session.adminUserId,
+      handleId: id,
+      reason: reason.value,
+    });
+
+    if (!result) {
+      return c.json({ error: "not_found", resource: "chat_handle" }, 404);
+    }
+
+    return c.json(result);
+  });
+
+  adminApp.post("/chat/rooms/:slug/password-rotation", async (c) => {
+    const session = await resolveSession(c);
+
+    if ("error" in session) {
+      return session.error;
+    }
+
+    if (!rotateRoomPasswordUseCase) {
+      return c.json<NotImplementedResponse>(
+        {
+          family: "admin",
+          method: c.req.method,
+          route: c.req.path,
+          service: serviceName,
+          status: "not_implemented",
+        },
+        501,
+      );
+    }
+
+    const slug = c.req.param("slug")?.trim();
+
+    if (!slug) {
+      return c.json({ error: "invalid_path", field: "slug" }, 400);
+    }
+
+    const parsedBody = await readJsonObject(c.req.raw);
+
+    if ("error" in parsedBody) {
+      return c.json(parsedBody.error, 400);
+    }
+
+    const nextPassword = readRequiredJsonString(parsedBody.value, "nextPassword");
+
+    if ("error" in nextPassword) {
+      return c.json(nextPassword.error, 400);
+    }
+
+    const reason = readOptionalJsonString(parsedBody.value, "reason");
+
+    if ("error" in reason) {
+      return c.json(reason.error, 400);
+    }
+
+    const result = await rotateRoomPasswordUseCase.execute({
+      actorAdminUserId: session.adminUserId,
+      nextPassword: nextPassword.value,
+      reason: reason.value,
+      slug,
+    });
+
+    if (!result) {
+      return c.json({ error: "not_found", resource: "chat_room" }, 404);
+    }
+
+    return c.json(result);
   });
 
   adminApp.get("/status-strip", async (c) => {

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
@@ -867,4 +867,438 @@ describe("prisma chat repository", () => {
     expect(result?.message?.moderationState).toBe("deleted");
     expect(result?.upload.moderationState).toBe("deleted");
   });
+
+  it("moderates a room message and linked upload with audit tracking", async () => {
+    let capturedAuditData: Record<string, unknown> | null = null;
+    let capturedMessageUpdate: Record<string, unknown> | null = null;
+    let capturedUploadUpdate: Record<string, unknown> | null = null;
+    const occurredAt = new Date("2026-04-28T12:08:00.000Z");
+    const repository = createPrismaChatRepository({
+      $transaction: async <T>(
+        runInTransaction: (tx: {
+          chatMessage: {
+            findUnique: (args: { where: { id: string } }) => Promise<Record<string, unknown> | null>;
+            update: (args: {
+              data: Record<string, unknown>;
+              where: { id: string };
+            }) => Promise<Record<string, unknown>>;
+          };
+          chatModerationAuditRecord: {
+            create: (args: { data: Record<string, unknown> }) => Promise<Record<string, unknown>>;
+          };
+          chatUpload: {
+            findUnique: (args: {
+              where: { messageId: string };
+            }) => Promise<Record<string, unknown> | null>;
+            update: (args: {
+              data: Record<string, unknown>;
+              where: { id: string };
+            }) => Promise<Record<string, unknown>>;
+          };
+        }) => Promise<T>,
+      ) =>
+        runInTransaction({
+          chatMessage: {
+            findUnique: async () => ({
+              authorHandleId: "handle_1",
+              body: "night drop",
+              createdAt: new Date("2026-04-24T10:00:00.000Z"),
+              deletedAt: null,
+              hiddenAt: null,
+              id: "message_1",
+              moderationState: "visible" as const,
+              roomId: "room_1",
+              roomSessionId: "session_1",
+              sentAt: new Date("2026-04-24T10:00:00.000Z"),
+              tone: "pink" as const,
+              updatedAt: new Date("2026-04-24T10:00:00.000Z"),
+            }),
+            update: async ({ data }) => {
+              capturedMessageUpdate = data;
+
+              return {
+                authorHandleId: "handle_1",
+                body: "night drop",
+                createdAt: new Date("2026-04-24T10:00:00.000Z"),
+                deletedAt: null,
+                hiddenAt: data.hiddenAt as Date,
+                id: "message_1",
+                moderationState: data.moderationState as "hidden",
+                roomId: "room_1",
+                roomSessionId: "session_1",
+                sentAt: new Date("2026-04-24T10:00:00.000Z"),
+                tone: "pink" as const,
+                updatedAt: occurredAt,
+              };
+            },
+          },
+          chatModerationAuditRecord: {
+            create: async ({ data }) => {
+              capturedAuditData = data;
+
+              return {
+                id: "audit_3",
+              };
+            },
+          },
+          chatUpload: {
+            findUnique: async () => ({
+              byteSize: 1234,
+              createdAt: new Date("2026-04-24T10:00:00.000Z"),
+              deletedAt: null,
+              displayFilename: "drop.png",
+              hiddenAt: null,
+              id: "upload_1",
+              kind: "image" as const,
+              messageId: "message_1",
+              mimeType: "image_png" as const,
+              moderationState: "visible" as const,
+              roomId: "room_1",
+              storageKey: "room_1/upload_1.png",
+              storagePath: "room_1/upload_1.png",
+              updatedAt: new Date("2026-04-24T10:00:00.000Z"),
+              uploaderHandleId: "handle_1",
+              uploaderSessionId: "session_1",
+            }),
+            update: async ({ data }) => {
+              capturedUploadUpdate = data;
+
+              return {
+                byteSize: 1234,
+                createdAt: new Date("2026-04-24T10:00:00.000Z"),
+                deletedAt: null,
+                displayFilename: "drop.png",
+                hiddenAt: data.hiddenAt as Date,
+                id: "upload_1",
+                kind: "image" as const,
+                messageId: "message_1",
+                mimeType: "image_png" as const,
+                moderationState: data.moderationState as "hidden",
+                roomId: "room_1",
+                storageKey: "room_1/upload_1.png",
+                storagePath: "room_1/upload_1.png",
+                updatedAt: occurredAt,
+                uploaderHandleId: "handle_1",
+                uploaderSessionId: "session_1",
+              };
+            },
+          },
+        }),
+    } as unknown as PrismaDatabaseClient);
+
+    const result = await repository.moderateMessage({
+      action: "hide_message",
+      actorAdminUserId: "admin_1",
+      messageId: "message_1",
+      occurredAt,
+      reason: "redact from room history",
+    });
+
+    expect(capturedMessageUpdate).toMatchObject({
+      deletedAt: null,
+      hiddenAt: occurredAt,
+      moderationState: "hidden",
+    });
+    expect(capturedUploadUpdate).toMatchObject({
+      deletedAt: null,
+      hiddenAt: occurredAt,
+      moderationState: "hidden",
+    });
+    expect(capturedAuditData).toMatchObject({
+      action: "hide_media_metadata",
+      actorAdminUserId: "admin_1",
+      reason: "redact from room history",
+      roomId: "room_1",
+      targetMessageId: "message_1",
+      targetUploadId: "upload_1",
+    });
+    expect(result).toEqual({
+      auditId: "audit_3",
+      message: {
+        authorHandleId: "handle_1",
+        body: "night drop",
+        createdAt: new Date("2026-04-24T10:00:00.000Z"),
+        deletedAt: null,
+        hiddenAt: occurredAt,
+        id: "message_1",
+        moderationState: "hidden",
+        roomId: "room_1",
+        roomSessionId: "session_1",
+        sentAt: new Date("2026-04-24T10:00:00.000Z"),
+        tone: "pink",
+        updatedAt: occurredAt,
+      },
+      upload: {
+        byteSize: 1234,
+        createdAt: new Date("2026-04-24T10:00:00.000Z"),
+        deletedAt: null,
+        displayFilename: "drop.png",
+        hiddenAt: occurredAt,
+        id: "upload_1",
+        kind: "image",
+        messageId: "message_1",
+        mimeType: "image/png",
+        moderationState: "hidden",
+        roomId: "room_1",
+        storageKey: "room_1/upload_1.png",
+        storagePath: "room_1/upload_1.png",
+        updatedAt: occurredAt,
+        uploaderHandleId: "handle_1",
+        uploaderSessionId: "session_1",
+      },
+    });
+  });
+
+  it("creates a ban record, revokes sessions, and emits moderation audit", async () => {
+    let capturedBanData: Record<string, unknown> | null = null;
+    let capturedAuditData: Record<string, unknown> | null = null;
+    let capturedRevokeWhere: Record<string, unknown> | null = null;
+    const occurredAt = new Date("2026-04-28T12:09:00.000Z");
+    const repository = createPrismaChatRepository({
+      $transaction: async <T>(
+        runInTransaction: (tx: {
+          chatBan: {
+            create: (args: { data: Record<string, unknown> }) => Promise<Record<string, unknown>>;
+          };
+          chatHandle: {
+            findUnique: (args: { where: { id: string } }) => Promise<Record<string, unknown> | null>;
+            update: (args: {
+              data: Record<string, unknown>;
+              where: { id: string };
+            }) => Promise<Record<string, unknown>>;
+          };
+          chatModerationAuditRecord: {
+            create: (args: { data: Record<string, unknown> }) => Promise<Record<string, unknown>>;
+          };
+          chatRoomSession: {
+            updateMany: (args: {
+              data: Record<string, unknown>;
+              where: Record<string, unknown>;
+            }) => Promise<{ count: number }>;
+          };
+        }) => Promise<T>,
+      ) =>
+        runInTransaction({
+          chatBan: {
+            create: async ({ data }) => {
+              capturedBanData = data;
+
+              return {
+                id: "ban_1",
+              };
+            },
+          },
+          chatHandle: {
+            findUnique: async () => ({
+              createdAt: new Date("2026-04-24T10:00:00.000Z"),
+              handle: "vinicius",
+              id: "handle_1",
+              normalizedHandle: "vinicius",
+              roomId: "room_1",
+              status: "active" as const,
+              updatedAt: new Date("2026-04-24T10:00:00.000Z"),
+            }),
+            update: async () => ({
+              createdAt: new Date("2026-04-24T10:00:00.000Z"),
+              handle: "vinicius",
+              id: "handle_1",
+              normalizedHandle: "vinicius",
+              roomId: "room_1",
+              status: "banned" as const,
+              updatedAt: occurredAt,
+            }),
+          },
+          chatModerationAuditRecord: {
+            create: async ({ data }) => {
+              capturedAuditData = data;
+
+              return {
+                id: "audit_4",
+              };
+            },
+          },
+          chatRoomSession: {
+            updateMany: async ({ where }) => {
+              capturedRevokeWhere = where;
+
+              return {
+                count: 2,
+              };
+            },
+          },
+        }),
+    } as unknown as PrismaDatabaseClient);
+
+    const result = await repository.banHandle({
+      actorAdminUserId: "admin_1",
+      handleId: "handle_1",
+      occurredAt,
+      reason: "abuse",
+    });
+
+    expect(capturedRevokeWhere).not.toBeNull();
+    expect(capturedRevokeWhere!).toEqual({
+      handleId: "handle_1",
+      roomId: "room_1",
+      status: "active",
+    });
+    expect(capturedBanData).toMatchObject({
+      actorAdminUserId: "admin_1",
+      reason: "abuse",
+      roomId: "room_1",
+      status: "active",
+      targetHandleId: "handle_1",
+    });
+    expect(capturedAuditData).toMatchObject({
+      action: "ban_handle",
+      actorAdminUserId: "admin_1",
+      roomId: "room_1",
+      targetBanId: "ban_1",
+      targetHandleId: "handle_1",
+    });
+    expect(result).toEqual({
+      auditId: "audit_4",
+      banId: "ban_1",
+      handle: {
+        createdAt: new Date("2026-04-24T10:00:00.000Z"),
+        handle: "vinicius",
+        id: "handle_1",
+        normalizedHandle: "vinicius",
+        roomId: "room_1",
+        status: "banned",
+        updatedAt: occurredAt,
+      },
+      revokedSessionCount: 2,
+    });
+  });
+
+  it("rotates room password, revokes sessions, and records audit metadata", async () => {
+    let capturedRoomUpdateData: Record<string, unknown> | null = null;
+    let capturedRotationData: Record<string, unknown> | null = null;
+    let capturedAuditData: Record<string, unknown> | null = null;
+    const occurredAt = new Date("2026-04-28T12:10:00.000Z");
+    const repository = createPrismaChatRepository({
+      $transaction: async <T>(
+        runInTransaction: (tx: {
+          chatModerationAuditRecord: {
+            create: (args: { data: Record<string, unknown> }) => Promise<Record<string, unknown>>;
+          };
+          chatRoom: {
+            findUnique: (args: { where: { slug: string } }) => Promise<Record<string, unknown> | null>;
+            update: (args: {
+              data: Record<string, unknown>;
+              where: { id: string };
+            }) => Promise<Record<string, unknown>>;
+          };
+          chatRoomPasswordRotation: {
+            create: (args: { data: Record<string, unknown> }) => Promise<Record<string, unknown>>;
+          };
+          chatRoomSession: {
+            updateMany: (args: {
+              data: Record<string, unknown>;
+              where: Record<string, unknown>;
+            }) => Promise<{ count: number }>;
+          };
+        }) => Promise<T>,
+      ) =>
+        runInTransaction({
+          chatModerationAuditRecord: {
+            create: async ({ data }) => {
+              capturedAuditData = data;
+
+              return {
+                id: "audit_5",
+              };
+            },
+          },
+          chatRoom: {
+            findUnique: async () => ({
+              createdAt: new Date("2026-04-24T10:00:00.000Z"),
+              id: "room_1",
+              passwordHash: "hash:old",
+              passwordRotatedAt: new Date("2026-04-20T10:00:00.000Z"),
+              passwordVersion: 3,
+              slug: "night-shift",
+              updatedAt: new Date("2026-04-24T10:00:00.000Z"),
+            }),
+            update: async ({ data }) => {
+              capturedRoomUpdateData = data;
+
+              return {
+                createdAt: new Date("2026-04-24T10:00:00.000Z"),
+                id: "room_1",
+                passwordHash: "hash:new",
+                passwordRotatedAt: data.passwordRotatedAt as Date,
+                passwordVersion: data.passwordVersion as number,
+                slug: "night-shift",
+                updatedAt: occurredAt,
+              };
+            },
+          },
+          chatRoomPasswordRotation: {
+            create: async ({ data }) => {
+              capturedRotationData = data;
+
+              return {
+                id: "rotation_1",
+                rotatedAt: occurredAt,
+              };
+            },
+          },
+          chatRoomSession: {
+            updateMany: async () => ({
+              count: 4,
+            }),
+          },
+        }),
+    } as unknown as PrismaDatabaseClient);
+
+    const result = await repository.rotateRoomPassword({
+      actorAdminUserId: "admin_1",
+      nextPasswordHash: "hash:new",
+      occurredAt,
+      reason: "credential leak",
+      slug: "night-shift",
+    });
+
+    expect(capturedRoomUpdateData).toMatchObject({
+      passwordHash: "hash:new",
+      passwordRotatedAt: occurredAt,
+      passwordVersion: 4,
+    });
+    expect(capturedRotationData).toMatchObject({
+      actorAdminUserId: "admin_1",
+      nextPasswordHash: "hash:new",
+      nextPasswordVersion: 4,
+      previousPasswordHash: "hash:old",
+      previousPasswordVersion: 3,
+      reason: "credential leak",
+      roomId: "room_1",
+      rotatedAt: occurredAt,
+    });
+    expect(capturedAuditData).toMatchObject({
+      action: "room_password_rotation",
+      actorAdminUserId: "admin_1",
+      reason: "credential leak",
+      roomId: "room_1",
+      targetRoomPasswordRotationId: "rotation_1",
+    });
+    expect(result).toEqual({
+      auditId: "audit_5",
+      revokedSessionCount: 4,
+      room: {
+        createdAt: new Date("2026-04-24T10:00:00.000Z"),
+        id: "room_1",
+        passwordHash: "hash:new",
+        passwordRotatedAt: occurredAt,
+        passwordVersion: 4,
+        slug: "night-shift",
+        updatedAt: occurredAt,
+      },
+      rotation: {
+        id: "rotation_1",
+        rotatedAt: occurredAt,
+      },
+    });
+  });
 });

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
@@ -1,4 +1,6 @@
 import type {
+  BanChatRoomHandleCommand,
+  BanChatRoomHandleResult,
   ChatHandleRepositoryRow,
   ChatMessageListItemRepositoryRow,
   ChatMessageListPage,
@@ -14,8 +16,12 @@ import type {
   CreateChatMessageWithUploadCommand,
   CreateChatMessageWithUploadResult,
   CreateChatRoomSessionCommand,
+  ModerateChatRoomMessageCommand,
+  ModerateChatRoomMessageResult,
   ModerateChatUploadRetentionCommand,
   ModerateChatUploadRetentionResult,
+  RotateChatRoomPasswordCommand,
+  RotateChatRoomPasswordResult,
 } from "@/modules/chat/ports/outbound";
 import { ChatUploadMimeType } from "../../../../../generated/prisma/client";
 
@@ -502,6 +508,376 @@ const moderateUploadRetention = async (
   });
 };
 
+const moderateMessage = async (
+  client: PrismaDatabaseClient,
+  input: ModerateChatRoomMessageCommand,
+): Promise<ModerateChatRoomMessageResult | null> => {
+  return client.$transaction(async (tx) => {
+    const message = await tx.chatMessage.findUnique({
+      select: {
+        authorHandleId: true,
+        body: true,
+        createdAt: true,
+        deletedAt: true,
+        hiddenAt: true,
+        id: true,
+        moderationState: true,
+        roomId: true,
+        roomSessionId: true,
+        sentAt: true,
+        tone: true,
+        updatedAt: true,
+      },
+      where: {
+        id: input.messageId,
+      },
+    });
+
+    if (!message) {
+      return null;
+    }
+
+    const upload = await tx.chatUpload.findUnique({
+      select: {
+        byteSize: true,
+        createdAt: true,
+        deletedAt: true,
+        displayFilename: true,
+        hiddenAt: true,
+        id: true,
+        kind: true,
+        messageId: true,
+        mimeType: true,
+        moderationState: true,
+        roomId: true,
+        storageKey: true,
+        storagePath: true,
+        updatedAt: true,
+        uploaderHandleId: true,
+        uploaderSessionId: true,
+      },
+      where: {
+        messageId: message.id,
+      },
+    });
+
+    const nextMessageHiddenAt = message.hiddenAt ?? input.occurredAt;
+    const nextMessageDeletedAt =
+      input.action === "delete_message"
+        ? message.deletedAt ?? input.occurredAt
+        : message.deletedAt;
+    const nextMessageModerationState =
+      input.action === "delete_message" ||
+      message.moderationState === "deleted" ||
+      !!message.deletedAt
+        ? "deleted"
+        : "hidden";
+
+    const updatedMessage = await tx.chatMessage.update({
+      data: {
+        deletedAt: nextMessageDeletedAt,
+        hiddenAt: nextMessageHiddenAt,
+        moderationState: nextMessageModerationState,
+      },
+      select: {
+        authorHandleId: true,
+        body: true,
+        createdAt: true,
+        deletedAt: true,
+        hiddenAt: true,
+        id: true,
+        moderationState: true,
+        roomId: true,
+        roomSessionId: true,
+        sentAt: true,
+        tone: true,
+        updatedAt: true,
+      },
+      where: {
+        id: message.id,
+      },
+    });
+
+    const updatedUpload = upload
+      ? await tx.chatUpload.update({
+          data: {
+            deletedAt: upload.deletedAt,
+            hiddenAt: upload.hiddenAt ?? input.occurredAt,
+            moderationState:
+              upload.moderationState === "deleted" || upload.deletedAt
+                ? "deleted"
+                : "hidden",
+          },
+          select: {
+            byteSize: true,
+            createdAt: true,
+            deletedAt: true,
+            displayFilename: true,
+            hiddenAt: true,
+            id: true,
+            kind: true,
+            messageId: true,
+            mimeType: true,
+            moderationState: true,
+            roomId: true,
+            storageKey: true,
+            storagePath: true,
+            updatedAt: true,
+            uploaderHandleId: true,
+            uploaderSessionId: true,
+          },
+          where: {
+            id: upload.id,
+          },
+        })
+      : null;
+
+    const audit = await tx.chatModerationAuditRecord.create({
+      data: {
+        action:
+          input.action === "delete_message" ? "delete_message" : "hide_media_metadata",
+        actorAdminUserId: input.actorAdminUserId,
+        nextState: {
+          messageDeletedAt: updatedMessage.deletedAt?.toISOString() ?? null,
+          messageHiddenAt: updatedMessage.hiddenAt?.toISOString() ?? null,
+          messageModerationState: updatedMessage.moderationState,
+          uploadDeletedAt: updatedUpload?.deletedAt?.toISOString() ?? null,
+          uploadHiddenAt: updatedUpload?.hiddenAt?.toISOString() ?? null,
+          uploadModerationState: updatedUpload?.moderationState ?? null,
+        },
+        previousState: {
+          messageDeletedAt: message.deletedAt?.toISOString() ?? null,
+          messageHiddenAt: message.hiddenAt?.toISOString() ?? null,
+          messageModerationState: message.moderationState,
+          uploadDeletedAt: upload?.deletedAt?.toISOString() ?? null,
+          uploadHiddenAt: upload?.hiddenAt?.toISOString() ?? null,
+          uploadModerationState: upload?.moderationState ?? null,
+        },
+        reason: input.reason,
+        roomId: message.roomId,
+        targetMessageId: message.id,
+        targetUploadId: upload?.id ?? null,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    return {
+      auditId: audit.id,
+      message: mapMessageRow(updatedMessage),
+      upload: updatedUpload ? mapUploadRow(updatedUpload) : null,
+    };
+  });
+};
+
+const banHandle = async (
+  client: PrismaDatabaseClient,
+  input: BanChatRoomHandleCommand,
+): Promise<BanChatRoomHandleResult | null> => {
+  return client.$transaction(async (tx) => {
+    const handle = await tx.chatHandle.findUnique({
+      select: {
+        createdAt: true,
+        handle: true,
+        id: true,
+        normalizedHandle: true,
+        roomId: true,
+        status: true,
+        updatedAt: true,
+      },
+      where: {
+        id: input.handleId,
+      },
+    });
+
+    if (!handle) {
+      return null;
+    }
+
+    const nextHandle =
+      handle.status === "banned"
+        ? handle
+        : await tx.chatHandle.update({
+            data: {
+              status: "banned",
+            },
+            select: {
+              createdAt: true,
+              handle: true,
+              id: true,
+              normalizedHandle: true,
+              roomId: true,
+              status: true,
+              updatedAt: true,
+            },
+            where: {
+              id: handle.id,
+            },
+          });
+
+    const revokedSessions = await tx.chatRoomSession.updateMany({
+      data: {
+        leftAt: input.occurredAt,
+        status: "revoked",
+      },
+      where: {
+        handleId: handle.id,
+        roomId: handle.roomId,
+        status: "active",
+      },
+    });
+
+    const ban = await tx.chatBan.create({
+      data: {
+        actorAdminUserId: input.actorAdminUserId,
+        bannedAt: input.occurredAt,
+        reason: input.reason,
+        roomId: handle.roomId,
+        status: "active",
+        targetHandleId: handle.id,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    const audit = await tx.chatModerationAuditRecord.create({
+      data: {
+        action: "ban_handle",
+        actorAdminUserId: input.actorAdminUserId,
+        nextState: {
+          handleStatus: nextHandle.status,
+          revokedSessionCount: revokedSessions.count,
+        },
+        previousState: {
+          handleStatus: handle.status,
+        },
+        reason: input.reason,
+        roomId: handle.roomId,
+        targetBanId: ban.id,
+        targetHandleId: handle.id,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    return {
+      auditId: audit.id,
+      banId: ban.id,
+      handle: mapHandleRow(nextHandle),
+      revokedSessionCount: revokedSessions.count,
+    };
+  });
+};
+
+const rotateRoomPassword = async (
+  client: PrismaDatabaseClient,
+  input: RotateChatRoomPasswordCommand,
+): Promise<RotateChatRoomPasswordResult | null> => {
+  return client.$transaction(async (tx) => {
+    const room = await tx.chatRoom.findUnique({
+      select: {
+        createdAt: true,
+        id: true,
+        passwordHash: true,
+        passwordRotatedAt: true,
+        passwordVersion: true,
+        slug: true,
+        updatedAt: true,
+      },
+      where: {
+        slug: input.slug,
+      },
+    });
+
+    if (!room) {
+      return null;
+    }
+
+    const updatedRoom = await tx.chatRoom.update({
+      data: {
+        passwordHash: input.nextPasswordHash,
+        passwordRotatedAt: input.occurredAt,
+        passwordVersion: room.passwordVersion + 1,
+      },
+      select: {
+        createdAt: true,
+        id: true,
+        passwordHash: true,
+        passwordRotatedAt: true,
+        passwordVersion: true,
+        slug: true,
+        updatedAt: true,
+      },
+      where: {
+        id: room.id,
+      },
+    });
+
+    const rotation = await tx.chatRoomPasswordRotation.create({
+      data: {
+        actorAdminUserId: input.actorAdminUserId,
+        nextPasswordHash: input.nextPasswordHash,
+        nextPasswordVersion: updatedRoom.passwordVersion,
+        previousPasswordHash: room.passwordHash,
+        previousPasswordVersion: room.passwordVersion,
+        reason: input.reason,
+        roomId: room.id,
+        rotatedAt: input.occurredAt,
+      },
+      select: {
+        id: true,
+        rotatedAt: true,
+      },
+    });
+
+    const revokedSessions = await tx.chatRoomSession.updateMany({
+      data: {
+        leftAt: input.occurredAt,
+        status: "revoked",
+      },
+      where: {
+        roomId: room.id,
+        status: "active",
+      },
+    });
+
+    const audit = await tx.chatModerationAuditRecord.create({
+      data: {
+        action: "room_password_rotation",
+        actorAdminUserId: input.actorAdminUserId,
+        nextState: {
+          passwordRotatedAt: updatedRoom.passwordRotatedAt?.toISOString() ?? null,
+          passwordVersion: updatedRoom.passwordVersion,
+          revokedSessionCount: revokedSessions.count,
+        },
+        previousState: {
+          passwordRotatedAt: room.passwordRotatedAt?.toISOString() ?? null,
+          passwordVersion: room.passwordVersion,
+        },
+        reason: input.reason,
+        roomId: room.id,
+        targetRoomPasswordRotationId: rotation.id,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    return {
+      auditId: audit.id,
+      revokedSessionCount: revokedSessions.count,
+      room: mapRoomRow(updatedRoom),
+      rotation: {
+        id: rotation.id,
+        rotatedAt: rotation.rotatedAt,
+      },
+    };
+  });
+};
+
 const listParticipantsByRoomId = async (
   client: PrismaDatabaseClient,
   roomId: string,
@@ -659,8 +1035,13 @@ export const createPrismaChatRepository = (client: PrismaDatabaseClient): ChatRe
   createMessageWithUpload: (input): Promise<CreateChatMessageWithUploadResult> =>
     createMessageWithUpload(client, input),
   createSession: (input): Promise<ChatRoomSessionRepositoryRow> => createSession(client, input),
+  banHandle: (input): Promise<BanChatRoomHandleResult | null> => banHandle(client, input),
+  moderateMessage: (input): Promise<ModerateChatRoomMessageResult | null> =>
+    moderateMessage(client, input),
   moderateUploadRetention: (input): Promise<ModerateChatUploadRetentionResult | null> =>
     moderateUploadRetention(client, input),
+  rotateRoomPassword: (input): Promise<RotateChatRoomPasswordResult | null> =>
+    rotateRoomPassword(client, input),
   findSessionById: async (sessionId): Promise<ChatRoomSessionRepositoryRow | null> => {
     const session = await client.chatRoomSession.findUnique({
       select: {

--- a/backend/src/bootstrap/container/create-container.test.ts
+++ b/backend/src/bootstrap/container/create-container.test.ts
@@ -14,6 +14,9 @@ describe("bootstrap container", () => {
     expect(typeof container.chat.openUploadMedia.execute).toBe("function");
     expect(typeof container.chat.joinRoomSession?.execute).toBe("function");
     expect(typeof container.chat.listRoomMessages?.execute).toBe("function");
+    expect(typeof container.chat.moderateRoomMessage?.execute).toBe("function");
+    expect(typeof container.chat.banRoomHandle?.execute).toBe("function");
+    expect(typeof container.chat.rotateRoomPassword?.execute).toBe("function");
     expect(typeof container.chat.sendRoomTextMessage?.execute).toBe("function");
     expect(typeof container.media.repository.findPhotoMediaById).toBe("function");
     expect(typeof container.media.repository.findChatUploadMediaById).toBe("function");

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -47,20 +47,26 @@ import type {
   VerifyMfaChallengePort,
 } from "@/modules/auth/ports/inbound";
 import {
+  createBanChatRoomHandleUseCase,
   createJoinChatRoomSessionUseCase,
   createListChatRoomMessagesUseCase,
   createListChatRoomParticipantsUseCase,
+  createModerateChatRoomMessageUseCase,
   createModerateChatUploadRetentionUseCase,
   createOpenChatUploadMediaUseCase,
+  createRotateChatRoomPasswordUseCase,
   createSendChatRoomTextMessageUseCase,
   createUploadChatMessageWithImageUseCase,
 } from "@/modules/chat/application";
 import type {
+  BanChatRoomHandlePort,
   JoinChatRoomSessionPort,
   ListChatRoomMessagesPort,
   ListChatRoomParticipantsPort,
+  ModerateChatRoomMessagePort,
   ModerateChatUploadRetentionPort,
   OpenChatUploadMediaPort,
+  RotateChatRoomPasswordPort,
   SendChatRoomTextMessagePort,
   UploadChatMessageWithImagePort,
 } from "@/modules/chat/ports/inbound";
@@ -106,11 +112,14 @@ export type BootstrapContainer = Readonly<{
     verifyMfaChallenge: VerifyMfaChallengePort;
   }>;
   chat: Readonly<{
+    banRoomHandle?: BanChatRoomHandlePort;
     joinRoomSession?: JoinChatRoomSessionPort;
     listRoomMessages?: ListChatRoomMessagesPort;
     listRoomParticipants?: ListChatRoomParticipantsPort;
+    moderateRoomMessage?: ModerateChatRoomMessagePort;
     moderateUploadRetention: ModerateChatUploadRetentionPort;
     openUploadMedia: OpenChatUploadMediaPort;
+    rotateRoomPassword?: RotateChatRoomPasswordPort;
     sendRoomTextMessage?: SendChatRoomTextMessagePort;
     uploadMessageWithImage: UploadChatMessageWithImagePort;
   }>;
@@ -229,6 +238,9 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
       }),
     },
     chat: {
+      banRoomHandle: createBanChatRoomHandleUseCase({
+        repository: persistence.chat,
+      }),
       joinRoomSession: createJoinChatRoomSessionUseCase({
         createSessionToken: () => chatSessionTokenGenerator.create(),
         hashSessionToken: (token) => chatSessionTokenHasher.hash(token),
@@ -247,6 +259,9 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
       listRoomMessages: createListChatRoomMessagesUseCase({
         repository: persistence.chat,
       }),
+      moderateRoomMessage: createModerateChatRoomMessageUseCase({
+        repository: persistence.chat,
+      }),
       moderateUploadRetention: createModerateChatUploadRetentionUseCase({
         repository: persistence.chat,
       }),
@@ -256,6 +271,9 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
         storage: storage.chatUploads,
       }),
       sendRoomTextMessage: createSendChatRoomTextMessageUseCase({
+        repository: persistence.chat,
+      }),
+      rotateRoomPassword: createRotateChatRoomPasswordUseCase({
         repository: persistence.chat,
       }),
       uploadMessageWithImage: createUploadChatMessageWithImageUseCase({

--- a/backend/src/modules/chat/application/index.test.ts
+++ b/backend/src/modules/chat/application/index.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from "bun:test";
 
 import {
   BannedChatHandleError,
+  createBanChatRoomHandleUseCase,
   createJoinChatRoomSessionUseCase,
   createListChatRoomMessagesUseCase,
   createListChatRoomParticipantsUseCase,
+  createModerateChatRoomMessageUseCase,
   createModerateChatUploadRetentionUseCase,
   createOpenChatUploadMediaUseCase,
+  createRotateChatRoomPasswordUseCase,
   createSendChatRoomTextMessageUseCase,
   createUploadChatMessageWithImageUseCase,
   InvalidChatMessageAccessError,
@@ -595,6 +598,233 @@ describe("chat text message send use case", () => {
         slug: "night-shift",
       }),
     ).rejects.toBeInstanceOf(InvalidChatMessageAccessError);
+  });
+});
+
+describe("chat message moderation use case", () => {
+  it("records a hide-message moderation action", async () => {
+    const occurredAt = new Date("2026-04-28T12:06:00.000Z");
+    const capturedCalls: Array<Record<string, unknown>> = [];
+    const useCase = createModerateChatRoomMessageUseCase({
+      clock: () => occurredAt,
+      repository: {
+        moderateMessage: async (input) => {
+          capturedCalls.push(input as unknown as Record<string, unknown>);
+
+          return {
+            auditId: "audit_1",
+            message: {
+              authorHandleId: "handle_1",
+              body: "from the bunker",
+              createdAt: occurredAt,
+              deletedAt: null,
+              hiddenAt: occurredAt,
+              id: "message_1",
+              moderationState: "hidden",
+              roomId: "room_1",
+              roomSessionId: "session_1",
+              sentAt: occurredAt,
+              tone: null,
+              updatedAt: occurredAt,
+            },
+            upload: {
+              byteSize: 512,
+              createdAt: occurredAt,
+              deletedAt: null,
+              displayFilename: "drop.png",
+              hiddenAt: occurredAt,
+              id: "upload_1",
+              kind: "image",
+              messageId: "message_1",
+              mimeType: "image/png",
+              moderationState: "hidden",
+              roomId: "room_1",
+              storageKey: "room_1/upload_1.png",
+              storagePath: "room_1/upload_1.png",
+              updatedAt: occurredAt,
+              uploaderHandleId: "handle_1",
+              uploaderSessionId: "session_1",
+            },
+          };
+        },
+      },
+    });
+
+    const output = await useCase.execute({
+      action: "hide_message",
+      actorAdminUserId: " admin_1 ",
+      messageId: "message_1",
+      reason: "  redact from room thread  ",
+    });
+
+    expect(capturedCalls).toEqual([
+      {
+        action: "hide_message",
+        actorAdminUserId: "admin_1",
+        messageId: "message_1",
+        occurredAt,
+        reason: "redact from room thread",
+      },
+    ]);
+    expect(output).toEqual({
+      action: "hide_message",
+      auditId: "audit_1",
+      messageId: "message_1",
+      messageModerationState: "hidden",
+      uploadId: "upload_1",
+      uploadModerationState: "hidden",
+    });
+  });
+
+  it("returns null when target message does not exist", async () => {
+    const useCase = createModerateChatRoomMessageUseCase({
+      repository: {
+        moderateMessage: async () => null,
+      },
+    });
+
+    await expect(
+      useCase.execute({
+        action: "delete_message",
+        actorAdminUserId: "admin_1",
+        messageId: "message_404",
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("chat handle ban use case", () => {
+  it("creates a ban and returns audit metadata", async () => {
+    const occurredAt = new Date("2026-04-28T12:07:00.000Z");
+    const capturedCalls: Array<Record<string, unknown>> = [];
+    const useCase = createBanChatRoomHandleUseCase({
+      clock: () => occurredAt,
+      repository: {
+        banHandle: async (input) => {
+          capturedCalls.push(input as unknown as Record<string, unknown>);
+
+          return {
+            auditId: "audit_2",
+            banId: "ban_1",
+            handle: {
+              createdAt: occurredAt,
+              handle: "vinicius",
+              id: "handle_1",
+              normalizedHandle: "vinicius",
+              roomId: "room_1",
+              status: "banned",
+              updatedAt: occurredAt,
+            },
+            revokedSessionCount: 2,
+          };
+        },
+      },
+    });
+
+    const output = await useCase.execute({
+      actorAdminUserId: " admin_1 ",
+      handleId: "handle_1",
+      reason: "  repeated abuse  ",
+    });
+
+    expect(capturedCalls).toEqual([
+      {
+        actorAdminUserId: "admin_1",
+        handleId: "handle_1",
+        occurredAt,
+        reason: "repeated abuse",
+      },
+    ]);
+    expect(output).toEqual({
+      auditId: "audit_2",
+      banId: "ban_1",
+      handleId: "handle_1",
+      revokedSessionCount: 2,
+      roomId: "room_1",
+      status: "banned",
+    });
+  });
+});
+
+describe("chat room password rotation use case", () => {
+  it("rotates password hash and returns rotation metadata", async () => {
+    const occurredAt = new Date("2026-04-28T12:08:00.000Z");
+    const capturedCalls: Array<Record<string, unknown>> = [];
+    const useCase = createRotateChatRoomPasswordUseCase({
+      clock: () => occurredAt,
+      hashRoomPassword: async (plainText) => `hash:${plainText}`,
+      repository: {
+        rotateRoomPassword: async (input) => {
+          capturedCalls.push(input as unknown as Record<string, unknown>);
+
+          return {
+            auditId: "audit_3",
+            revokedSessionCount: 3,
+            room: {
+              createdAt: occurredAt,
+              id: "room_1",
+              passwordHash: "hash:new-secret",
+              passwordRotatedAt: occurredAt,
+              passwordVersion: 4,
+              slug: "night-shift",
+              updatedAt: occurredAt,
+            },
+            rotation: {
+              id: "rotation_1",
+              rotatedAt: occurredAt,
+            },
+          };
+        },
+      },
+    });
+
+    const output = await useCase.execute({
+      actorAdminUserId: " admin_1 ",
+      nextPassword: "new-secret",
+      reason: "  leaked in public channel  ",
+      slug: " night-shift ",
+    });
+
+    expect(capturedCalls).toEqual([
+      {
+        actorAdminUserId: "admin_1",
+        nextPasswordHash: "hash:new-secret",
+        occurredAt,
+        reason: "leaked in public channel",
+        slug: "night-shift",
+      },
+    ]);
+    expect(output).toEqual({
+      auditId: "audit_3",
+      revokedSessionCount: 3,
+      room: {
+        id: "room_1",
+        passwordRotatedAt: "2026-04-28T12:08:00.000Z",
+        passwordVersion: 4,
+        slug: "night-shift",
+      },
+      rotation: {
+        id: "rotation_1",
+        rotatedAt: "2026-04-28T12:08:00.000Z",
+      },
+    });
+  });
+
+  it("returns null when room slug does not exist", async () => {
+    const useCase = createRotateChatRoomPasswordUseCase({
+      hashRoomPassword: async (plainText) => `hash:${plainText}`,
+      repository: {
+        rotateRoomPassword: async () => null,
+      },
+    });
+
+    await expect(
+      useCase.execute({
+        actorAdminUserId: "admin_1",
+        nextPassword: "new-secret",
+        slug: "unknown-room",
+      }),
+    ).resolves.toBeNull();
   });
 });
 

--- a/backend/src/modules/chat/application/index.ts
+++ b/backend/src/modules/chat/application/index.ts
@@ -4,6 +4,9 @@ import type {
 } from "@/modules/media/ports/outbound";
 import type { ChatRepositoryPort } from "@/modules/chat/ports/outbound";
 import type {
+  BanChatRoomHandleInput,
+  BanChatRoomHandleOutput,
+  BanChatRoomHandlePort,
   ChatUploadMimeType,
   ChatRoomMessageOutput,
   JoinChatRoomSessionInput,
@@ -15,12 +18,18 @@ import type {
   ListChatRoomParticipantsInput,
   ListChatRoomParticipantsOutput,
   ListChatRoomParticipantsPort,
+  ModerateChatRoomMessageInput,
+  ModerateChatRoomMessageOutput,
+  ModerateChatRoomMessagePort,
   ModerateChatUploadRetentionInput,
   ModerateChatUploadRetentionOutput,
   ModerateChatUploadRetentionPort,
   OpenChatUploadMediaInput,
   OpenChatUploadMediaOutput,
   OpenChatUploadMediaPort,
+  RotateChatRoomPasswordInput,
+  RotateChatRoomPasswordOutput,
+  RotateChatRoomPasswordPort,
   SendChatRoomTextMessageInput,
   SendChatRoomTextMessageOutput,
   SendChatRoomTextMessagePort,
@@ -28,7 +37,10 @@ import type {
   UploadChatMessageWithImageOutput,
   UploadChatMessageWithImagePort,
 } from "@/modules/chat/ports/inbound";
-import type { ModerateChatUploadRetentionAction } from "@/modules/chat/ports/outbound";
+import type {
+  ModerateChatRoomMessageAction,
+  ModerateChatUploadRetentionAction,
+} from "@/modules/chat/ports/outbound";
 
 const IMAGE_ONLY_FALLBACK_BODY = "uploaded an image without a caption";
 
@@ -124,6 +136,10 @@ const hashToken = async (token: string): Promise<string> => {
     .join("");
 };
 
+const hashPassword = async (plainText: string): Promise<string> => {
+  return Bun.password.hash(plainText);
+};
+
 export type ChatApplicationDependencies = Readonly<{
   clock?: () => Date;
   createId?: () => string;
@@ -173,6 +189,22 @@ export type ChatUploadMediaAccessDependencies = Readonly<{
 export type ChatUploadRetentionDependencies = Readonly<{
   clock?: () => Date;
   repository: Pick<ChatRepositoryPort, "moderateUploadRetention">;
+}>;
+
+export type ModerateChatRoomMessageDependencies = Readonly<{
+  clock?: () => Date;
+  repository: Pick<ChatRepositoryPort, "moderateMessage">;
+}>;
+
+export type BanChatRoomHandleDependencies = Readonly<{
+  clock?: () => Date;
+  repository: Pick<ChatRepositoryPort, "banHandle">;
+}>;
+
+export type RotateChatRoomPasswordDependencies = Readonly<{
+  clock?: () => Date;
+  hashRoomPassword?: (plainText: string) => Promise<string>;
+  repository: Pick<ChatRepositoryPort, "rotateRoomPassword">;
 }>;
 
 const normalizeListMessagesLimit = (inputLimit: number | undefined): number => {
@@ -444,6 +476,112 @@ export const createSendChatRoomTextMessageUseCase = ({
       sentAt: message.sentAt,
       tone: message.tone,
     });
+  },
+});
+
+const normalizeMessageModerationAction = (
+  value: ModerateChatRoomMessageInput["action"],
+): ModerateChatRoomMessageAction => value;
+
+export const createModerateChatRoomMessageUseCase = ({
+  clock = () => new Date(),
+  repository,
+}: ModerateChatRoomMessageDependencies): ModerateChatRoomMessagePort => ({
+  execute: async (
+    input: ModerateChatRoomMessageInput,
+  ): Promise<ModerateChatRoomMessageOutput | null> => {
+    const result = await repository.moderateMessage({
+      action: normalizeMessageModerationAction(input.action),
+      actorAdminUserId: input.actorAdminUserId.trim(),
+      messageId: input.messageId,
+      occurredAt: clock(),
+      reason: input.reason?.trim() || undefined,
+    });
+
+    if (!result) {
+      return null;
+    }
+
+    const uploadModerationState =
+      result.upload?.moderationState === "hidden" || result.upload?.moderationState === "deleted"
+        ? result.upload.moderationState
+        : null;
+
+    return {
+      action: input.action,
+      auditId: result.auditId,
+      messageId: result.message.id,
+      messageModerationState:
+        result.message.moderationState === "deleted" ? "deleted" : "hidden",
+      uploadId: result.upload?.id ?? null,
+      uploadModerationState,
+    };
+  },
+});
+
+export const createBanChatRoomHandleUseCase = ({
+  clock = () => new Date(),
+  repository,
+}: BanChatRoomHandleDependencies): BanChatRoomHandlePort => ({
+  execute: async (
+    input: BanChatRoomHandleInput,
+  ): Promise<BanChatRoomHandleOutput | null> => {
+    const result = await repository.banHandle({
+      actorAdminUserId: input.actorAdminUserId.trim(),
+      handleId: input.handleId,
+      occurredAt: clock(),
+      reason: input.reason?.trim() || undefined,
+    });
+
+    if (!result) {
+      return null;
+    }
+
+    return {
+      auditId: result.auditId,
+      banId: result.banId,
+      handleId: result.handle.id,
+      revokedSessionCount: result.revokedSessionCount,
+      roomId: result.handle.roomId,
+      status: "banned",
+    };
+  },
+});
+
+export const createRotateChatRoomPasswordUseCase = ({
+  clock = () => new Date(),
+  hashRoomPassword = hashPassword,
+  repository,
+}: RotateChatRoomPasswordDependencies): RotateChatRoomPasswordPort => ({
+  execute: async (
+    input: RotateChatRoomPasswordInput,
+  ): Promise<RotateChatRoomPasswordOutput | null> => {
+    const result = await repository.rotateRoomPassword({
+      actorAdminUserId: input.actorAdminUserId.trim(),
+      nextPasswordHash: await hashRoomPassword(input.nextPassword),
+      occurredAt: clock(),
+      reason: input.reason?.trim() || undefined,
+      slug: input.slug.trim(),
+    });
+
+    if (!result) {
+      return null;
+    }
+
+    return {
+      auditId: result.auditId,
+      revokedSessionCount: result.revokedSessionCount,
+      room: {
+        id: result.room.id,
+        passwordRotatedAt: result.room.passwordRotatedAt?.toISOString() ?? null,
+        passwordVersion: result.room.passwordVersion,
+        slug: result.room.slug,
+      },
+      rotation: {
+        id: result.rotation.id,
+        rotatedAt: result.rotation.rotatedAt.toISOString(),
+      },
+    };
   },
 });
 

--- a/backend/src/modules/chat/ports/inbound/index.ts
+++ b/backend/src/modules/chat/ports/inbound/index.ts
@@ -93,6 +93,68 @@ export type SendChatRoomTextMessageOutput = ChatRoomMessageOutput;
 export interface SendChatRoomTextMessagePort
   extends UseCase<SendChatRoomTextMessageInput, SendChatRoomTextMessageOutput> {}
 
+export type ModerateChatRoomMessageInput = Readonly<{
+  action: "hide_message" | "delete_message";
+  actorAdminUserId: string;
+  messageId: string;
+  reason?: string;
+}>;
+
+export type ModerateChatRoomMessageOutput = Readonly<{
+  action: "hide_message" | "delete_message";
+  auditId: string;
+  messageId: string;
+  messageModerationState: "hidden" | "deleted";
+  uploadId: string | null;
+  uploadModerationState: "hidden" | "deleted" | null;
+}>;
+
+export interface ModerateChatRoomMessagePort
+  extends UseCase<ModerateChatRoomMessageInput, ModerateChatRoomMessageOutput | null> {}
+
+export type BanChatRoomHandleInput = Readonly<{
+  actorAdminUserId: string;
+  handleId: string;
+  reason?: string;
+}>;
+
+export type BanChatRoomHandleOutput = Readonly<{
+  auditId: string;
+  banId: string;
+  handleId: string;
+  revokedSessionCount: number;
+  roomId: string;
+  status: "banned";
+}>;
+
+export interface BanChatRoomHandlePort
+  extends UseCase<BanChatRoomHandleInput, BanChatRoomHandleOutput | null> {}
+
+export type RotateChatRoomPasswordInput = Readonly<{
+  actorAdminUserId: string;
+  nextPassword: string;
+  reason?: string;
+  slug: string;
+}>;
+
+export type RotateChatRoomPasswordOutput = Readonly<{
+  auditId: string;
+  revokedSessionCount: number;
+  room: Readonly<{
+    id: string;
+    passwordVersion: number;
+    passwordRotatedAt: string | null;
+    slug: string;
+  }>;
+  rotation: Readonly<{
+    id: string;
+    rotatedAt: string;
+  }>;
+}>;
+
+export interface RotateChatRoomPasswordPort
+  extends UseCase<RotateChatRoomPasswordInput, RotateChatRoomPasswordOutput | null> {}
+
 export type UploadChatMessageImageInput = Readonly<{
   body: Uint8Array;
   displayFilename: string;

--- a/backend/src/modules/chat/ports/outbound/index.ts
+++ b/backend/src/modules/chat/ports/outbound/index.ts
@@ -156,6 +156,54 @@ export type ModerateChatUploadRetentionResult = Readonly<{
   upload: ChatUploadRepositoryRow;
 }>;
 
+export type ModerateChatRoomMessageAction = "hide_message" | "delete_message";
+
+export type ModerateChatRoomMessageCommand = Readonly<{
+  action: ModerateChatRoomMessageAction;
+  actorAdminUserId: string;
+  messageId: string;
+  occurredAt: Date;
+  reason?: string;
+}>;
+
+export type ModerateChatRoomMessageResult = Readonly<{
+  auditId: string;
+  message: ChatMessageRepositoryRow;
+  upload: ChatUploadRepositoryRow | null;
+}>;
+
+export type BanChatRoomHandleCommand = Readonly<{
+  actorAdminUserId: string;
+  handleId: string;
+  occurredAt: Date;
+  reason?: string;
+}>;
+
+export type BanChatRoomHandleResult = Readonly<{
+  auditId: string;
+  banId: string;
+  handle: ChatHandleRepositoryRow;
+  revokedSessionCount: number;
+}>;
+
+export type RotateChatRoomPasswordCommand = Readonly<{
+  actorAdminUserId: string;
+  nextPasswordHash: string;
+  occurredAt: Date;
+  reason?: string;
+  slug: string;
+}>;
+
+export type RotateChatRoomPasswordResult = Readonly<{
+  auditId: string;
+  revokedSessionCount: number;
+  room: ChatRoomRepositoryRow;
+  rotation: Readonly<{
+    id: string;
+    rotatedAt: Date;
+  }>;
+}>;
+
 export type ChatRoomQuery = Readonly<{
   slug: string;
 }>;
@@ -181,6 +229,13 @@ export interface ChatRepositoryPort {
   moderateUploadRetention(
     input: ModerateChatUploadRetentionCommand,
   ): Promise<ModerateChatUploadRetentionResult | null>;
+  moderateMessage(
+    input: ModerateChatRoomMessageCommand,
+  ): Promise<ModerateChatRoomMessageResult | null>;
+  banHandle(input: BanChatRoomHandleCommand): Promise<BanChatRoomHandleResult | null>;
+  rotateRoomPassword(
+    input: RotateChatRoomPasswordCommand,
+  ): Promise<RotateChatRoomPasswordResult | null>;
   findHandleById(handleId: string): Promise<ChatHandleRepositoryRow | null>;
   findSessionById(sessionId: string): Promise<ChatRoomSessionRepositoryRow | null>;
   findRoomBySlug(query: ChatRoomQuery): Promise<ChatRoomRepositoryRow | null>;


### PR DESCRIPTION
## Summary
- implement chat moderation use cases for message moderation, handle bans, and room password rotation
- add prisma chat repository support for moderation commands and audit writes
- add admin endpoints under `/api/admin/chat/*` with validation and error mapping
- wire new CHAT-005 ports/use-cases in bootstrap container
- expand application, route, and repository tests for moderation flows

## Files
- backend/src/modules/chat/application/index.ts
- backend/src/modules/chat/ports/inbound/index.ts
- backend/src/modules/chat/ports/outbound/index.ts
- backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
- backend/src/adapters/inbound/http/hono/http-adapter.ts
- backend/src/bootstrap/container/create-container.ts
- tests in corresponding `*.test.ts` files

## Verification
- bun test backend/src/modules/chat/application/index.test.ts backend/src/adapters/inbound/http/hono/admin-routes.test.ts backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts backend/src/bootstrap/container/create-container.test.ts
- bun run --cwd backend typecheck
- bun run --cwd backend test
- bun run --cwd backend verify

Closes #75
