### PR TITLE
[CHAT-006] Implement chat moderation audit trail query API

### DIFF
--- a/backend/src/adapters/inbound/http/hono/admin-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/admin-routes.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from "bun:test";
 import type { BootstrapContainer } from "@/bootstrap/container";
 import { InvalidAdminPhotoMetadataDateError } from "@/modules/admin/application";
 import { InvalidAuthSessionError } from "@/modules/auth/application";
+import { InvalidChatModerationAuditCursorError } from "@/modules/chat/application";
 import type {
   BanChatRoomHandleInput,
   BanChatRoomHandleOutput,
+  ListChatModerationAuditsInput,
+  ListChatModerationAuditsOutput,
   ModerateChatRoomMessageInput,
   ModerateChatRoomMessageOutput,
   RotateChatRoomPasswordInput,
@@ -84,6 +87,12 @@ const createTestContainer = (
     executeBanHandle?: (
       input: BanChatRoomHandleInput,
     ) => BanChatRoomHandleOutput | Promise<BanChatRoomHandleOutput> | null | Promise<null>;
+    executeListModerationAudits?: (
+      input: ListChatModerationAuditsInput,
+    ) =>
+      | ListChatModerationAuditsOutput
+      | Promise<ListChatModerationAuditsOutput>
+      | Promise<never>;
     executeModerateMessage?: (
       input: ModerateChatRoomMessageInput,
     ) =>
@@ -246,6 +255,16 @@ const createTestContainer = (
     banRoomHandle: {
       execute: options.executeBanHandle ?? (async () => null),
     },
+    listModerationAudits: {
+      execute:
+        options.executeListModerationAudits ??
+        (async () => ({
+          items: [],
+          pageInfo: {
+            nextCursor: null,
+          },
+        })),
+    },
     moderateRoomMessage: {
       execute: options.executeModerateMessage ?? (async () => null),
     },
@@ -279,6 +298,14 @@ const createTestContainer = (
       execute: (
         input: BanChatRoomHandleInput,
       ) => BanChatRoomHandleOutput | Promise<BanChatRoomHandleOutput> | null | Promise<null>;
+    };
+    listModerationAudits: {
+      execute: (
+        input: ListChatModerationAuditsInput,
+      ) =>
+        | ListChatModerationAuditsOutput
+        | Promise<ListChatModerationAuditsOutput>
+        | Promise<never>;
     };
     moderateRoomMessage: {
       execute: (
@@ -440,6 +467,177 @@ describe("admin routes", () => {
     await expect(response.json()).resolves.toEqual({
       error: "denied",
       resource: "auth",
+    });
+  });
+
+  it("maps moderation audit listing query params into the use case", async () => {
+    let capturedInput: ListChatModerationAuditsInput | undefined;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeListModerationAudits: async (input) => {
+          capturedInput = input;
+
+          return {
+            items: [
+              {
+                action: "ban_handle",
+                actorAdminUserId: "admin_1",
+                createdAt: "2026-04-28T12:09:00.000Z",
+                id: "audit_2",
+                nextState: {
+                  handleStatus: "banned",
+                },
+                previousState: {
+                  handleStatus: "active",
+                },
+                reason: "abuse",
+                roomId: "room_1",
+                targetBanId: "ban_1",
+                targetHandleId: "handle_1",
+                targetMessageId: null,
+                targetRoomPasswordRotationId: null,
+                targetSessionId: null,
+                targetUploadId: null,
+              },
+            ],
+            pageInfo: {
+              nextCursor: "cursor_1",
+            },
+          };
+        },
+      }),
+    );
+
+    const response = await app.request(
+      "/api/admin/chat/moderation/audits?cursor=cursor_0&limit=20&action=ban_handle&roomId=room_1&actorAdminUserId=admin_2",
+      {
+        headers: {
+          cookie: "vinicius.dev-session=session-token-1",
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      items: [
+        {
+          action: "ban_handle",
+          actorAdminUserId: "admin_1",
+          createdAt: "2026-04-28T12:09:00.000Z",
+          id: "audit_2",
+          nextState: {
+            handleStatus: "banned",
+          },
+          previousState: {
+            handleStatus: "active",
+          },
+          reason: "abuse",
+          roomId: "room_1",
+          targetBanId: "ban_1",
+          targetHandleId: "handle_1",
+          targetMessageId: null,
+          targetRoomPasswordRotationId: null,
+          targetSessionId: null,
+          targetUploadId: null,
+        },
+      ],
+      pageInfo: {
+        nextCursor: "cursor_1",
+      },
+    });
+    expect(capturedInput).toEqual({
+      action: "ban_handle",
+      actorAdminUserId: "admin_2",
+      cursor: "cursor_0",
+      limit: 20,
+      roomId: "room_1",
+    });
+  });
+
+  it("rejects invalid moderation audit action query values", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeListModerationAudits: async () => {
+          called = true;
+
+          return {
+            items: [],
+            pageInfo: {
+              nextCursor: null,
+            },
+          };
+        },
+      }),
+    );
+
+    const response = await app.request(
+      "/api/admin/chat/moderation/audits?action=invalid_action",
+      {
+        headers: {
+          cookie: "vinicius.dev-session=session-token-1",
+        },
+      },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_query",
+      field: "action",
+    });
+    expect(called).toBe(false);
+  });
+
+  it("rejects invalid moderation audit limit query values", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeListModerationAudits: async () => {
+          called = true;
+
+          return {
+            items: [],
+            pageInfo: {
+              nextCursor: null,
+            },
+          };
+        },
+      }),
+    );
+
+    const response = await app.request("/api/admin/chat/moderation/audits?limit=0", {
+      headers: {
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_query",
+      field: "limit",
+    });
+    expect(called).toBe(false);
+  });
+
+  it("maps malformed moderation audit cursor errors to invalid_query", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeListModerationAudits: async () => {
+          throw new InvalidChatModerationAuditCursorError();
+        },
+      }),
+    );
+
+    const response = await app.request("/api/admin/chat/moderation/audits?cursor=bad", {
+      headers: {
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_query",
+      field: "cursor",
     });
   });
 

--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -11,6 +11,7 @@ import { InvalidAdminPhotoMetadataDateError } from "@/modules/admin/application"
 import {
   BannedChatHandleError,
   InvalidChatMessageAccessError,
+  InvalidChatModerationAuditCursorError,
   InvalidChatMessageCursorError,
   InvalidChatParticipantAccessError,
   InvalidChatRoomCredentialsError,
@@ -21,6 +22,7 @@ import { InvalidThoughtCursorError } from "@/modules/content/application";
 import type {
   BanChatRoomHandlePort,
   ChatUploadMimeType,
+  ListChatModerationAuditsPort,
   ListChatRoomMessagesPort,
   ModerateChatRoomMessagePort,
   RotateChatRoomPasswordPort,
@@ -1499,6 +1501,9 @@ const createAdminFamily = (container: BootstrapContainer) => {
   const moderateRoomMessageUseCase = (container.chat as {
     moderateRoomMessage?: ModerateChatRoomMessagePort;
   }).moderateRoomMessage;
+  const listModerationAuditsUseCase = (container.chat as {
+    listModerationAudits?: ListChatModerationAuditsPort;
+  }).listModerationAudits;
   const banRoomHandleUseCase = (container.chat as {
     banRoomHandle?: BanChatRoomHandlePort;
   }).banRoomHandle;
@@ -1924,6 +1929,74 @@ const createAdminFamily = (container: BootstrapContainer) => {
     } catch (error) {
       if (error instanceof InvalidAdminPhotoMetadataDateError) {
         return c.json({ error: "invalid_request", field: "date" }, 400);
+      }
+
+      throw error;
+    }
+  });
+
+  adminApp.get("/chat/moderation/audits", async (c) => {
+    const session = await resolveSession(c);
+
+    if ("error" in session) {
+      return session.error;
+    }
+
+    if (!listModerationAuditsUseCase) {
+      return c.json<NotImplementedResponse>(
+        {
+          family: "admin",
+          method: c.req.method,
+          route: c.req.path,
+          service: serviceName,
+          status: "not_implemented",
+        },
+        501,
+      );
+    }
+
+    const {
+      action,
+      actorAdminUserId,
+      cursor,
+      limit: rawLimit,
+      roomId,
+    } = c.req.query();
+    const limit = parsePositiveInteger(rawLimit);
+
+    if (typeof rawLimit !== "undefined" && typeof limit === "undefined") {
+      return c.json({ error: "invalid_query", field: "limit" }, 400);
+    }
+
+    if (
+      typeof action !== "undefined" &&
+      action !== "delete_message" &&
+      action !== "hide_media_metadata" &&
+      action !== "ban_handle" &&
+      action !== "room_password_rotation"
+    ) {
+      return c.json({ error: "invalid_query", field: "action" }, 400);
+    }
+
+    try {
+      const response = await listModerationAuditsUseCase.execute({
+        action:
+          action === "delete_message" ||
+          action === "hide_media_metadata" ||
+          action === "ban_handle" ||
+          action === "room_password_rotation"
+            ? action
+            : undefined,
+        actorAdminUserId,
+        cursor,
+        limit,
+        roomId,
+      });
+
+      return c.json(response);
+    } catch (error) {
+      if (error instanceof InvalidChatModerationAuditCursorError) {
+        return c.json({ error: "invalid_query", field: "cursor" }, 400);
       }
 
       throw error;

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
@@ -279,6 +279,167 @@ describe("prisma chat repository", () => {
     });
   });
 
+  it("maps moderation audit rows with cursor pagination and optional filters", async () => {
+    let capturedTake = -1;
+    let capturedWhere: Record<string, unknown> = {};
+    const repository = createPrismaChatRepository({
+      chatModerationAuditRecord: {
+        findMany: async ({
+          take,
+          where,
+        }: {
+          take: number;
+          where: Record<string, unknown>;
+        }) => {
+          capturedTake = take;
+          capturedWhere = where;
+
+          return [
+            {
+              action: "ban_handle" as const,
+              actorAdminUserId: "admin_1",
+              createdAt: new Date("2026-04-28T12:09:00.000Z"),
+              id: "audit_3",
+              nextState: {
+                handleStatus: "banned",
+              },
+              previousState: {
+                handleStatus: "active",
+              },
+              reason: "abuse",
+              roomId: "room_1",
+              targetBanId: "ban_1",
+              targetHandleId: "handle_1",
+              targetMessageId: null,
+              targetRoomPasswordRotationId: null,
+              targetSessionId: null,
+              targetUploadId: null,
+            },
+            {
+              action: "ban_handle" as const,
+              actorAdminUserId: "admin_1",
+              createdAt: new Date("2026-04-28T12:08:00.000Z"),
+              id: "audit_2",
+              nextState: {
+                handleStatus: "banned",
+              },
+              previousState: {
+                handleStatus: "active",
+              },
+              reason: "abuse",
+              roomId: "room_1",
+              targetBanId: "ban_1",
+              targetHandleId: "handle_1",
+              targetMessageId: null,
+              targetRoomPasswordRotationId: null,
+              targetSessionId: null,
+              targetUploadId: null,
+            },
+            {
+              action: "ban_handle" as const,
+              actorAdminUserId: "admin_1",
+              createdAt: new Date("2026-04-28T12:07:00.000Z"),
+              id: "audit_1",
+              nextState: {
+                handleStatus: "banned",
+              },
+              previousState: {
+                handleStatus: "active",
+              },
+              reason: "abuse",
+              roomId: "room_1",
+              targetBanId: "ban_1",
+              targetHandleId: "handle_1",
+              targetMessageId: null,
+              targetRoomPasswordRotationId: null,
+              targetSessionId: null,
+              targetUploadId: null,
+            },
+          ];
+        },
+      },
+    } as unknown as PrismaDatabaseClient);
+
+    const page = await repository.listModerationAudits({
+      action: "ban_handle",
+      actorAdminUserId: "admin_1",
+      cursor: {
+        createdAt: new Date("2026-04-28T12:10:00.000Z"),
+        id: "audit_4",
+      },
+      limit: 2,
+      roomId: "room_1",
+    });
+
+    expect(capturedTake).toBe(3);
+    expect(capturedWhere).toEqual({
+      OR: [
+        {
+          createdAt: {
+            lt: new Date("2026-04-28T12:10:00.000Z"),
+          },
+        },
+        {
+          createdAt: new Date("2026-04-28T12:10:00.000Z"),
+          id: {
+            lt: "audit_4",
+          },
+        },
+      ],
+      action: "ban_handle",
+      actorAdminUserId: "admin_1",
+      roomId: "room_1",
+    });
+    expect(page).toEqual({
+      items: [
+        {
+          action: "ban_handle",
+          actorAdminUserId: "admin_1",
+          createdAt: new Date("2026-04-28T12:09:00.000Z"),
+          id: "audit_3",
+          nextState: {
+            handleStatus: "banned",
+          },
+          previousState: {
+            handleStatus: "active",
+          },
+          reason: "abuse",
+          roomId: "room_1",
+          targetBanId: "ban_1",
+          targetHandleId: "handle_1",
+          targetMessageId: null,
+          targetRoomPasswordRotationId: null,
+          targetSessionId: null,
+          targetUploadId: null,
+        },
+        {
+          action: "ban_handle",
+          actorAdminUserId: "admin_1",
+          createdAt: new Date("2026-04-28T12:08:00.000Z"),
+          id: "audit_2",
+          nextState: {
+            handleStatus: "banned",
+          },
+          previousState: {
+            handleStatus: "active",
+          },
+          reason: "abuse",
+          roomId: "room_1",
+          targetBanId: "ban_1",
+          targetHandleId: "handle_1",
+          targetMessageId: null,
+          targetRoomPasswordRotationId: null,
+          targetSessionId: null,
+          targetUploadId: null,
+        },
+      ],
+      nextCursor: {
+        createdAt: new Date("2026-04-28T12:08:00.000Z"),
+        id: "audit_2",
+      },
+    });
+  });
+
   it("creates and maps a chat handle row", async () => {
     let capturedData: Record<string, unknown> | null = null;
     const repository = createPrismaChatRepository({

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
@@ -2,6 +2,10 @@ import type {
   BanChatRoomHandleCommand,
   BanChatRoomHandleResult,
   ChatHandleRepositoryRow,
+  ChatModerationAuditAction,
+  ChatModerationAuditListPage,
+  ChatModerationAuditListQuery,
+  ChatModerationAuditRepositoryRow,
   ChatMessageListItemRepositoryRow,
   ChatMessageListPage,
   ChatMessageListQuery,
@@ -878,6 +882,128 @@ const rotateRoomPassword = async (
   });
 };
 
+const mapModerationAuditRow = (row: {
+  action: ChatModerationAuditAction;
+  actorAdminUserId: string;
+  createdAt: Date;
+  id: string;
+  nextState: unknown | null;
+  previousState: unknown | null;
+  reason: string | null;
+  roomId: string | null;
+  targetBanId: string | null;
+  targetHandleId: string | null;
+  targetMessageId: string | null;
+  targetRoomPasswordRotationId: string | null;
+  targetSessionId: string | null;
+  targetUploadId: string | null;
+}): ChatModerationAuditRepositoryRow => ({
+  action: row.action,
+  actorAdminUserId: row.actorAdminUserId,
+  createdAt: row.createdAt,
+  id: row.id,
+  nextState: row.nextState,
+  previousState: row.previousState,
+  reason: row.reason,
+  roomId: row.roomId,
+  targetBanId: row.targetBanId,
+  targetHandleId: row.targetHandleId,
+  targetMessageId: row.targetMessageId,
+  targetRoomPasswordRotationId: row.targetRoomPasswordRotationId,
+  targetSessionId: row.targetSessionId,
+  targetUploadId: row.targetUploadId,
+});
+
+const buildModerationAuditCursorWhere = (
+  query: ChatModerationAuditListQuery,
+):
+  | {
+      OR: Array<
+        | { createdAt: { lt: Date } }
+        | { createdAt: Date; id: { lt: string } }
+      >;
+    }
+  | undefined => {
+  if (!query.cursor) {
+    return undefined;
+  }
+
+  return {
+    OR: [
+      {
+        createdAt: {
+          lt: query.cursor.createdAt,
+        },
+      },
+      {
+        createdAt: query.cursor.createdAt,
+        id: {
+          lt: query.cursor.id,
+        },
+      },
+    ],
+  };
+};
+
+const listModerationAudits = async (
+  client: PrismaDatabaseClient,
+  query: ChatModerationAuditListQuery,
+): Promise<ChatModerationAuditListPage> => {
+  const rows = await client.chatModerationAuditRecord.findMany({
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    select: {
+      action: true,
+      actorAdminUserId: true,
+      createdAt: true,
+      id: true,
+      nextState: true,
+      previousState: true,
+      reason: true,
+      roomId: true,
+      targetBanId: true,
+      targetHandleId: true,
+      targetMessageId: true,
+      targetRoomPasswordRotationId: true,
+      targetSessionId: true,
+      targetUploadId: true,
+    },
+    take: query.limit + 1,
+    where: {
+      ...buildModerationAuditCursorWhere(query),
+      ...(query.action
+        ? {
+            action: query.action,
+          }
+        : {}),
+      ...(query.roomId
+        ? {
+            roomId: query.roomId,
+          }
+        : {}),
+      ...(query.actorAdminUserId
+        ? {
+            actorAdminUserId: query.actorAdminUserId,
+          }
+        : {}),
+    },
+  });
+
+  const pageRows = rows.slice(0, query.limit);
+  const hasNextPage = rows.length > query.limit;
+  const nextCursorRow = pageRows.at(pageRows.length - 1);
+
+  return {
+    items: pageRows.map(mapModerationAuditRow),
+    nextCursor:
+      hasNextPage && nextCursorRow
+        ? {
+            createdAt: nextCursorRow.createdAt,
+            id: nextCursorRow.id,
+          }
+        : null,
+  };
+};
+
 const listParticipantsByRoomId = async (
   client: PrismaDatabaseClient,
   roomId: string,
@@ -1127,6 +1253,8 @@ export const createPrismaChatRepository = (client: PrismaDatabaseClient): ChatRe
     listParticipantsByRoomId(client, roomId),
   listMessages: (query: ChatMessageListQuery): Promise<ChatMessageListPage> =>
     listMessages(client, query),
+  listModerationAudits: (query: ChatModerationAuditListQuery): Promise<ChatModerationAuditListPage> =>
+    listModerationAudits(client, query),
   findUploadById: (_uploadId: string): Promise<ChatUploadRepositoryRow | null> =>
     notImplemented("findUploadById"),
 });

--- a/backend/src/bootstrap/container/create-container.test.ts
+++ b/backend/src/bootstrap/container/create-container.test.ts
@@ -13,6 +13,7 @@ describe("bootstrap container", () => {
     expect(typeof container.chat.moderateUploadRetention.execute).toBe("function");
     expect(typeof container.chat.openUploadMedia.execute).toBe("function");
     expect(typeof container.chat.joinRoomSession?.execute).toBe("function");
+    expect(typeof container.chat.listModerationAudits?.execute).toBe("function");
     expect(typeof container.chat.listRoomMessages?.execute).toBe("function");
     expect(typeof container.chat.moderateRoomMessage?.execute).toBe("function");
     expect(typeof container.chat.banRoomHandle?.execute).toBe("function");

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -49,6 +49,7 @@ import type {
 import {
   createBanChatRoomHandleUseCase,
   createJoinChatRoomSessionUseCase,
+  createListChatModerationAuditsUseCase,
   createListChatRoomMessagesUseCase,
   createListChatRoomParticipantsUseCase,
   createModerateChatRoomMessageUseCase,
@@ -61,6 +62,7 @@ import {
 import type {
   BanChatRoomHandlePort,
   JoinChatRoomSessionPort,
+  ListChatModerationAuditsPort,
   ListChatRoomMessagesPort,
   ListChatRoomParticipantsPort,
   ModerateChatRoomMessagePort,
@@ -114,6 +116,7 @@ export type BootstrapContainer = Readonly<{
   chat: Readonly<{
     banRoomHandle?: BanChatRoomHandlePort;
     joinRoomSession?: JoinChatRoomSessionPort;
+    listModerationAudits?: ListChatModerationAuditsPort;
     listRoomMessages?: ListChatRoomMessagesPort;
     listRoomParticipants?: ListChatRoomParticipantsPort;
     moderateRoomMessage?: ModerateChatRoomMessagePort;
@@ -254,6 +257,9 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
           }),
       }),
       listRoomParticipants: createListChatRoomParticipantsUseCase({
+        repository: persistence.chat,
+      }),
+      listModerationAudits: createListChatModerationAuditsUseCase({
         repository: persistence.chat,
       }),
       listRoomMessages: createListChatRoomMessagesUseCase({

--- a/backend/src/modules/chat/application/index.test.ts
+++ b/backend/src/modules/chat/application/index.test.ts
@@ -4,6 +4,7 @@ import {
   BannedChatHandleError,
   createBanChatRoomHandleUseCase,
   createJoinChatRoomSessionUseCase,
+  createListChatModerationAuditsUseCase,
   createListChatRoomMessagesUseCase,
   createListChatRoomParticipantsUseCase,
   createModerateChatRoomMessageUseCase,
@@ -12,6 +13,7 @@ import {
   createRotateChatRoomPasswordUseCase,
   createSendChatRoomTextMessageUseCase,
   createUploadChatMessageWithImageUseCase,
+  InvalidChatModerationAuditCursorError,
   InvalidChatMessageAccessError,
   InvalidChatMessageCursorError,
   InvalidChatParticipantAccessError,
@@ -467,6 +469,123 @@ describe("chat message archive list use case", () => {
         slug: "night-shift",
       }),
     ).rejects.toBeInstanceOf(InvalidChatMessageCursorError);
+  });
+});
+
+describe("chat moderation audits list use case", () => {
+  it("lists moderation audits with normalized filters and cursor pagination", async () => {
+    const cursor = Buffer.from(
+      JSON.stringify({
+        createdAt: "2026-04-28T12:05:00.000Z",
+        id: "audit_3",
+      }),
+      "utf8",
+    ).toString("base64url");
+    let capturedQuery: Record<string, unknown> | undefined;
+    const useCase = createListChatModerationAuditsUseCase({
+      repository: {
+        listModerationAudits: async (input) => {
+          capturedQuery = input as unknown as Record<string, unknown>;
+
+          return {
+            items: [
+              {
+                action: "ban_handle",
+                actorAdminUserId: "admin_1",
+                createdAt: new Date("2026-04-28T12:06:00.000Z"),
+                id: "audit_2",
+                nextState: {
+                  handleStatus: "banned",
+                },
+                previousState: {
+                  handleStatus: "active",
+                },
+                reason: "abuse",
+                roomId: "room_1",
+                targetBanId: "ban_1",
+                targetHandleId: "handle_1",
+                targetMessageId: null,
+                targetRoomPasswordRotationId: null,
+                targetSessionId: null,
+                targetUploadId: null,
+              },
+            ],
+            nextCursor: {
+              createdAt: new Date("2026-04-28T12:06:00.000Z"),
+              id: "audit_2",
+            },
+          };
+        },
+      },
+    });
+
+    const output = await useCase.execute({
+      action: "ban_handle",
+      actorAdminUserId: "  admin_1  ",
+      cursor,
+      limit: 999,
+      roomId: "  room_1  ",
+    });
+
+    expect(capturedQuery).toEqual({
+      action: "ban_handle",
+      actorAdminUserId: "admin_1",
+      cursor: {
+        createdAt: new Date("2026-04-28T12:05:00.000Z"),
+        id: "audit_3",
+      },
+      limit: 80,
+      roomId: "room_1",
+    });
+    expect(output).toEqual({
+      items: [
+        {
+          action: "ban_handle",
+          actorAdminUserId: "admin_1",
+          createdAt: "2026-04-28T12:06:00.000Z",
+          id: "audit_2",
+          nextState: {
+            handleStatus: "banned",
+          },
+          previousState: {
+            handleStatus: "active",
+          },
+          reason: "abuse",
+          roomId: "room_1",
+          targetBanId: "ban_1",
+          targetHandleId: "handle_1",
+          targetMessageId: null,
+          targetRoomPasswordRotationId: null,
+          targetSessionId: null,
+          targetUploadId: null,
+        },
+      ],
+      pageInfo: {
+        nextCursor: Buffer.from(
+          JSON.stringify({
+            createdAt: "2026-04-28T12:06:00.000Z",
+            id: "audit_2",
+          }),
+          "utf8",
+        ).toString("base64url"),
+      },
+    });
+  });
+
+  it("rejects malformed moderation audit cursor input", async () => {
+    const useCase = createListChatModerationAuditsUseCase({
+      repository: {
+        listModerationAudits: async () => {
+          throw new Error("should not list moderation audits");
+        },
+      },
+    });
+
+    await expect(
+      useCase.execute({
+        cursor: "invalid-cursor",
+      }),
+    ).rejects.toBeInstanceOf(InvalidChatModerationAuditCursorError);
   });
 });
 

--- a/backend/src/modules/chat/application/index.ts
+++ b/backend/src/modules/chat/application/index.ts
@@ -12,6 +12,9 @@ import type {
   JoinChatRoomSessionInput,
   JoinChatRoomSessionOutput,
   JoinChatRoomSessionPort,
+  ListChatModerationAuditsInput,
+  ListChatModerationAuditsOutput,
+  ListChatModerationAuditsPort,
   ListChatRoomMessagesInput,
   ListChatRoomMessagesOutput,
   ListChatRoomMessagesPort,
@@ -38,6 +41,7 @@ import type {
   UploadChatMessageWithImagePort,
 } from "@/modules/chat/ports/inbound";
 import type {
+  ChatModerationAuditAction,
   ModerateChatRoomMessageAction,
   ModerateChatUploadRetentionAction,
 } from "@/modules/chat/ports/outbound";
@@ -93,6 +97,13 @@ export class InvalidChatMessageCursorError extends Error {
   }
 }
 
+export class InvalidChatModerationAuditCursorError extends Error {
+  constructor() {
+    super("chat moderation audit cursor is invalid");
+    this.name = "InvalidChatModerationAuditCursorError";
+  }
+}
+
 const MIME_EXTENSION_BY_TYPE: Record<ChatUploadMimeType, string> = {
   "image/jpeg": "jpg",
   "image/png": "png",
@@ -124,6 +135,8 @@ const normalizeHandle = (value: string): string => collapseWhitespace(value).toL
 
 const DEFAULT_CHAT_MESSAGES_PAGE_SIZE = 30;
 const MAX_CHAT_MESSAGES_PAGE_SIZE = 80;
+const DEFAULT_CHAT_MODERATION_AUDITS_PAGE_SIZE = 30;
+const MAX_CHAT_MODERATION_AUDITS_PAGE_SIZE = 80;
 
 const defaultSessionToken = (): string => crypto.randomUUID();
 
@@ -172,6 +185,10 @@ export type ListChatRoomMessagesDependencies = Readonly<{
   repository: Pick<ChatRepositoryPort, "findRoomBySlug" | "findSessionById" | "listMessages">;
 }>;
 
+export type ListChatModerationAuditsDependencies = Readonly<{
+  repository: Pick<ChatRepositoryPort, "listModerationAudits">;
+}>;
+
 export type SendChatRoomTextMessageDependencies = Readonly<{
   clock?: () => Date;
   repository: Pick<
@@ -215,6 +232,17 @@ const normalizeListMessagesLimit = (inputLimit: number | undefined): number => {
   return Math.min(Math.max(Math.trunc(inputLimit), 1), MAX_CHAT_MESSAGES_PAGE_SIZE);
 };
 
+const normalizeListModerationAuditsLimit = (inputLimit: number | undefined): number => {
+  if (typeof inputLimit !== "number" || Number.isNaN(inputLimit)) {
+    return DEFAULT_CHAT_MODERATION_AUDITS_PAGE_SIZE;
+  }
+
+  return Math.min(
+    Math.max(Math.trunc(inputLimit), 1),
+    MAX_CHAT_MODERATION_AUDITS_PAGE_SIZE,
+  );
+};
+
 const encodeChatMessageCursor = (cursor: Readonly<{ id: string; sentAt: Date }>): string => {
   return Buffer.from(
     JSON.stringify({
@@ -251,6 +279,54 @@ const decodeChatMessageCursor = (input: string): Readonly<{ id: string; sentAt: 
   }
 };
 
+const encodeChatModerationAuditCursor = (cursor: Readonly<{ createdAt: Date; id: string }>): string => {
+  return Buffer.from(
+    JSON.stringify({
+      createdAt: cursor.createdAt.toISOString(),
+      id: cursor.id,
+    }),
+    "utf8",
+  ).toString("base64url");
+};
+
+const decodeChatModerationAuditCursor = (
+  input: string,
+): Readonly<{ createdAt: Date; id: string }> => {
+  try {
+    const parsed = JSON.parse(Buffer.from(input, "base64url").toString("utf8")) as {
+      createdAt?: unknown;
+      id?: unknown;
+    };
+
+    if (typeof parsed.createdAt !== "string" || typeof parsed.id !== "string") {
+      throw new InvalidChatModerationAuditCursorError();
+    }
+
+    const createdAt = new Date(parsed.createdAt);
+
+    if (Number.isNaN(createdAt.getTime())) {
+      throw new InvalidChatModerationAuditCursorError();
+    }
+
+    return {
+      createdAt,
+      id: parsed.id,
+    };
+  } catch (_error) {
+    throw new InvalidChatModerationAuditCursorError();
+  }
+};
+
+const normalizeChatModerationAuditAction = (
+  value: ListChatModerationAuditsInput["action"],
+): ChatModerationAuditAction | undefined => value;
+
+const normalizeOptionalFilter = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim();
+
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+};
+
 const mapChatMessageOutput = (input: Readonly<{
   attachment?: Readonly<{
     byteSize: number;
@@ -279,6 +355,38 @@ const mapChatMessageOutput = (input: Readonly<{
   body: input.body,
   id: input.id,
   sentAt: input.sentAt.toISOString(),
+});
+
+const mapChatModerationAuditOutput = (input: Readonly<{
+  action: "delete_message" | "hide_media_metadata" | "ban_handle" | "room_password_rotation";
+  actorAdminUserId: string;
+  createdAt: Date;
+  id: string;
+  nextState: unknown | null;
+  previousState: unknown | null;
+  reason: string | null;
+  roomId: string | null;
+  targetBanId: string | null;
+  targetHandleId: string | null;
+  targetMessageId: string | null;
+  targetRoomPasswordRotationId: string | null;
+  targetSessionId: string | null;
+  targetUploadId: string | null;
+}>) => ({
+  action: input.action,
+  actorAdminUserId: input.actorAdminUserId,
+  createdAt: input.createdAt.toISOString(),
+  id: input.id,
+  nextState: input.nextState,
+  previousState: input.previousState,
+  reason: input.reason,
+  roomId: input.roomId,
+  targetBanId: input.targetBanId,
+  targetHandleId: input.targetHandleId,
+  targetMessageId: input.targetMessageId,
+  targetRoomPasswordRotationId: input.targetRoomPasswordRotationId,
+  targetSessionId: input.targetSessionId,
+  targetUploadId: input.targetUploadId,
 });
 
 export const createJoinChatRoomSessionUseCase = ({
@@ -424,6 +532,31 @@ export const createListChatRoomMessagesUseCase = ({
       items: page.items.map((item) => mapChatMessageOutput(item)),
       pageInfo: {
         nextCursor: page.nextCursor ? encodeChatMessageCursor(page.nextCursor) : null,
+      },
+    };
+  },
+});
+
+export const createListChatModerationAuditsUseCase = ({
+  repository,
+}: ListChatModerationAuditsDependencies): ListChatModerationAuditsPort => ({
+  execute: async (
+    input: ListChatModerationAuditsInput,
+  ): Promise<ListChatModerationAuditsOutput> => {
+    const page = await repository.listModerationAudits({
+      action: normalizeChatModerationAuditAction(input.action),
+      actorAdminUserId: normalizeOptionalFilter(input.actorAdminUserId),
+      cursor: input.cursor ? decodeChatModerationAuditCursor(input.cursor) : undefined,
+      limit: normalizeListModerationAuditsLimit(input.limit),
+      roomId: normalizeOptionalFilter(input.roomId),
+    });
+
+    return {
+      items: page.items.map((item) => mapChatModerationAuditOutput(item)),
+      pageInfo: {
+        nextCursor: page.nextCursor
+          ? encodeChatModerationAuditCursor(page.nextCursor)
+          : null,
       },
     };
   },

--- a/backend/src/modules/chat/ports/inbound/index.ts
+++ b/backend/src/modules/chat/ports/inbound/index.ts
@@ -81,6 +81,41 @@ export type ListChatRoomMessagesOutput = Readonly<{
 export interface ListChatRoomMessagesPort
   extends UseCase<ListChatRoomMessagesInput, ListChatRoomMessagesOutput> {}
 
+export type ListChatModerationAuditsInput = Readonly<{
+  action?: "delete_message" | "hide_media_metadata" | "ban_handle" | "room_password_rotation";
+  actorAdminUserId?: string;
+  cursor?: string;
+  limit?: number;
+  roomId?: string;
+}>;
+
+export type ChatModerationAuditOutput = Readonly<{
+  action: "delete_message" | "hide_media_metadata" | "ban_handle" | "room_password_rotation";
+  actorAdminUserId: string;
+  createdAt: string;
+  id: string;
+  nextState: unknown | null;
+  previousState: unknown | null;
+  reason: string | null;
+  roomId: string | null;
+  targetBanId: string | null;
+  targetHandleId: string | null;
+  targetMessageId: string | null;
+  targetRoomPasswordRotationId: string | null;
+  targetSessionId: string | null;
+  targetUploadId: string | null;
+}>;
+
+export type ListChatModerationAuditsOutput = Readonly<{
+  items: readonly ChatModerationAuditOutput[];
+  pageInfo: Readonly<{
+    nextCursor: string | null;
+  }>;
+}>;
+
+export interface ListChatModerationAuditsPort
+  extends UseCase<ListChatModerationAuditsInput, ListChatModerationAuditsOutput> {}
+
 export type SendChatRoomTextMessageInput = Readonly<{
   body: string;
   roomSessionId: string;

--- a/backend/src/modules/chat/ports/outbound/index.ts
+++ b/backend/src/modules/chat/ports/outbound/index.ts
@@ -73,6 +73,34 @@ export type ChatMessageCursor = Readonly<{
   sentAt: Date;
 }>;
 
+export type ChatModerationAuditAction =
+  | "delete_message"
+  | "hide_media_metadata"
+  | "ban_handle"
+  | "room_password_rotation";
+
+export type ChatModerationAuditCursor = Readonly<{
+  createdAt: Date;
+  id: string;
+}>;
+
+export type ChatModerationAuditRepositoryRow = Readonly<{
+  action: ChatModerationAuditAction;
+  actorAdminUserId: string;
+  createdAt: Date;
+  id: string;
+  nextState: unknown | null;
+  previousState: unknown | null;
+  reason: string | null;
+  roomId: string | null;
+  targetBanId: string | null;
+  targetHandleId: string | null;
+  targetMessageId: string | null;
+  targetRoomPasswordRotationId: string | null;
+  targetSessionId: string | null;
+  targetUploadId: string | null;
+}>;
+
 export type ChatUploadRepositoryRow = Readonly<{
   id: string;
   roomId: string;
@@ -172,6 +200,19 @@ export type ModerateChatRoomMessageResult = Readonly<{
   upload: ChatUploadRepositoryRow | null;
 }>;
 
+export type ChatModerationAuditListQuery = Readonly<{
+  action?: ChatModerationAuditAction;
+  actorAdminUserId?: string;
+  cursor?: ChatModerationAuditCursor;
+  limit: number;
+  roomId?: string;
+}>;
+
+export type ChatModerationAuditListPage = Readonly<{
+  items: readonly ChatModerationAuditRepositoryRow[];
+  nextCursor: ChatModerationAuditCursor | null;
+}>;
+
 export type BanChatRoomHandleCommand = Readonly<{
   actorAdminUserId: string;
   handleId: string;
@@ -242,5 +283,6 @@ export interface ChatRepositoryPort {
   findHandleByRoomIdAndNormalizedHandle(roomId: string, normalizedHandle: string): Promise<ChatHandleRepositoryRow | null>;
   listParticipantsByRoomId(roomId: string): Promise<readonly ChatRoomParticipantRepositoryRow[]>;
   listMessages(query: ChatMessageListQuery): Promise<ChatMessageListPage>;
+  listModerationAudits(query: ChatModerationAuditListQuery): Promise<ChatModerationAuditListPage>;
   findUploadById(uploadId: string): Promise<ChatUploadRepositoryRow | null>;
 }


### PR DESCRIPTION
## Summary
- add moderation-audit listing use case and ports in `modules/chat`
- add Prisma repository support for moderation-audit filters and cursor pagination
- add admin endpoint `GET /api/admin/chat/moderation/audits`
- wire `listModerationAudits` in the bootstrap container
- add route/application/repository/container tests for the new endpoint

## Files
- backend/src/modules/chat/application/index.ts
- backend/src/modules/chat/ports/inbound/index.ts
- backend/src/modules/chat/ports/outbound/index.ts
- backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
- backend/src/adapters/inbound/http/hono/http-adapter.ts
- backend/src/bootstrap/container/create-container.ts
- corresponding `*.test.ts` files

## Verification
- bun run --cwd backend verify

Closes #76
