### PR TITLE
[CHAT-007] Add chat lifecycle moderation and audit verification hardening

### DIFF
--- a/backend/scripts/verify.ts
+++ b/backend/scripts/verify.ts
@@ -40,6 +40,14 @@ async function runMediaVerification(): Promise<number> {
   );
 }
 
+async function runAdminChatVerification(): Promise<number> {
+  return runCommand(
+    ["bun", "test", "src/adapters/inbound/http/hono/admin-routes.test.ts"],
+    BACKEND_ROOT,
+    "Running admin chat route verification",
+  );
+}
+
 export async function main(): Promise<number> {
   const violations = await checkBoundaryViolations();
   if (violations.length > 0) {
@@ -60,6 +68,9 @@ export async function main(): Promise<number> {
 
   const mediaVerificationExitCode = await runMediaVerification();
   if (mediaVerificationExitCode !== 0) return mediaVerificationExitCode;
+
+  const adminChatVerificationExitCode = await runAdminChatVerification();
+  if (adminChatVerificationExitCode !== 0) return adminChatVerificationExitCode;
 
   const analyzerExitCode = await runFrontendAnalyzer();
   if (analyzerExitCode !== 0) return analyzerExitCode;

--- a/backend/src/adapters/inbound/http/hono/admin-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/admin-routes.test.ts
@@ -727,6 +727,37 @@ describe("admin routes", () => {
     expect(called).toBe(false);
   });
 
+  it("rejects moderation requests with non-string reason payloads", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeModerateMessage: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
+      }),
+    );
+
+    const response = await app.request("/api/admin/chat/messages/message_1/moderation", {
+      body: JSON.stringify({
+        action: "hide_message",
+        reason: { value: "invalid" },
+      }),
+      headers: {
+        "content-type": "application/json",
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_request",
+      field: "reason",
+    });
+    expect(called).toBe(false);
+  });
+
   it("returns not_found when chat moderation target message does not exist", async () => {
     const app = createHonoHttpAdapter(
       createTestContainer({
@@ -795,6 +826,31 @@ describe("admin routes", () => {
       actorAdminUserId: "admin_1",
       handleId: "handle_1",
       reason: "repeated abuse",
+    });
+  });
+
+  it("returns not_found when chat handle ban target does not exist", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeBanHandle: async () => null,
+      }),
+    );
+
+    const response = await app.request("/api/admin/chat/handles/handle_404/ban", {
+      body: JSON.stringify({
+        reason: "repeated abuse",
+      }),
+      headers: {
+        "content-type": "application/json",
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "not_found",
+      resource: "chat_handle",
     });
   });
 
@@ -900,6 +956,31 @@ describe("admin routes", () => {
       field: "nextPassword",
     });
     expect(called).toBe(false);
+  });
+
+  it("returns not_found when room password rotation target does not exist", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeRotateRoomPassword: async () => null,
+      }),
+    );
+
+    const response = await app.request("/api/admin/chat/rooms/unknown/password-rotation", {
+      body: JSON.stringify({
+        nextPassword: "new-secret",
+      }),
+      headers: {
+        "content-type": "application/json",
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "not_found",
+      resource: "chat_room",
+    });
   });
 
   it("rejects invalid thoughts query parameters", async () => {

--- a/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
@@ -365,6 +365,36 @@ describe("chat routes", () => {
     expect(called).toBe(false);
   });
 
+  it("rejects join requests with a blank room slug before calling the core", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeJoin: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/%20/join", {
+      body: JSON.stringify({
+        handle: "vinicius",
+        password: "open-sesame",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_path",
+      field: "slug",
+    });
+    expect(called).toBe(false);
+  });
+
   it("returns denied when chat room credentials are invalid", async () => {
     const app = createHonoHttpAdapter(
       createTestContainer({
@@ -798,6 +828,34 @@ describe("chat routes", () => {
     await expect(response.json()).resolves.toEqual({
       error: "invalid_request",
       field: "tone",
+    });
+    expect(called).toBe(false);
+  });
+
+  it("rejects text message requests with malformed JSON before calling the core", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeSendText: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/messages", {
+      body: "{",
+      headers: {
+        "content-type": "application/json",
+        "x-chat-room-session-id": "session_1",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_request",
+      field: "body",
     });
     expect(called).toBe(false);
   });

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
@@ -1210,6 +1210,32 @@ describe("prisma chat repository", () => {
     });
   });
 
+  it("returns null when moderating a message that does not exist", async () => {
+    const repository = createPrismaChatRepository({
+      $transaction: async <T>(
+        runInTransaction: (tx: {
+          chatMessage: {
+            findUnique: (args: { where: { id: string } }) => Promise<Record<string, unknown> | null>;
+          };
+        }) => Promise<T>,
+      ) =>
+        runInTransaction({
+          chatMessage: {
+            findUnique: async () => null,
+          },
+        }),
+    } as unknown as PrismaDatabaseClient);
+
+    await expect(
+      repository.moderateMessage({
+        action: "hide_message",
+        actorAdminUserId: "admin_1",
+        messageId: "message_404",
+        occurredAt: new Date("2026-04-28T12:08:00.000Z"),
+      }),
+    ).resolves.toBeNull();
+  });
+
   it("creates a ban record, revokes sessions, and emits moderation audit", async () => {
     let capturedBanData: Record<string, unknown> | null = null;
     let capturedAuditData: Record<string, unknown> | null = null;
@@ -1331,6 +1357,31 @@ describe("prisma chat repository", () => {
       },
       revokedSessionCount: 2,
     });
+  });
+
+  it("returns null when banning a handle that does not exist", async () => {
+    const repository = createPrismaChatRepository({
+      $transaction: async <T>(
+        runInTransaction: (tx: {
+          chatHandle: {
+            findUnique: (args: { where: { id: string } }) => Promise<Record<string, unknown> | null>;
+          };
+        }) => Promise<T>,
+      ) =>
+        runInTransaction({
+          chatHandle: {
+            findUnique: async () => null,
+          },
+        }),
+    } as unknown as PrismaDatabaseClient);
+
+    await expect(
+      repository.banHandle({
+        actorAdminUserId: "admin_1",
+        handleId: "handle_404",
+        occurredAt: new Date("2026-04-28T12:09:00.000Z"),
+      }),
+    ).resolves.toBeNull();
   });
 
   it("rotates room password, revokes sessions, and records audit metadata", async () => {
@@ -1461,5 +1512,31 @@ describe("prisma chat repository", () => {
         rotatedAt: occurredAt,
       },
     });
+  });
+
+  it("returns null when rotating password for a room slug that does not exist", async () => {
+    const repository = createPrismaChatRepository({
+      $transaction: async <T>(
+        runInTransaction: (tx: {
+          chatRoom: {
+            findUnique: (args: { where: { slug: string } }) => Promise<Record<string, unknown> | null>;
+          };
+        }) => Promise<T>,
+      ) =>
+        runInTransaction({
+          chatRoom: {
+            findUnique: async () => null,
+          },
+        }),
+    } as unknown as PrismaDatabaseClient);
+
+    await expect(
+      repository.rotateRoomPassword({
+        actorAdminUserId: "admin_1",
+        nextPasswordHash: "hash:new",
+        occurredAt: new Date("2026-04-28T12:10:00.000Z"),
+        slug: "unknown-room",
+      }),
+    ).resolves.toBeNull();
   });
 });

--- a/backend/src/modules/chat/application/index.test.ts
+++ b/backend/src/modules/chat/application/index.test.ts
@@ -718,6 +718,54 @@ describe("chat text message send use case", () => {
       }),
     ).rejects.toBeInstanceOf(InvalidChatMessageAccessError);
   });
+
+  it("rejects text message send when the session handle is no longer active in the room", async () => {
+    const useCase = createSendChatRoomTextMessageUseCase({
+      repository: {
+        createTextMessage: async () => {
+          throw new Error("should not create message");
+        },
+        findHandleById: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          handle: "vinicius",
+          id: "handle_1",
+          normalizedHandle: "vinicius",
+          roomId: "room_1",
+          status: "banned",
+          updatedAt: new Date("2026-04-28T12:00:00.000Z"),
+        }),
+        findRoomBySlug: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          id: "room_1",
+          passwordHash: "hash",
+          passwordRotatedAt: null,
+          passwordVersion: 1,
+          slug: "night-shift",
+          updatedAt: new Date("2026-04-28T12:00:00.000Z"),
+        }),
+        findSessionById: async () => ({
+          createdAt: new Date("2026-04-28T12:00:00.000Z"),
+          expiresAt: null,
+          handleId: "handle_1",
+          id: "session_1",
+          joinedAt: new Date("2026-04-28T12:00:00.000Z"),
+          lastSeenAt: new Date("2026-04-28T12:00:00.000Z"),
+          leftAt: null,
+          roomId: "room_1",
+          status: "active",
+          updatedAt: new Date("2026-04-28T12:00:00.000Z"),
+        }),
+      },
+    });
+
+    await expect(
+      useCase.execute({
+        body: "message body",
+        roomSessionId: "session_1",
+        slug: "night-shift",
+      }),
+    ).rejects.toBeInstanceOf(InvalidChatMessageAccessError);
+  });
 });
 
 describe("chat message moderation use case", () => {
@@ -795,6 +843,63 @@ describe("chat message moderation use case", () => {
     });
   });
 
+  it("maps delete-message moderation state transitions", async () => {
+    const useCase = createModerateChatRoomMessageUseCase({
+      repository: {
+        moderateMessage: async () => ({
+          auditId: "audit_2",
+          message: {
+            authorHandleId: "handle_1",
+            body: "from the bunker",
+            createdAt: new Date("2026-04-28T12:06:00.000Z"),
+            deletedAt: new Date("2026-04-28T12:06:00.000Z"),
+            hiddenAt: new Date("2026-04-28T12:06:00.000Z"),
+            id: "message_1",
+            moderationState: "deleted",
+            roomId: "room_1",
+            roomSessionId: "session_1",
+            sentAt: new Date("2026-04-28T12:06:00.000Z"),
+            tone: null,
+            updatedAt: new Date("2026-04-28T12:06:00.000Z"),
+          },
+          upload: {
+            byteSize: 512,
+            createdAt: new Date("2026-04-28T12:06:00.000Z"),
+            deletedAt: new Date("2026-04-28T12:06:00.000Z"),
+            displayFilename: "drop.png",
+            hiddenAt: new Date("2026-04-28T12:06:00.000Z"),
+            id: "upload_1",
+            kind: "image",
+            messageId: "message_1",
+            mimeType: "image/png",
+            moderationState: "deleted",
+            roomId: "room_1",
+            storageKey: "room_1/upload_1.png",
+            storagePath: "room_1/upload_1.png",
+            updatedAt: new Date("2026-04-28T12:06:00.000Z"),
+            uploaderHandleId: "handle_1",
+            uploaderSessionId: "session_1",
+          },
+        }),
+      },
+    });
+
+    await expect(
+      useCase.execute({
+        action: "delete_message",
+        actorAdminUserId: "admin_1",
+        messageId: "message_1",
+      }),
+    ).resolves.toEqual({
+      action: "delete_message",
+      auditId: "audit_2",
+      messageId: "message_1",
+      messageModerationState: "deleted",
+      uploadId: "upload_1",
+      uploadModerationState: "deleted",
+    });
+  });
+
   it("returns null when target message does not exist", async () => {
     const useCase = createModerateChatRoomMessageUseCase({
       repository: {
@@ -862,6 +967,21 @@ describe("chat handle ban use case", () => {
       roomId: "room_1",
       status: "banned",
     });
+  });
+
+  it("returns null when the target handle does not exist", async () => {
+    const useCase = createBanChatRoomHandleUseCase({
+      repository: {
+        banHandle: async () => null,
+      },
+    });
+
+    await expect(
+      useCase.execute({
+        actorAdminUserId: "admin_1",
+        handleId: "handle_404",
+      }),
+    ).resolves.toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- harden chat lifecycle/moderation/audit verification coverage in application, route, and repository tests
- add explicit admin chat route verification step to backend verify flow
- keep runtime behavior unchanged (verification-only scope)

## Files
- backend/scripts/verify.ts
- backend/src/modules/chat/application/index.test.ts
- backend/src/adapters/inbound/http/hono/chat-routes.test.ts
- backend/src/adapters/inbound/http/hono/admin-routes.test.ts
- backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts

## Verification
- bun run --cwd backend verify

Closes #78
