### PR TITLE
[INFRA-001] Implement Docker Compose service topology baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Docker Compose defaults for INFRA-001 topology
+POSTGRES_DB=vinicius_dev
+POSTGRES_USER=vinicius_dev
+POSTGRES_PASSWORD=vinicius_dev
+BACKEND_NODE_ENV=development
+BACKEND_PORT=3000
+FRONTEND_PORT=5173

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,81 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-vinicius_dev}
+      POSTGRES_USER: ${POSTGRES_USER:-vinicius_dev}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-vinicius_dev}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-vinicius_dev} -d ${POSTGRES_DB:-vinicius_dev}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - app_net
+
+  backend:
+    image: oven/bun:1.3.11-alpine
+    restart: unless-stopped
+    working_dir: /app/backend
+    command: sh -c "bun install --frozen-lockfile && bun run start"
+    environment:
+      NODE_ENV: ${BACKEND_NODE_ENV:-development}
+      PORT: ${BACKEND_PORT:-3000}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-vinicius_dev}:${POSTGRES_PASSWORD:-vinicius_dev}@postgres:5432/${POSTGRES_DB:-vinicius_dev}?schema=public
+      MEDIA_PHOTOS_ROOT: /var/lib/vinicius.dev/media/photos
+      MEDIA_CHAT_ROOT: /var/lib/vinicius.dev/media/chat
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - .:/app
+      - backend_media_photos:/var/lib/vinicius.dev/media/photos
+      - backend_media_chat:/var/lib/vinicius.dev/media/chat
+    networks:
+      - app_net
+
+  frontend:
+    image: oven/bun:1.3.11-alpine
+    restart: unless-stopped
+    working_dir: /app/frontend
+    command: sh -c "bun install --frozen-lockfile && bun run dev --host 0.0.0.0 --port ${FRONTEND_PORT:-5173}"
+    depends_on:
+      backend:
+        condition: service_started
+    volumes:
+      - .:/app
+    networks:
+      - app_net
+
+  caddy:
+    image: caddy:2.9-alpine
+    restart: unless-stopped
+    depends_on:
+      frontend:
+        condition: service_started
+      backend:
+        condition: service_started
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./infra/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - app_net
+
+networks:
+  app_net:
+    driver: bridge
+
+volumes:
+  postgres_data:
+  backend_media_photos:
+  backend_media_chat:
+  caddy_data:
+  caddy_config:

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,0 +1,4 @@
+:80 {
+	reverse_proxy /api/* backend:3000
+	reverse_proxy frontend:5173
+}


### PR DESCRIPTION
## Summary
- add a baseline `docker-compose.yml` with stable `frontend`, `backend`, `caddy`, and `postgres` services
- define startup relationships and postgres healthcheck for topology readiness
- add persistent volumes for postgres and backend media roots
- add minimal topology-only Caddy proxy wiring and compose env defaults
- preserve INFRA-002/INFRA-003 scope by avoiding full routing and env-policy implementation

## Files
- docker-compose.yml
- infra/caddy/Caddyfile
- .env.example

## Verification
- docker compose -f docker-compose.yml config
- docker compose -f docker-compose.yml --env-file .env.example config
- docker run --rm -v "$PWD/infra/caddy/Caddyfile:/etc/caddy/Caddyfile:ro" caddy:2.9-alpine caddy validate --config /etc/caddy/Caddyfile

Closes #87
