### PR TITLE
[INFRA-002] Implement Caddy routing for API and media paths

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,4 +1,18 @@
-:80 {
-	reverse_proxy /api/* backend:3000
-	reverse_proxy frontend:5173
+development.viniciuslab.dev, viniciuslab.dev, :80 {
+	handle /api/* {
+		reverse_proxy backend:3000
+	}
+
+	handle /media/photos/*/original {
+		reverse_proxy backend:3000
+	}
+
+	# Chat media must remain backend-gated and never public static.
+	handle /media/chat/* {
+		respond "Not Found" 404
+	}
+
+	handle {
+		reverse_proxy frontend:5173
+	}
 }


### PR DESCRIPTION
## Summary
- implement Caddy route contract for Wave 3 `INFRA-002`
- proxy `/api/*` to backend service
- proxy `/media/photos/*/original` to backend service
- deny `/media/chat/*` direct exposure
- preserve frontend fallback routing for non-API/non-media requests

## Files
- infra/caddy/Caddyfile

## Verification
- docker run --rm -v "$PWD/infra/caddy/Caddyfile:/etc/caddy/Caddyfile:ro" caddy:2.9-alpine caddy validate --config /etc/caddy/Caddyfile
- docker compose -f docker-compose.yml config

Closes #88
