### PR TITLE
[INFRA-003] Implement environment and volume policy

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,0 +1,10 @@
+# Development compose policy
+COMPOSE_PROJECT_NAME=vinicius_dev
+
+POSTGRES_DB=vinicius_dev
+POSTGRES_USER=vinicius_dev
+POSTGRES_PASSWORD=change-me-dev
+
+BACKEND_NODE_ENV=development
+BACKEND_PORT=3000
+FRONTEND_PORT=5173

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,13 @@
-# Docker Compose defaults for INFRA-001 topology
+# Base env template.
+# Copy to .env and choose an environment-specific policy file below.
+# Compose project name defines volume/container namespace.
+# Use a unique value per environment to keep Postgres/media volumes separated.
+COMPOSE_PROJECT_NAME=vinicius_dev
+
 POSTGRES_DB=vinicius_dev
 POSTGRES_USER=vinicius_dev
-POSTGRES_PASSWORD=vinicius_dev
+POSTGRES_PASSWORD=change-me
+
 BACKEND_NODE_ENV=development
 BACKEND_PORT=3000
 FRONTEND_PORT=5173

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,10 @@
+# Production compose policy
+COMPOSE_PROJECT_NAME=vinicius_prod
+
+POSTGRES_DB=vinicius_prod
+POSTGRES_USER=vinicius_prod
+POSTGRES_PASSWORD=change-me-prod
+
+BACKEND_NODE_ENV=production
+BACKEND_PORT=3000
+FRONTEND_PORT=5173

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ bun.lockb
 # Environment
 .env
 .env.*
+!.env.dev.example
+!.env.prod.example
 !.env.example
 
 # Build output
@@ -28,4 +30,3 @@ pnpm-debug.log*
 .DS_Store
 .idea/
 .vscode/
-

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,12 @@
+services:
+  backend:
+    command: sh -c "bun install --frozen-lockfile && bun run start"
+    environment:
+      NODE_ENV: ${BACKEND_NODE_ENV:-development}
+    volumes:
+      - .:/app
+
+  frontend:
+    command: sh -c "bun install --frozen-lockfile && bun run dev --host 0.0.0.0 --port ${FRONTEND_PORT:-5173}"
+    volumes:
+      - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ services:
     image: postgres:16-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-vinicius_dev}
-      POSTGRES_USER: ${POSTGRES_USER:-vinicius_dev}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-vinicius_dev}
+      POSTGRES_DB: ${POSTGRES_DB:-vinicius}
+      POSTGRES_USER: ${POSTGRES_USER:-vinicius}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in your env file}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-vinicius_dev} -d ${POSTGRES_DB:-vinicius_dev}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-vinicius} -d ${POSTGRES_DB:-vinicius}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -21,18 +21,17 @@ services:
     image: oven/bun:1.3.11-alpine
     restart: unless-stopped
     working_dir: /app/backend
-    command: sh -c "bun install --frozen-lockfile && bun run start"
+    command: sh -c "bun run start"
     environment:
-      NODE_ENV: ${BACKEND_NODE_ENV:-development}
+      NODE_ENV: ${BACKEND_NODE_ENV:-production}
       PORT: ${BACKEND_PORT:-3000}
-      DATABASE_URL: postgresql://${POSTGRES_USER:-vinicius_dev}:${POSTGRES_PASSWORD:-vinicius_dev}@postgres:5432/${POSTGRES_DB:-vinicius_dev}?schema=public
+      DATABASE_URL: postgresql://${POSTGRES_USER:-vinicius}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-vinicius}?schema=public
       MEDIA_PHOTOS_ROOT: /var/lib/vinicius.dev/media/photos
       MEDIA_CHAT_ROOT: /var/lib/vinicius.dev/media/chat
     depends_on:
       postgres:
         condition: service_healthy
     volumes:
-      - .:/app
       - backend_media_photos:/var/lib/vinicius.dev/media/photos
       - backend_media_chat:/var/lib/vinicius.dev/media/chat
     networks:
@@ -42,12 +41,10 @@ services:
     image: oven/bun:1.3.11-alpine
     restart: unless-stopped
     working_dir: /app/frontend
-    command: sh -c "bun install --frozen-lockfile && bun run dev --host 0.0.0.0 --port ${FRONTEND_PORT:-5173}"
+    command: sh -c "bun run dev --host 0.0.0.0 --port ${FRONTEND_PORT:-5173}"
     depends_on:
       backend:
         condition: service_started
-    volumes:
-      - .:/app
     networks:
       - app_net
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,37 @@
+# Infra environment and volume policy (INFRA-003)
+
+## Environment isolation strategy
+
+- Environment isolation is enforced by `COMPOSE_PROJECT_NAME`.
+- Use different values per environment (for example `vinicius_dev` and `vinicius_prod`).
+- Compose prefixes named volumes with that project name, keeping Postgres and media storage separate.
+
+## Compose files
+
+- Base: `docker-compose.yml` (shared and production-safe defaults).
+- Development override: `docker-compose.dev.yml` (source bind mounts and install-on-start workflow).
+
+## Env templates
+
+- Development template: `.env.dev.example`
+- Production template: `.env.prod.example`
+- Generic template: `.env.example`
+
+## Run examples
+
+Development:
+
+```bash
+docker compose --env-file .env.dev -f docker-compose.yml -f docker-compose.dev.yml up -d
+```
+
+Production:
+
+```bash
+docker compose --env-file .env.prod -f docker-compose.yml up -d
+```
+
+## Secret policy
+
+- Never commit real secrets.
+- Keep committed files as placeholders/samples only (`change-me-*`).


### PR DESCRIPTION
## Summary
- define base + dev-override compose policy for environment separation
- add dev/prod env templates with placeholder secrets
- enforce separation via `COMPOSE_PROJECT_NAME` namespacing for volumes/networks
- document infra env/volume policy in `infra/README.md`
- keep routing and CI workflow scopes unchanged

## Files
- docker-compose.yml
- docker-compose.dev.yml
- .env.example
- .env.dev.example
- .env.prod.example
- .gitignore
- infra/README.md

## Verification
- docker compose --env-file .env.dev.example -f docker-compose.yml -f docker-compose.dev.yml config
- docker compose --env-file .env.prod.example -f docker-compose.yml config

Closes #89
