### PR TITLE
[QA-005] Add persistence and migration validation CI workflow

### DIFF
--- a/.github/workflows/persistence-migration-validation.yml
+++ b/.github/workflows/persistence-migration-validation.yml
@@ -1,0 +1,62 @@
+name: persistence-migration-validation
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - "backend/prisma/**"
+      - "backend/scripts/persistence-check.ts"
+      - "backend/package.json"
+      - "backend/bun.lock"
+      - ".github/workflows/persistence-migration-validation.yml"
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - "backend/prisma/**"
+      - "backend/scripts/persistence-check.ts"
+      - "backend/package.json"
+      - "backend/bun.lock"
+      - ".github/workflows/persistence-migration-validation.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: persistence-migration-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  BUN_VERSION: 1.3.11
+
+jobs:
+  persistence-migration-checks:
+    name: persistence migration checks
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install backend dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run Prisma persistence and migration validation
+        run: bun run prisma:check


### PR DESCRIPTION
## Summary
- add dedicated persistence/migration CI workflow for QA-005
- run backend `bun run prisma:check` using existing repo validation logic
- keep workflow isolated from PR/branch/deploy and other QA scopes

## Files
- .github/workflows/persistence-migration-validation.yml

## Validation
- ruby YAML parse check for workflow syntax

Closes #94
