### PR TITLE
[QA-004] Add backend boundary architecture CI workflow

### DIFF
--- a/.github/workflows/backend-boundary-architecture.yml
+++ b/.github/workflows/backend-boundary-architecture.yml
@@ -1,0 +1,61 @@
+name: backend-boundary-architecture
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - backend/**
+      - docs/specs/backend-architecture.md
+      - docs/specs/project-structure.md
+      - docs/specs/verification.md
+      - .github/workflows/backend-boundary-architecture.yml
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - backend/**
+      - docs/specs/backend-architecture.md
+      - docs/specs/project-structure.md
+      - docs/specs/verification.md
+      - .github/workflows/backend-boundary-architecture.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-boundary-architecture-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  BUN_VERSION: 1.3.11
+
+jobs:
+  backend-boundary-check:
+    name: backend-boundary-check
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install backend dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run backend boundary architecture verification
+        run: bun run verify:boundary


### PR DESCRIPTION
## Summary
- add dedicated backend boundary/architecture CI workflow for QA-004
- run backend `bun run verify:boundary` via existing repo script
- keep workflow scope isolated from other QA and deploy pipelines

## Files
- .github/workflows/backend-boundary-architecture.yml

## Validation
- ruby YAML parse check for workflow syntax

Closes #93
