### PR TITLE
[QA-006] Add tag-gated production deploy workflow

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,0 +1,139 @@
+name: production-deploy
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to redeploy (must match v*)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-deploy-${{ github.event_name == 'push' && github.ref || github.event.inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: preflight checks
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      github.event_name == 'workflow_dispatch'
+    outputs:
+      deploy_tag: ${{ steps.resolve.outputs.deploy_tag }}
+      deploy_sha: ${{ steps.resolve.outputs.deploy_sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve tag and commit
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            DEPLOY_TAG="${GITHUB_REF#refs/tags/}"
+            DEPLOY_SHA="${GITHUB_SHA}"
+          else
+            DEPLOY_TAG="${{ github.event.inputs.tag }}"
+            git fetch --force --tags origin
+            DEPLOY_SHA="$(git rev-list -n 1 "refs/tags/${DEPLOY_TAG}")"
+          fi
+
+          if [[ ! "${DEPLOY_TAG}" =~ ^v[0-9A-Za-z._-]+$ ]]; then
+            echo "Tag '${DEPLOY_TAG}' does not match approved v* policy." >&2
+            exit 1
+          fi
+
+          echo "deploy_tag=${DEPLOY_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "deploy_sha=${DEPLOY_SHA}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify tag commit is on main
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin main
+          if ! git merge-base --is-ancestor "${{ steps.resolve.outputs.deploy_sha }}" "origin/main"; then
+            echo "Release tag must point to a commit already promoted to main." >&2
+            exit 1
+          fi
+
+      - name: Verify QA-002 dependency contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f .github/workflows/branch-validation.yml
+
+      - name: Verify INFRA-002 runtime routing contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f infra/caddy/Caddyfile
+          test -f docker-compose.yml
+          grep -F "handle /api/*" infra/caddy/Caddyfile
+          grep -F "handle /media/photos/*/original" infra/caddy/Caddyfile
+
+  deploy-production:
+    name: deploy production
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      github.event_name == 'workflow_dispatch'
+    environment:
+      name: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required production secrets are configured
+        shell: bash
+        env:
+          PROD_SSH_HOST: ${{ secrets.PROD_SSH_HOST }}
+          PROD_SSH_USER: ${{ secrets.PROD_SSH_USER }}
+          PROD_SSH_PRIVATE_KEY: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+          PROD_SSH_KNOWN_HOSTS: ${{ secrets.PROD_SSH_KNOWN_HOSTS }}
+          PROD_DEPLOY_PATH: ${{ secrets.PROD_DEPLOY_PATH }}
+          PROD_DEPLOY_COMMAND: ${{ secrets.PROD_DEPLOY_COMMAND }}
+        run: |
+          set -euo pipefail
+          for name in PROD_SSH_HOST PROD_SSH_USER PROD_SSH_PRIVATE_KEY PROD_SSH_KNOWN_HOSTS PROD_DEPLOY_PATH PROD_DEPLOY_COMMAND; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "Missing required secret: ${name}" >&2
+              exit 1
+            fi
+          done
+
+      - name: Configure SSH key
+        shell: bash
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${{ secrets.PROD_SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "${{ secrets.PROD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Deploy tagged release to production VPS
+        shell: bash
+        env:
+          DEPLOY_TAG: ${{ needs.preflight.outputs.deploy_tag }}
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          PROD_SSH_HOST: ${{ secrets.PROD_SSH_HOST }}
+          PROD_SSH_USER: ${{ secrets.PROD_SSH_USER }}
+          PROD_DEPLOY_PATH: ${{ secrets.PROD_DEPLOY_PATH }}
+          PROD_DEPLOY_COMMAND: ${{ secrets.PROD_DEPLOY_COMMAND }}
+        run: |
+          set -euo pipefail
+          ssh "${PROD_SSH_USER}@${PROD_SSH_HOST}" \
+            "cd '${PROD_DEPLOY_PATH}' && TAG='${DEPLOY_TAG}' SHA='${DEPLOY_SHA}' ${PROD_DEPLOY_COMMAND}"


### PR DESCRIPTION
## Summary
- add production deploy workflow with strict `v*` tag gating
- prevent deploy execution on PRs and regular branch pushes
- add preflight checks for tag policy, main-branch ancestry, and INFRA-002/QA-002 prerequisite contracts
- deploy via production environment secrets and SSH command contract

## Files
- .github/workflows/production-deploy.yml

## Validation
- ruby YAML parse check for workflow syntax

Closes #95
