### PR TITLE
infra(QA-008): remove stale frontend analyzer dependency from backend verify

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -42,7 +42,7 @@ jobs:
 
           if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
             DEPLOY_TAG="${GITHUB_REF#refs/tags/}"
-            DEPLOY_SHA="${GITHUB_SHA}"
+            DEPLOY_SHA="${GITHUB_SHA}" 
           else
             DEPLOY_TAG="${{ github.event.inputs.tag }}"
             git fetch --force --tags origin

--- a/backend/README.md
+++ b/backend/README.md
@@ -19,7 +19,7 @@ Bun + Hono + TypeScript backend scaffold for Wave 2.
 
 `bun run prisma:check` runs Prisma format, validate, generate, and conditionally migration status. Migration status is skipped with a clear message when `DATABASE_URL` is not set.
 
-`bun run verify` runs the backend boundary check, persistence verification, and the frontend analyzer in non-mutating mode, writing the analyzer output to `/tmp/vinicius-dev-frontend-analyzer-be005.md`.
+`bun run verify` runs the backend boundary check, persistence verification, media verification, selected route/integration tests, and deploy-readiness checks.
 
 ## Persistence
 Copy `.env.example` to `.env` for local development and set `DATABASE_URL` to a PostgreSQL database. DATA-001 only establishes Prisma/Postgres tooling; product models are added by later persistence tasks.

--- a/backend/scripts/verify.ts
+++ b/backend/scripts/verify.ts
@@ -6,8 +6,6 @@ import { checkBoundaryViolations } from "./boundary-check";
 
 const REPO_ROOT = path.resolve(import.meta.dir, "../..");
 const BACKEND_ROOT = path.resolve(import.meta.dir, "..");
-const FRONTEND_ANALYZER = path.join(REPO_ROOT, "scripts", "frontend-analyzer.ts");
-const FRONTEND_ANALYZER_OUTPUT = "/tmp/vinicius-dev-frontend-analyzer-be005.md";
 
 async function runCommand(
   command: readonly string[],
@@ -22,14 +20,6 @@ async function runCommand(
   });
 
   return await proc.exited;
-}
-
-async function runFrontendAnalyzer(): Promise<number> {
-  return runCommand(
-    ["bun", FRONTEND_ANALYZER, `--output=${FRONTEND_ANALYZER_OUTPUT}`],
-    REPO_ROOT,
-    `Running frontend analyzer to ${FRONTEND_ANALYZER_OUTPUT}`,
-  );
 }
 
 async function runMediaVerification(): Promise<number> {
@@ -129,9 +119,6 @@ export async function main(): Promise<number> {
 
   const deployReadinessVerificationExitCode = await runDeployReadinessVerification();
   if (deployReadinessVerificationExitCode !== 0) return deployReadinessVerificationExitCode;
-
-  const analyzerExitCode = await runFrontendAnalyzer();
-  if (analyzerExitCode !== 0) return analyzerExitCode;
 
   console.log("Backend verification passed.");
   return 0;

--- a/docs/specs/ci-cd.md
+++ b/docs/specs/ci-cd.md
@@ -15,10 +15,8 @@ GitHub Actions workflow families, trigger rules, GitHub environments, release-ta
 - Production deploy jobs run on GitHub-hosted runners and connect to the VPS over SSH.
 - `development.viniciuslab.dev` and `viniciuslab.dev` run on the same VPS behind `Caddy`.
 - `Caddy` handles public `80/443` traffic and routes by hostname to separate internal services or ports.
-- Frontend validation uses Bun and must cover install, typecheck/lint where configured, build, and analyzer policy.
+- Frontend validation uses Bun and must cover install, typecheck/lint where configured, and build.
 - Backend validation uses Bun once scaffolded and must cover install, lint/typecheck where configured, tests, Prisma migration checks, and backend boundary checks.
-- Frontend analyzer freshness is required for spec/frontend-impacting PRs.
-- Backend-only PRs run the frontend analyzer as a non-mutating validation check and do not require report changes unless drift is detected.
 - The repo currently has no backend workflow YAML files or deploy descriptors, so this spec defines required validation families and lets implementation tasks wire concrete script names as the runtime is scaffolded.
 
 ## Interfaces and Responsibilities
@@ -32,9 +30,7 @@ GitHub Actions workflow families, trigger rules, GitHub environments, release-ta
 - `pr-validation` is the required review gate for merge readiness.
 - `branch-validation` protects long-lived branches after merges and direct maintenance work.
 - Validation jobs must call canonical frontend and backend verification commands once those commands are defined by package scripts.
-- Frontend validation must run through Bun and include dependency install, static checks configured by the frontend package, production build, and analyzer policy.
-- Spec/frontend-impacting PRs must update or verify `docs/specs/frontend-analyzer-report.md` when frontend contracts change.
-- Backend-only PRs must run `bun scripts/frontend-analyzer.ts` as a non-mutating validation check, preferably writing temporary output outside the repo or comparing without modifying the tracked report.
+- Frontend validation must run through Bun and include dependency install, static checks configured by the frontend package, and production build.
 - Backend validation must run through Bun after backend scaffold exists and include tests, lint/typecheck where configured, Prisma migration validation, and an architectural boundary check.
 - CI must fail on contract drift once analyzer automation and boundary checks exist.
 
@@ -67,7 +63,6 @@ GitHub Actions workflow families, trigger rules, GitHub environments, release-ta
 ### Required command families
 - Frontend install/build family: Bun-based install and production build for the Vite React TypeScript app.
 - Frontend static check family: typecheck and lint commands when configured.
-- Frontend analyzer family: tracked-report refresh for frontend/spec-impacting work and non-mutating validation for backend-only work.
 - Backend install/check family: Bun-based install, typecheck/lint when configured, and unit/integration tests after backend scaffold exists.
 - Prisma migration family: schema format/validate and migration status/check after Prisma exists.
 - Boundary check family: verifies backend domain/application code does not import Hono, Prisma, filesystem, email providers, or other adapter-only dependencies.
@@ -79,7 +74,6 @@ GitHub Actions workflow families, trigger rules, GitHub environments, release-ta
 - release-tag convention
 - VPS deploy transport
 - hostname-to-service routing expectations
-- frontend analyzer freshness policy
 - backend migration and boundary check policy
 
 ## Acceptance Checklist
@@ -93,10 +87,8 @@ GitHub Actions workflow families, trigger rules, GitHub environments, release-ta
 - [ ] `workflow_dispatch` is limited to production redeploy or rerun paths.
 - [ ] GitHub-hosted runners plus SSH are the chosen production deploy transport.
 - [ ] The same-VPS, two-hostname topology is consistent with `Caddy` on `80/443` and internal environment separation.
-- [ ] Frontend checks explicitly use Bun and include build/static-check/analyzer policy.
+- [ ] Frontend checks explicitly use Bun and include build/static-check coverage.
 - [ ] Backend checks explicitly use Bun once scaffolded and include tests, migration validation, and boundary checks.
-- [ ] Spec/frontend-impacting PRs require analyzer freshness.
-- [ ] Backend-only PRs run analyzer as a non-mutating validation check.
 - [ ] Workflow implementation may choose exact package script names, but must satisfy the required command families.
 
 ## Dependencies
@@ -117,7 +109,7 @@ GitHub Actions workflow families, trigger rules, GitHub environments, release-ta
 - Do not split CI/CD implementation tasks until this spec is `Approved`.
 - Keep workflow authoring separate from frontend or backend scaffold tasks if runtime commands are not ready yet.
 - Do not bundle manual development environment operations into GitHub Actions work.
-- Add analyzer and backend boundary checks as separate CI tasks if the first workflow task would otherwise become too broad.
+- Add backend boundary checks as separate CI tasks if the first workflow task would otherwise become too broad.
 
 ## Git Branch Implications
 - CI/CD harness changes use `spec/` branches.

--- a/docs/specs/implementation-playbook.md
+++ b/docs/specs/implementation-playbook.md
@@ -26,7 +26,6 @@ The harness and `develop` must stay aligned. If implementation lands ahead of th
 
 ### Phase 1: Gate review
 - Read [tracker.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/tracker.md).
-- Read the latest [frontend-analyzer-report.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-analyzer-report.md).
 - Approve the specs that block the next layer of work.
 
 ### Phase 2: Task clustering
@@ -180,18 +179,11 @@ Responsibilities:
 - confirm the tracker and cluster docs still describe the active phase correctly when the task closes a cluster
 - confirm `In Review` and `Done` transitions in the tracker
 
-## Commands and Helpers
-### Analyzer
-```bash
-bun scripts/frontend-analyzer.ts
-```
-
 ## Manual Operator Checklist
 Before starting any development session:
 - confirm `develop` exists
 - open the tracker
 - identify the current highest-priority approved cluster
-- confirm the analyzer report is current
 
 Before assigning an agent:
 - confirm the task exists in `tracker.md`


### PR DESCRIPTION
## Summary
- Task ID: `QA-008`
- Source tracker entry: `docs/specs/tracker.md` (`QA-008`)
- Source spec: `docs/specs/ci-workflow-maintenance.md`

## Branching
- Base branch: `develop`
- Merge target: `develop`

## Acceptance
- Acceptance source: `docs/specs/ci-workflow-maintenance.md`
- Verification performed:
  - removed the stale `scripts/frontend-analyzer.ts` invocation from `backend/scripts/verify.ts`
  - updated backend/docs references that still described the removed analyzer contract
  - ran `cd backend && bun run verify`
- Required CI status checks:
  - `pr-validation / backend verify`

## Notes
- Deployment impact: none; this only removes a stale CI verification dependency and aligns docs/spec text with the current workflow maintenance scope.
- Revert impact: revert commit `71b0d95` to restore the previous backend verify behavior and related documentation references.
- Follow-up tasks:
  - none required for this fix; merged QA-008 follow-up PR #117 removed the analyzer script, and this PR removes the remaining backend verify dependency that still referenced it.
