### PR TITLE
SEC-003 MFA challenge lockout and production delivery

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -12,3 +12,10 @@ FRONTEND_PORT=5173
 # Development placeholders
 AUTH_SESSION_SECRET=development-session-secret
 AUTH_ROOM_PASSWORD_SECRET=development-room-password-secret
+
+# MFA defaults; leave Resend values empty to use the development debug fallback
+AUTH_MFA_ENABLED=true
+AUTH_MFA_CODE_MAX_AGE_SECONDS=600
+AUTH_MFA_MAX_ATTEMPTS=5
+AUTH_MFA_RESEND_FROM_EMAIL=
+AUTH_MFA_RESEND_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,10 @@ FRONTEND_PORT=5173
 # Required when BACKEND_NODE_ENV=production
 AUTH_SESSION_SECRET=change-me-session-secret
 AUTH_ROOM_PASSWORD_SECRET=change-me-room-password-secret
+
+# MFA defaults and delivery
+AUTH_MFA_ENABLED=true
+AUTH_MFA_CODE_MAX_AGE_SECONDS=600
+AUTH_MFA_MAX_ATTEMPTS=5
+AUTH_MFA_RESEND_FROM_EMAIL=Vinicius Dev <no-reply@example.com>
+AUTH_MFA_RESEND_API_KEY=

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -12,3 +12,10 @@ FRONTEND_PORT=5173
 # Required production auth secrets (must be unique, high-entropy values)
 AUTH_SESSION_SECRET=change-me-prod-session-secret
 AUTH_ROOM_PASSWORD_SECRET=change-me-prod-room-password-secret
+
+# MFA production delivery (required when AUTH_MFA_ENABLED=true)
+AUTH_MFA_ENABLED=true
+AUTH_MFA_CODE_MAX_AGE_SECONDS=600
+AUTH_MFA_MAX_ATTEMPTS=5
+AUTH_MFA_RESEND_FROM_EMAIL=Vinicius Dev <no-reply@example.com>
+AUTH_MFA_RESEND_API_KEY=replace-with-resend-api-key

--- a/backend/src/adapters/inbound/http/hono/admin-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/admin-routes.test.ts
@@ -366,6 +366,7 @@ const createTestContainer = (
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,
+      mfaMaxAttempts: 5,
       roomPasswordSecret: "test-room-secret",
       sessionCookieName: "vinicius.dev-session",
       sessionMaxAgeSeconds: 604800,

--- a/backend/src/adapters/inbound/http/hono/auth-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/auth-routes.test.ts
@@ -98,6 +98,7 @@ const createTestContainer = (
     config: {
       auth: {
         mfaCodeMaxAgeSeconds: 600,
+        mfaMaxAttempts: 5,
         roomPasswordSecret: "test-room-secret",
         sessionCookieName: "vinicius.dev-session",
         sessionMaxAgeSeconds: 604800,

--- a/backend/src/adapters/inbound/http/hono/auth-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/auth-routes.test.ts
@@ -69,6 +69,10 @@ const createDefaultAuth = (): NonNullable<BootstrapContainer["auth"]> => ({
 
 const createTestContainer = (
   auth?: Partial<NonNullable<BootstrapContainer["auth"]>>,
+  cors?: Readonly<{
+    allowCredentials?: boolean;
+    allowedOrigins?: string[];
+  }>,
 ): BootstrapContainer => {
   const base: BootstrapContainer = {
     chat: {
@@ -104,8 +108,8 @@ const createTestContainer = (
         sessionSecret: "test-session-secret",
       },
       cors: {
-        allowCredentials: true,
-        allowedOrigins: [],
+        allowCredentials: cors?.allowCredentials ?? true,
+        allowedOrigins: cors?.allowedOrigins ?? [],
       },
       media: {
         chatRoot: "/tmp/chat",
@@ -206,6 +210,58 @@ const createTestContainer = (
 };
 
 describe("auth routes", () => {
+  it("applies CORS policy from bootstrap config for allowed origins", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer(
+        {},
+        {
+          allowCredentials: true,
+          allowedOrigins: ["https://app.viniciuslab.dev"],
+        },
+      ),
+    );
+
+    const response = await app.request("/api/auth/login", {
+      headers: {
+        "access-control-request-headers": "content-type,x-chat-room-session-id",
+        "access-control-request-method": "POST",
+        origin: "https://app.viniciuslab.dev",
+      },
+      method: "OPTIONS",
+    });
+
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      "https://app.viniciuslab.dev",
+    );
+    expect(response.headers.get("access-control-allow-credentials")).toBe("true");
+    expect(response.headers.get("access-control-allow-methods")).toContain("POST");
+    expect(response.headers.get("access-control-allow-headers")).toContain(
+      "x-chat-room-session-id",
+    );
+  });
+
+  it("does not allow CORS for origins outside the bootstrap allowlist", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer(
+        {},
+        {
+          allowCredentials: true,
+          allowedOrigins: ["https://app.viniciuslab.dev"],
+        },
+      ),
+    );
+
+    const response = await app.request("/api/auth/login", {
+      headers: {
+        "access-control-request-method": "POST",
+        origin: "https://evil.example",
+      },
+      method: "OPTIONS",
+    });
+
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
   it("maps login payload to the auth use case", async () => {
     let capturedEmail: string | undefined;
     let capturedPassword: string | undefined;
@@ -369,6 +425,64 @@ describe("auth routes", () => {
     });
   });
 
+  it("rate limits repeated login attempts", async () => {
+    let callCount = 0;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        loginWithCredentials: {
+          execute: async () => {
+            callCount += 1;
+
+            return {
+              challenge: {
+                delivery: "email",
+                expiresAt: "2026-04-28T12:10:00.000Z",
+                id: "challenge_1",
+                maskedEmail: "ad***@example.com",
+              },
+              state: "mfa_required",
+            };
+          },
+        },
+      }),
+    );
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const response = await app.request("/api/auth/login", {
+        body: JSON.stringify({
+          email: "admin@example.com",
+          password: "correct-password",
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-forwarded-for": "203.0.113.10",
+        },
+        method: "POST",
+      });
+
+      expect(response.status).toBe(200);
+    }
+
+    const limitedResponse = await app.request("/api/auth/login", {
+      body: JSON.stringify({
+        email: "admin@example.com",
+        password: "correct-password",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-for": "203.0.113.10",
+      },
+      method: "POST",
+    });
+
+    expect(limitedResponse.status).toBe(429);
+    await expect(limitedResponse.json()).resolves.toEqual({
+      error: "rate_limited",
+      resource: "api",
+    });
+    expect(callCount).toBe(5);
+  });
+
   it("maps MFA verify payload and returns ready state", async () => {
     let capturedChallengeId: string | undefined;
     let capturedCode: string | undefined;
@@ -526,6 +640,67 @@ describe("auth routes", () => {
       error: "challenge_not_pending",
       resource: "mfa_challenge",
     });
+  });
+
+  it("rate limits repeated MFA verification attempts", async () => {
+    let callCount = 0;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        verifyMfaChallenge: {
+          execute: async () => {
+            callCount += 1;
+
+            return {
+              admin: {
+                email: "admin@example.com",
+                id: "admin_1",
+              },
+              session: {
+                expiresAt: "2026-04-28T12:10:00.000Z",
+                id: "session_1",
+              },
+              sessionToken: "session-token-1",
+              state: "ready",
+            };
+          },
+        },
+      }),
+    );
+
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const response = await app.request("/api/auth/mfa/verify", {
+        body: JSON.stringify({
+          challengeId: "challenge_1",
+          code: "123456",
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-forwarded-for": "203.0.113.11",
+        },
+        method: "POST",
+      });
+
+      expect(response.status).toBe(200);
+    }
+
+    const limitedResponse = await app.request("/api/auth/mfa/verify", {
+      body: JSON.stringify({
+        challengeId: "challenge_1",
+        code: "123456",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-for": "203.0.113.11",
+      },
+      method: "POST",
+    });
+
+    expect(limitedResponse.status).toBe(429);
+    await expect(limitedResponse.json()).resolves.toEqual({
+      error: "rate_limited",
+      resource: "api",
+    });
+    expect(callCount).toBe(10);
   });
 
   it("refreshes an admin session from cookie auth", async () => {

--- a/backend/src/adapters/inbound/http/hono/chat-media-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-media-routes.test.ts
@@ -51,6 +51,7 @@ const createTestContainer = ({
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,
+      mfaMaxAttempts: 5,
       roomPasswordSecret: "test-room-secret",
       sessionCookieName: "vinicius.dev-session",
       sessionMaxAgeSeconds: 604800,

--- a/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
@@ -1151,4 +1151,156 @@ describe("chat routes", () => {
       resource: "chat",
     });
   });
+
+  it("rate limits repeated chat room join attempts", async () => {
+    let callCount = 0;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeJoin: async () => {
+          callCount += 1;
+
+          return {
+            participant: {
+              handle: "vinicius",
+              id: "handle_1",
+              status: "online",
+            },
+            room: {
+              id: "room_1",
+              slug: "night-shift",
+            },
+            session: {
+              expiresAt: "2026-04-25T12:00:00.000Z",
+              handleId: "handle_1",
+              id: "session_1",
+              joinedAt: "2026-04-24T12:00:00.000Z",
+              roomId: "room_1",
+              status: "active",
+            },
+          };
+        },
+      }),
+    );
+
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const response = await app.request("/api/chat/rooms/night-shift/join", {
+        body: JSON.stringify({
+          handle: "vinicius",
+          password: "open-sesame",
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-forwarded-for": "198.51.100.10",
+        },
+        method: "POST",
+      });
+
+      expect(response.status).toBe(200);
+    }
+
+    const limitedResponse = await app.request("/api/chat/rooms/night-shift/join", {
+      body: JSON.stringify({
+        handle: "vinicius",
+        password: "open-sesame",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-for": "198.51.100.10",
+      },
+      method: "POST",
+    });
+
+    expect(limitedResponse.status).toBe(429);
+    await expect(limitedResponse.json()).resolves.toEqual({
+      error: "rate_limited",
+      resource: "api",
+    });
+    expect(callCount).toBe(10);
+  });
+
+  it("rate limits repeated chat message send attempts", async () => {
+    let callCount = 0;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeSendText: async () => {
+          callCount += 1;
+          return defaultTextMessageResponse;
+        },
+      }),
+    );
+
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      const response = await app.request("/api/chat/rooms/night-shift/messages", {
+        body: JSON.stringify({
+          body: "message body",
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-chat-room-session-id": "session_1",
+          "x-forwarded-for": "198.51.100.11",
+        },
+        method: "POST",
+      });
+
+      expect(response.status).toBe(201);
+    }
+
+    const limitedResponse = await app.request("/api/chat/rooms/night-shift/messages", {
+      body: JSON.stringify({
+        body: "message body",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-chat-room-session-id": "session_1",
+        "x-forwarded-for": "198.51.100.11",
+      },
+      method: "POST",
+    });
+
+    expect(limitedResponse.status).toBe(429);
+    await expect(limitedResponse.json()).resolves.toEqual({
+      error: "rate_limited",
+      resource: "api",
+    });
+    expect(callCount).toBe(30);
+  });
+
+  it("rate limits repeated chat upload attempts", async () => {
+    let callCount = 0;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeUpload: async () => {
+          callCount += 1;
+          return defaultUploadResponse;
+        },
+      }),
+    );
+
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const response = await app.request("/api/chat/messages/upload", {
+        body: createUploadFormData(),
+        headers: {
+          "x-forwarded-for": "198.51.100.12",
+        },
+        method: "POST",
+      });
+
+      expect(response.status).toBe(201);
+    }
+
+    const limitedResponse = await app.request("/api/chat/messages/upload", {
+      body: createUploadFormData(),
+      headers: {
+        "x-forwarded-for": "198.51.100.12",
+      },
+      method: "POST",
+    });
+
+    expect(limitedResponse.status).toBe(429);
+    await expect(limitedResponse.json()).resolves.toEqual({
+      error: "rate_limited",
+      resource: "api",
+    });
+    expect(callCount).toBe(10);
+  });
 });

--- a/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
@@ -180,6 +180,7 @@ const createTestContainer = ({
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,
+      mfaMaxAttempts: 5,
       roomPasswordSecret: "test-room-secret",
       sessionCookieName: "vinicius.dev-session",
       sessionMaxAgeSeconds: 604800,

--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -2,6 +2,7 @@ import { extname } from "node:path";
 
 import { Hono, type Context } from "hono";
 import { upgradeWebSocket } from "hono/bun";
+import { cors } from "hono/cors";
 
 import {
   InvalidAuthCredentialsError,
@@ -42,6 +43,15 @@ import { presentSitemapXml } from "./sitemap-presenter";
 
 const serviceName = "vinicius.dev-backend";
 const defaultMediaContentType = "application/octet-stream";
+const corsAllowMethods = [
+  "GET",
+  "POST",
+  "PATCH",
+  "PUT",
+  "DELETE",
+  "OPTIONS",
+] as const;
+const corsAllowHeaders = ["Content-Type", "x-chat-room-session-id"] as const;
 const mediaContentTypeByExtension: Record<string, string> = {
   ".avif": "image/avif",
   ".gif": "image/gif",
@@ -86,6 +96,24 @@ type ChatLiveConnection = Readonly<{
   roomSlug: string;
   socket: ChatLiveSocket;
 }>;
+
+type RateLimitRule = Readonly<{
+  maxRequests: number;
+  windowMs: number;
+}>;
+
+type RateLimitWindow = Readonly<{
+  count: number;
+  resetAt: number;
+}>;
+
+const rateLimitRules = {
+  authLogin: { maxRequests: 5, windowMs: 60_000 },
+  authMfaVerify: { maxRequests: 10, windowMs: 60_000 },
+  chatJoin: { maxRequests: 10, windowMs: 60_000 },
+  chatSendMessage: { maxRequests: 30, windowMs: 60_000 },
+  chatUpload: { maxRequests: 10, windowMs: 60_000 },
+} as const satisfies Record<string, RateLimitRule>;
 
 const createChatLiveManager = () => {
   const connectionsByRoomSlug = new Map<string, Map<string, ChatLiveConnection>>();
@@ -178,6 +206,55 @@ const createChatLiveManager = () => {
 
       this.broadcast(roomSlug, payload);
     },
+  };
+};
+
+const parseForwardedForAddress = (value: string | undefined) =>
+  value
+    ?.split(",")
+    .map((candidate) => candidate.trim())
+    .find((candidate) => candidate.length > 0);
+
+const resolveRateLimitClientKey = (context: Context) =>
+  parseForwardedForAddress(context.req.header("x-forwarded-for")) ??
+  context.req.header("x-real-ip")?.trim() ??
+  context.req.header("cf-connecting-ip")?.trim() ??
+  "global";
+
+const createRateLimiter = (rule: RateLimitRule) => {
+  const windows = new Map<string, RateLimitWindow>();
+
+  return (context: Context) => {
+    const now = Date.now();
+    const key = resolveRateLimitClientKey(context);
+    const existing = windows.get(key);
+
+    if (!existing || now >= existing.resetAt) {
+      windows.set(key, {
+        count: 1,
+        resetAt: now + rule.windowMs,
+      });
+      return null;
+    }
+
+    if (existing.count >= rule.maxRequests) {
+      context.header("Retry-After", String(Math.max(1, Math.ceil((existing.resetAt - now) / 1000))));
+
+      return context.json(
+        {
+          error: "rate_limited",
+          resource: "api",
+        },
+        429,
+      );
+    }
+
+    windows.set(key, {
+      count: existing.count + 1,
+      resetAt: existing.resetAt,
+    });
+
+    return null;
   };
 };
 
@@ -720,6 +797,9 @@ const createChatFamily = (
   live: ReturnType<typeof createChatLiveManager>,
 ) => {
   const chatApp = new Hono();
+  const joinRateLimiter = createRateLimiter(rateLimitRules.chatJoin);
+  const sendMessageRateLimiter = createRateLimiter(rateLimitRules.chatSendMessage);
+  const uploadRateLimiter = createRateLimiter(rateLimitRules.chatUpload);
   const resolveRoomSessionUseCase = (container.chat as {
     resolveRoomSession?: ResolveChatRoomSessionPort;
   }).resolveRoomSession;
@@ -754,6 +834,12 @@ const createChatFamily = (
   };
 
   chatApp.post("/rooms/:slug/join", async (c) => {
+    const limited = joinRateLimiter(c);
+
+    if (limited) {
+      return limited;
+    }
+
     if (!container.chat.joinRoomSession) {
       return c.json<NotImplementedResponse>(
         {
@@ -1088,6 +1174,12 @@ const createChatFamily = (
   });
 
   chatApp.post("/rooms/:slug/messages", async (c) => {
+    const limited = sendMessageRateLimiter(c);
+
+    if (limited) {
+      return limited;
+    }
+
     if (!sendRoomTextMessageUseCase) {
       return c.json<NotImplementedResponse>(
         {
@@ -1254,6 +1346,12 @@ const createChatFamily = (
   });
 
   chatApp.post("/messages/upload", async (c) => {
+    const limited = uploadRateLimiter(c);
+
+    if (limited) {
+      return limited;
+    }
+
     let formData: FormData;
 
     try {
@@ -1525,8 +1623,16 @@ const createAuthFamily = (container: BootstrapContainer) => {
   }
 
   const authApp = new Hono();
+  const loginRateLimiter = createRateLimiter(rateLimitRules.authLogin);
+  const mfaVerifyRateLimiter = createRateLimiter(rateLimitRules.authMfaVerify);
 
   authApp.post("/login", async (c) => {
+    const limited = loginRateLimiter(c);
+
+    if (limited) {
+      return limited;
+    }
+
     const parsedBody = await readJsonObject(c.req.raw);
 
     if ("error" in parsedBody) {
@@ -1582,6 +1688,12 @@ const createAuthFamily = (container: BootstrapContainer) => {
   });
 
   authApp.post("/mfa/verify", async (c) => {
+    const limited = mfaVerifyRateLimiter(c);
+
+    if (limited) {
+      return limited;
+    }
+
     const parsedBody = await readJsonObject(c.req.raw);
 
     if ("error" in parsedBody) {
@@ -2621,6 +2733,16 @@ const createSitemapFamily = () => {
 export const createHonoHttpAdapter = (container: BootstrapContainer) => {
   const app = new Hono();
   const live = createChatLiveManager();
+
+  app.use(
+    "/api/*",
+    cors({
+      allowHeaders: [...corsAllowHeaders],
+      allowMethods: [...corsAllowMethods],
+      credentials: container.config.cors.allowCredentials,
+      origin: container.config.cors.allowedOrigins,
+    }),
+  );
 
   app.get("/api", (c) =>
     c.json({

--- a/backend/src/adapters/inbound/http/hono/photo-media-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/photo-media-routes.test.ts
@@ -84,6 +84,7 @@ const createTestContainer = (options: TestContainerOptions = {}): BootstrapConta
     config: {
       auth: {
         mfaCodeMaxAgeSeconds: 600,
+        mfaMaxAttempts: 5,
         roomPasswordSecret: "test-room-secret",
         sessionCookieName: "vinicius.dev-session",
         sessionMaxAgeSeconds: 604800,

--- a/backend/src/adapters/inbound/http/hono/photos-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/photos-routes.test.ts
@@ -32,6 +32,7 @@ const createTestContainer = (): BootstrapContainer => ({
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,
+      mfaMaxAttempts: 5,
       roomPasswordSecret: "test-room-secret",
       sessionCookieName: "vinicius.dev-session",
       sessionMaxAgeSeconds: 604800,

--- a/backend/src/adapters/inbound/http/hono/projects-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/projects-routes.test.ts
@@ -32,6 +32,7 @@ const createTestContainer = (): BootstrapContainer => ({
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,
+      mfaMaxAttempts: 5,
       roomPasswordSecret: "test-room-secret",
       sessionCookieName: "vinicius.dev-session",
       sessionMaxAgeSeconds: 604800,

--- a/backend/src/adapters/inbound/http/hono/rss-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/rss-routes.test.ts
@@ -33,6 +33,7 @@ const createTestContainer = (): BootstrapContainer => ({
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,
+      mfaMaxAttempts: 5,
       roomPasswordSecret: "test-room-secret",
       sessionCookieName: "vinicius.dev-session",
       sessionMaxAgeSeconds: 604800,

--- a/backend/src/adapters/inbound/http/hono/sitemap-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/sitemap-routes.test.ts
@@ -33,6 +33,7 @@ const createTestContainer = (): BootstrapContainer => ({
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,
+      mfaMaxAttempts: 5,
       roomPasswordSecret: "test-room-secret",
       sessionCookieName: "vinicius.dev-session",
       sessionMaxAgeSeconds: 604800,

--- a/backend/src/adapters/inbound/http/hono/status-strip-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/status-strip-routes.test.ts
@@ -32,6 +32,7 @@ const createTestContainer = (): BootstrapContainer => ({
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,
+      mfaMaxAttempts: 5,
       roomPasswordSecret: "test-room-secret",
       sessionCookieName: "vinicius.dev-session",
       sessionMaxAgeSeconds: 604800,

--- a/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/thoughts-routes.test.ts
@@ -32,6 +32,7 @@ const createTestContainer = (): BootstrapContainer => ({
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,
+      mfaMaxAttempts: 5,
       roomPasswordSecret: "test-room-secret",
       sessionCookieName: "vinicius.dev-session",
       sessionMaxAgeSeconds: 604800,

--- a/backend/src/adapters/outbound/mail/create-auth-mfa-message-port.test.ts
+++ b/backend/src/adapters/outbound/mail/create-auth-mfa-message-port.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  createDevelopmentAuthMfaMessagePort,
+  createResendAuthMfaMessagePort,
+} from "./create-auth-mfa-message-port";
+
+describe("resend auth MFA message port", () => {
+  it("submits MFA challenge emails to the Resend API", async () => {
+    const requests: RequestInit[] = [];
+    let capturedUrl = "";
+
+    const port = createResendAuthMfaMessagePort({
+      apiKey: "resend-key",
+      fetchImpl: async (url, init) => {
+        capturedUrl = String(url);
+        requests.push(init ?? {});
+        return new Response(JSON.stringify({ id: "email_1" }), {
+          status: 202,
+        });
+      },
+      fromEmail: "Vinicius Dev <no-reply@example.com>",
+    });
+
+    await port.sendMfaChallenge({
+      adminEmail: "admin@example.com",
+      challengeId: "challenge_1",
+      code: "123456",
+      expiresAt: new Date("2026-05-04T12:10:00.000Z"),
+    });
+
+    expect(capturedUrl).toBe("https://api.resend.com/emails");
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("POST");
+    expect(requests[0]?.headers).toEqual({
+      Authorization: "Bearer resend-key",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(requests[0]?.body))).toMatchObject({
+      from: "Vinicius Dev <no-reply@example.com>",
+      subject: "Your admin login verification code",
+      text: expect.stringContaining("123456"),
+      to: ["admin@example.com"],
+    });
+  });
+
+  it("throws when the provider rejects the send request", async () => {
+    const port = createResendAuthMfaMessagePort({
+      apiKey: "resend-key",
+      fetchImpl: async () =>
+        new Response(JSON.stringify({ error: "denied" }), {
+          status: 403,
+        }),
+      fromEmail: "Vinicius Dev <no-reply@example.com>",
+    });
+
+    await expect(
+      port.sendMfaChallenge({
+        adminEmail: "admin@example.com",
+        challengeId: "challenge_1",
+        code: "123456",
+        expiresAt: new Date("2026-05-04T12:10:00.000Z"),
+      }),
+    ).rejects.toThrow("Resend MFA delivery failed with status 403");
+  });
+});
+
+describe("development auth MFA message port", () => {
+  it("logs a debug-only challenge record", async () => {
+    const logs: string[] = [];
+    const port = createDevelopmentAuthMfaMessagePort({
+      log: (message) => logs.push(message),
+    });
+
+    await port.sendMfaChallenge({
+      adminEmail: "admin@example.com",
+      challengeId: "challenge_1",
+      code: "654321",
+      expiresAt: new Date("2026-05-04T12:10:00.000Z"),
+    });
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain("auth:mfa:debug");
+    expect(logs[0]).toContain("challenge_1");
+    expect(logs[0]).toContain("654321");
+  });
+});

--- a/backend/src/adapters/outbound/mail/create-auth-mfa-message-port.ts
+++ b/backend/src/adapters/outbound/mail/create-auth-mfa-message-port.ts
@@ -1,0 +1,60 @@
+import type { AuthMfaMessagePort } from "@/modules/auth/ports/outbound";
+
+const DEFAULT_RESEND_API_BASE_URL = "https://api.resend.com";
+
+type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export type ResendAuthMfaMessagePortDependencies = Readonly<{
+  apiKey: string;
+  fromEmail: string;
+  apiBaseUrl?: string;
+  fetchImpl?: FetchLike;
+}>;
+
+export const createResendAuthMfaMessagePort = ({
+  apiKey,
+  fromEmail,
+  apiBaseUrl = DEFAULT_RESEND_API_BASE_URL,
+  fetchImpl = fetch,
+}: ResendAuthMfaMessagePortDependencies): AuthMfaMessagePort => ({
+  sendMfaChallenge: async ({ adminEmail, code, expiresAt }) => {
+    const response = await fetchImpl(`${apiBaseUrl}/emails`, {
+      body: JSON.stringify({
+        from: fromEmail,
+        subject: "Your admin login verification code",
+        text: `Your vinicius.dev MFA code is ${code}. It expires at ${expiresAt.toISOString()}.`,
+        to: [adminEmail],
+      }),
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    if (!response.ok) {
+      const responseBody = await response.text();
+
+      throw new Error(
+        `Resend MFA delivery failed with status ${response.status}: ${responseBody}`,
+      );
+    }
+  },
+});
+
+export type DevelopmentAuthMfaMessagePortDependencies = Readonly<{
+  log?: (message: string) => void;
+}>;
+
+export const createDevelopmentAuthMfaMessagePort = ({
+  log = console.log,
+}: DevelopmentAuthMfaMessagePortDependencies = {}): AuthMfaMessagePort => ({
+  sendMfaChallenge: async ({ adminEmail, challengeId, code, expiresAt }) => {
+    log(
+      `[auth:mfa:debug] challengeId=${challengeId} email=${adminEmail} code=${code} expiresAt=${expiresAt.toISOString()}`,
+    );
+  },
+});

--- a/backend/src/adapters/outbound/mail/index.ts
+++ b/backend/src/adapters/outbound/mail/index.ts
@@ -1,0 +1,6 @@
+export {
+  createDevelopmentAuthMfaMessagePort,
+  createResendAuthMfaMessagePort,
+  type DevelopmentAuthMfaMessagePortDependencies,
+  type ResendAuthMfaMessagePortDependencies,
+} from "./create-auth-mfa-message-port";

--- a/backend/src/bootstrap/config/bootstrap-config.test.ts
+++ b/backend/src/bootstrap/config/bootstrap-config.test.ts
@@ -24,6 +24,7 @@ describe("bootstrap config", () => {
     expect(config).toEqual({
       auth: {
         mfaCodeMaxAgeSeconds: 600,
+        mfaMaxAttempts: 5,
         roomPasswordSecret: "development-room-password-secret",
         sessionCookieName: "vinicius.dev-session",
         sessionMaxAgeSeconds: 604800,
@@ -57,6 +58,7 @@ describe("bootstrap config", () => {
   it("applies environment overrides for runtime config", () => {
     const config = loadBootstrapConfig({
       AUTH_MFA_CODE_MAX_AGE_SECONDS: "120",
+      AUTH_MFA_MAX_ATTEMPTS: "3",
       AUTH_ROOM_PASSWORD_SECRET: "room-secret",
       AUTH_SESSION_COOKIE_NAME: "session-cookie",
       AUTH_SESSION_MAX_AGE_SECONDS: "3600",
@@ -86,6 +88,7 @@ describe("bootstrap config", () => {
     expect(config.auth.sessionCookieName).toBe("session-cookie");
     expect(config.auth.sessionMaxAgeSeconds).toBe(3600);
     expect(config.auth.mfaCodeMaxAgeSeconds).toBe(120);
+    expect(config.auth.mfaMaxAttempts).toBe(3);
     expect(config.auth.roomPasswordSecret).toBe("room-secret");
     expect(config.cors.allowCredentials).toBe(false);
     expect(config.cors.allowedOrigins).toEqual([
@@ -150,6 +153,14 @@ describe("bootstrap config", () => {
         MEDIA_PHOTOS_ROOT: "/tmp/media",
       }),
     ).toThrow("MEDIA_PHOTOS_ROOT and MEDIA_CHAT_ROOT must be different");
+  });
+
+  it("rejects non-positive MFA max attempts", () => {
+    expect(() =>
+      loadBootstrapConfig({
+        AUTH_MFA_MAX_ATTEMPTS: "0",
+      }),
+    ).toThrow("AUTH_MFA_MAX_ATTEMPTS must be greater than zero");
   });
 
   it("rejects existing symlink aliases to the same root", async () => {

--- a/backend/src/bootstrap/config/bootstrap-config.ts
+++ b/backend/src/bootstrap/config/bootstrap-config.ts
@@ -20,6 +20,7 @@ const DEFAULT_SESSION_SECRET = "development-session-secret";
 const DEFAULT_SESSION_COOKIE_NAME = "vinicius.dev-session";
 const DEFAULT_SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7;
 const DEFAULT_MFA_CODE_MAX_AGE_SECONDS = 60 * 10;
+const DEFAULT_MFA_MAX_ATTEMPTS = 5;
 const DEFAULT_ROOM_PASSWORD_SECRET = "development-room-password-secret";
 
 export type NodeEnv = "development" | "test" | "production";
@@ -27,6 +28,7 @@ export type NodeEnv = "development" | "test" | "production";
 export type BootstrapConfig = {
   auth: {
     mfaCodeMaxAgeSeconds: number;
+    mfaMaxAttempts: number;
     roomPasswordSecret: string;
     sessionCookieName: string;
     sessionMaxAgeSeconds: number;
@@ -212,6 +214,11 @@ export const loadBootstrapConfig = (
       DEFAULT_MFA_CODE_MAX_AGE_SECONDS,
       "AUTH_MFA_CODE_MAX_AGE_SECONDS",
     ),
+    mfaMaxAttempts: parseInteger(
+      env.AUTH_MFA_MAX_ATTEMPTS,
+      DEFAULT_MFA_MAX_ATTEMPTS,
+      "AUTH_MFA_MAX_ATTEMPTS",
+    ),
     roomPasswordSecret: parseString(
       env.AUTH_ROOM_PASSWORD_SECRET,
       DEFAULT_ROOM_PASSWORD_SECRET,
@@ -240,6 +247,10 @@ export const loadBootstrapConfig = (
     auth.roomPasswordSecret === DEFAULT_ROOM_PASSWORD_SECRET
   ) {
     throw new Error("AUTH_ROOM_PASSWORD_SECRET must be set in production");
+  }
+
+  if (auth.mfaMaxAttempts < 1) {
+    throw new Error("AUTH_MFA_MAX_ATTEMPTS must be greater than zero");
   }
 
   return {

--- a/backend/src/bootstrap/container/create-container.test.ts
+++ b/backend/src/bootstrap/container/create-container.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { createContainer } from "./create-container";
+import { createContainer, createRuntimeAuthMfaMessagePort } from "./create-container";
 
 describe("bootstrap container", () => {
   it("wires media repository and filesystem storage ports", () => {
@@ -40,5 +40,85 @@ describe("bootstrap container", () => {
     expect(typeof container.admin?.updateProjectCuration.execute).toBe("function");
     expect(typeof container.admin?.updatePhotoCuration.execute).toBe("function");
     expect(typeof container.admin?.updatePhotoMetadata.execute).toBe("function");
+  });
+
+  it("uses development debug MFA delivery when provider credentials are absent", async () => {
+    const originalLog = console.log;
+    const logs: string[] = [];
+    console.log = (message?: unknown, ...rest: unknown[]) => {
+      logs.push([message, ...rest].join(" "));
+    };
+
+    try {
+      const mfaMessage = createRuntimeAuthMfaMessagePort(
+        {
+          NODE_ENV: "development",
+        },
+        "development",
+        true,
+      );
+
+      await mfaMessage.sendMfaChallenge({
+        adminEmail: "admin@example.com",
+        challengeId: "challenge_1",
+        code: "123456",
+        expiresAt: new Date("2026-05-04T12:10:00.000Z"),
+      });
+    } finally {
+      console.log = originalLog;
+    }
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain("auth:mfa:debug");
+  });
+
+  it("requires provider credentials when MFA is enabled outside development", () => {
+    expect(() =>
+      createRuntimeAuthMfaMessagePort(
+        {
+          NODE_ENV: "production",
+        },
+        "production",
+        true,
+      ),
+    ).toThrow(
+      "AUTH_MFA_RESEND_API_KEY and AUTH_MFA_RESEND_FROM_EMAIL must be set when MFA is enabled outside development",
+    );
+  });
+
+  it("allows noop delivery in test and when MFA is disabled", async () => {
+    const testPort = createRuntimeAuthMfaMessagePort(
+      {
+        NODE_ENV: "test",
+      },
+      "test",
+      true,
+    );
+
+    await expect(
+      testPort.sendMfaChallenge({
+        adminEmail: "admin@example.com",
+        challengeId: "challenge_1",
+        code: "123456",
+        expiresAt: new Date("2026-05-04T12:10:00.000Z"),
+      }),
+    ).resolves.toBeUndefined();
+
+    const disabledPort = createRuntimeAuthMfaMessagePort(
+      {
+        NODE_ENV: "production",
+      },
+      "production",
+      false,
+    );
+
+    await expect(
+      disabledPort.sendMfaChallenge({
+        adminEmail: "admin@example.com",
+        challengeId: "challenge_2",
+        code: "654321",
+        expiresAt: new Date("2026-05-04T12:10:00.000Z"),
+      }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -1,4 +1,8 @@
 import { createPrismaPersistenceAdapter } from "@/adapters/outbound/persistence";
+import {
+  createDevelopmentAuthMfaMessagePort,
+  createResendAuthMfaMessagePort,
+} from "@/adapters/outbound/mail";
 import { createFilesystemMediaStorageAdapter } from "@/adapters/outbound/storage/filesystem";
 import {
   createGetAdminDashboardSummaryUseCase,
@@ -46,6 +50,7 @@ import type {
   ResolveAdminSessionPort,
   VerifyMfaChallengePort,
 } from "@/modules/auth/ports/inbound";
+import type { AuthMfaMessagePort } from "@/modules/auth/ports/outbound";
 import {
   createBanChatRoomHandleUseCase,
   createGetChatRoomAccessUseCase,
@@ -158,6 +163,34 @@ const parseAuthMfaEnabled = (value: string | undefined): boolean => {
   return value !== "false";
 };
 
+export const createRuntimeAuthMfaMessagePort = (
+  env: BootstrapEnv,
+  nodeEnv: BootstrapConfig["server"]["nodeEnv"],
+  mfaEnabled: boolean,
+): AuthMfaMessagePort => {
+  if (!mfaEnabled || nodeEnv === "test") {
+    return createNoopAuthMfaMessagePort();
+  }
+
+  const resendApiKey = env.AUTH_MFA_RESEND_API_KEY?.trim();
+  const resendFromEmail = env.AUTH_MFA_RESEND_FROM_EMAIL?.trim();
+
+  if (resendApiKey && resendFromEmail) {
+    return createResendAuthMfaMessagePort({
+      apiKey: resendApiKey,
+      fromEmail: resendFromEmail,
+    });
+  }
+
+  if (nodeEnv === "development") {
+    return createDevelopmentAuthMfaMessagePort();
+  }
+
+  throw new Error(
+    "AUTH_MFA_RESEND_API_KEY and AUTH_MFA_RESEND_FROM_EMAIL must be set when MFA is enabled outside development",
+  );
+};
+
 export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer => {
   const config = loadBootstrapConfig(env);
   const persistence = createPrismaPersistenceAdapter(undefined, {
@@ -173,6 +206,8 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
   const chatSessionTokenHasher = createHmacSessionTokenHashPort(config.auth.roomPasswordSecret);
   const chatPasswordHasher = createBunPasswordHashPort();
   const chatSessionTokenGenerator = createCryptoSessionTokenGenerator();
+  const mfaEnabled = parseAuthMfaEnabled(env.AUTH_MFA_ENABLED);
+  const mfaMessage = createRuntimeAuthMfaMessagePort(env, config.server.nodeEnv, mfaEnabled);
 
   return {
     admin: {
@@ -214,8 +249,8 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
         mfaCodeGenerator: createRandomDigitMfaCodeGenerator(),
         mfaCodeHasher: authMfaCodeHasher,
         mfaCodeMaxAgeSeconds: config.auth.mfaCodeMaxAgeSeconds,
-        mfaEnabled: parseAuthMfaEnabled(env.AUTH_MFA_ENABLED),
-        mfaMessage: createNoopAuthMfaMessagePort(),
+        mfaEnabled,
+        mfaMessage,
         passwordHasher: createBunPasswordHashPort(),
         repository: persistence.admin,
         sessionMaxAgeSeconds: config.auth.sessionMaxAgeSeconds,
@@ -242,6 +277,7 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
       verifyMfaChallenge: createVerifyMfaChallengeUseCase({
         clock: authClock,
         mfaCodeHasher: authMfaCodeHasher,
+        mfaMaxAttempts: config.auth.mfaMaxAttempts,
         repository: persistence.admin,
         sessionMaxAgeSeconds: config.auth.sessionMaxAgeSeconds,
         sessionTokenGenerator: createCryptoSessionTokenGenerator(),

--- a/backend/src/bootstrap/server.test.ts
+++ b/backend/src/bootstrap/server.test.ts
@@ -31,6 +31,7 @@ const createTestContainer = (): BootstrapContainer => ({
   config: {
     auth: {
       mfaCodeMaxAgeSeconds: 600,
+      mfaMaxAttempts: 5,
       roomPasswordSecret: "test-room-secret",
       sessionCookieName: "vinicius.dev-session",
       sessionMaxAgeSeconds: 604800,

--- a/backend/src/modules/auth/application/index.test.ts
+++ b/backend/src/modules/auth/application/index.test.ts
@@ -296,6 +296,49 @@ describe("auth MFA verify use case", () => {
       status: "pending",
     });
   });
+
+  it("expires the challenge after reaching the MFA max attempt ceiling", async () => {
+    const repository = createTestRepository();
+    await repository.createMfaChallenge({
+      adminEmail: "admin@example.com",
+      adminUserId: "admin_1",
+      codeHash: "hashed:123456",
+      expiresAt: new Date("2026-04-28T12:10:00.000Z"),
+      id: "challenge_3",
+      sentAt: baseNow,
+    });
+    const useCase = createVerifyMfaChallengeUseCase({
+      clock: {
+        now: () => baseNow,
+      },
+      mfaCodeHasher: {
+        verify: async () => false,
+      },
+      mfaMaxAttempts: 2,
+      repository,
+      sessionMaxAgeSeconds: 3600,
+      sessionTokenHasher: createTokenHasher(),
+    });
+
+    await expect(
+      useCase.execute({
+        challengeId: "challenge_3",
+        code: "000000",
+      }),
+    ).rejects.toBeInstanceOf(InvalidAuthCredentialsError);
+
+    await expect(
+      useCase.execute({
+        challengeId: "challenge_3",
+        code: "111111",
+      }),
+    ).rejects.toBeInstanceOf(InvalidAuthCredentialsError);
+
+    await expect(repository.findMfaChallengeById("challenge_3")).resolves.toMatchObject({
+      attempts: 2,
+      status: "expired",
+    });
+  });
 });
 
 describe("auth session lifecycle use cases", () => {

--- a/backend/src/modules/auth/application/index.ts
+++ b/backend/src/modules/auth/application/index.ts
@@ -32,6 +32,7 @@ import type {
 } from "@/modules/auth/ports/outbound";
 
 const DEFAULT_MFA_CODE_LENGTH = 6;
+const DEFAULT_MFA_MAX_ATTEMPTS = 5;
 const DEFAULT_SESSION_TOKEN_BYTES = 32;
 
 const normalizeEmail = (value: string): string => value.trim().toLowerCase();
@@ -211,6 +212,7 @@ export type LoginWithCredentialsDependencies = Readonly<{
 
 export type VerifyMfaChallengeDependencies = Readonly<{
   sessionMaxAgeSeconds: number;
+  mfaMaxAttempts?: number;
   repository: Pick<
     AuthRepositoryPort,
     | "findMfaChallengeById"
@@ -344,6 +346,7 @@ export const createLoginWithCredentialsUseCase = ({
 
 export const createVerifyMfaChallengeUseCase = ({
   sessionMaxAgeSeconds,
+  mfaMaxAttempts = DEFAULT_MFA_MAX_ATTEMPTS,
   repository,
   mfaCodeHasher,
   sessionTokenHasher,
@@ -384,7 +387,16 @@ export const createVerifyMfaChallengeUseCase = ({
     });
 
     if (!isValidCode) {
+      const attemptsAfterFailure = challenge.attempts + 1;
       await repository.incrementMfaChallengeAttempts(challengeId);
+
+      if (attemptsAfterFailure >= mfaMaxAttempts) {
+        await repository.markMfaChallengeExpired({
+          challengeId,
+          expiredAt: now,
+        });
+      }
+
       throw new InvalidAuthCredentialsError();
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,11 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER:-vinicius}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-vinicius}?schema=public
       AUTH_SESSION_SECRET: ${AUTH_SESSION_SECRET:?set AUTH_SESSION_SECRET in your env file}
       AUTH_ROOM_PASSWORD_SECRET: ${AUTH_ROOM_PASSWORD_SECRET:?set AUTH_ROOM_PASSWORD_SECRET in your env file}
+      AUTH_MFA_ENABLED: ${AUTH_MFA_ENABLED:-true}
+      AUTH_MFA_CODE_MAX_AGE_SECONDS: ${AUTH_MFA_CODE_MAX_AGE_SECONDS:-600}
+      AUTH_MFA_MAX_ATTEMPTS: ${AUTH_MFA_MAX_ATTEMPTS:-5}
+      AUTH_MFA_RESEND_FROM_EMAIL: ${AUTH_MFA_RESEND_FROM_EMAIL:-}
+      AUTH_MFA_RESEND_API_KEY: ${AUTH_MFA_RESEND_API_KEY:-}
       MEDIA_PHOTOS_ROOT: /var/lib/vinicius.dev/media/photos
       MEDIA_CHAT_ROOT: /var/lib/vinicius.dev/media/chat
     depends_on:

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -121,13 +121,15 @@ Done criteria for `CHAT-010`:
   - Start: branch `backend/SEC-003-mfa-lockout-and-delivery` moved to `In Progress`.
   - Local execution: MFA challenge attempt ceiling + expiry enforcement and non-test delivery wiring were implemented with focused auth and delivery tests.
   - Blocker: none.
+  - Local verification: auth use-case, delivery adapter, container/config, Hono adapter, typecheck, and boundary verification passed on 2026-05-04.
+  - PR/Open review: PR [#126](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/126) opened against `develop`.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Done | SPEC-031 | SPEC-031 | spec | develop | `spec/SPEC-031-security-hardening-production-readiness` | develop | `docs/specs/security-hardening-production-readiness.md` | [#123](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/123) merged | — |
 | In Review | SEC-001 | SPEC-031 | infra | develop | `infra/SEC-001-production-secret-enforcement` | develop | `docs/specs/security-hardening-production-readiness.md` | [#124](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/124) | — |
 | Todo | SEC-002 | SPEC-031 | backend | develop | `backend/SEC-002-cors-and-rate-limits` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
-| In Progress | SEC-003 | SPEC-031 | backend | develop | `backend/SEC-003-mfa-lockout-and-delivery` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
+| In Review | SEC-003 | SPEC-031 | backend | develop | `backend/SEC-003-mfa-lockout-and-delivery` | develop | `docs/specs/security-hardening-production-readiness.md` | [#126](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/126) | — |
 | Blocked | SEC-004 | SPEC-031 | backend | develop | `backend/SEC-004-chat-request-validation-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |
 | Blocked | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |
 | Blocked | SEC-006 | SPEC-031 | backend | develop | `backend/SEC-006-websocket-auth-transport-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-002`; phase-ordered after first-wave critical tasks. |

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -107,7 +107,7 @@ Done criteria for `CHAT-010`:
 - upload validation remains aligned with MIME, size, and one-file-per-message rules
 
 ### Security Hardening Execution
-- Status: tasked; first-wave critical tasks are queued.
+- Status: in progress; first-wave critical tasks are executing.
 - Primary spec: `SPEC-031`.
 - Supporting specs: `frontend-structure.md`, `frontend-architecture.md`, `project-structure.md`, `backend-architecture.md`, `chat-room-live-integration.md`, `frontend-admin-auth-integration.md`, `media-storage.md`, `admin-cms.md`, `infra-deployment.md`, `verification.md`, and `git-workflow.md`.
 - Scope: execute the approved remediation wave from the 2026-05-03 security review with one task branch per finding cluster.
@@ -117,13 +117,17 @@ Done criteria for `CHAT-010`:
   - Blocker: none.
   - PR/Open review: PR [#124](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/124) opened against `develop`.
   - Completion: production secret enforcement, compose env contract, and operator env docs updated; awaiting review/merge.
+- SEC-003 status log:
+  - Start: branch `backend/SEC-003-mfa-lockout-and-delivery` moved to `In Progress`.
+  - Local execution: MFA challenge attempt ceiling + expiry enforcement and non-test delivery wiring were implemented with focused auth and delivery tests.
+  - Blocker: none.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Done | SPEC-031 | SPEC-031 | spec | develop | `spec/SPEC-031-security-hardening-production-readiness` | develop | `docs/specs/security-hardening-production-readiness.md` | [#123](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/123) merged | — |
 | In Review | SEC-001 | SPEC-031 | infra | develop | `infra/SEC-001-production-secret-enforcement` | develop | `docs/specs/security-hardening-production-readiness.md` | [#124](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/124) | — |
 | Todo | SEC-002 | SPEC-031 | backend | develop | `backend/SEC-002-cors-and-rate-limits` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
-| Todo | SEC-003 | SPEC-031 | backend | develop | `backend/SEC-003-mfa-lockout-and-delivery` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
+| In Progress | SEC-003 | SPEC-031 | backend | develop | `backend/SEC-003-mfa-lockout-and-delivery` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
 | Blocked | SEC-004 | SPEC-031 | backend | develop | `backend/SEC-004-chat-request-validation-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |
 | Blocked | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |
 | Blocked | SEC-006 | SPEC-031 | backend | develop | `backend/SEC-006-websocket-auth-transport-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-002`; phase-ordered after first-wave critical tasks. |

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -121,12 +121,13 @@ Done criteria for `CHAT-010`:
   - Start: branch `backend/SEC-002-cors-and-rate-limits` moved to `In Progress`.
   - Blocker: none.
   - Local verification: adapter coverage for CORS and targeted auth/chat rate-limits plus `backend` boundary verification passed on 2026-05-04.
+  - PR/Open review: PR [#125](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/125) opened against `develop`.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Done | SPEC-031 | SPEC-031 | spec | develop | `spec/SPEC-031-security-hardening-production-readiness` | develop | `docs/specs/security-hardening-production-readiness.md` | [#123](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/123) merged | — |
 | In Review | SEC-001 | SPEC-031 | infra | develop | `infra/SEC-001-production-secret-enforcement` | develop | `docs/specs/security-hardening-production-readiness.md` | [#124](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/124) | — |
-| In Progress | SEC-002 | SPEC-031 | backend | develop | `backend/SEC-002-cors-and-rate-limits` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
+| In Review | SEC-002 | SPEC-031 | backend | develop | `backend/SEC-002-cors-and-rate-limits` | develop | `docs/specs/security-hardening-production-readiness.md` | [#125](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/125) | — |
 | Todo | SEC-003 | SPEC-031 | backend | develop | `backend/SEC-003-mfa-lockout-and-delivery` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
 | Blocked | SEC-004 | SPEC-031 | backend | develop | `backend/SEC-004-chat-request-validation-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |
 | Blocked | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -117,12 +117,16 @@ Done criteria for `CHAT-010`:
   - Blocker: none.
   - PR/Open review: PR [#124](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/124) opened against `develop`.
   - Completion: production secret enforcement, compose env contract, and operator env docs updated; awaiting review/merge.
+- SEC-002 status log:
+  - Start: branch `backend/SEC-002-cors-and-rate-limits` moved to `In Progress`.
+  - Blocker: none.
+  - Local verification: adapter coverage for CORS and targeted auth/chat rate-limits plus `backend` boundary verification passed on 2026-05-04.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Done | SPEC-031 | SPEC-031 | spec | develop | `spec/SPEC-031-security-hardening-production-readiness` | develop | `docs/specs/security-hardening-production-readiness.md` | [#123](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/123) merged | — |
 | In Review | SEC-001 | SPEC-031 | infra | develop | `infra/SEC-001-production-secret-enforcement` | develop | `docs/specs/security-hardening-production-readiness.md` | [#124](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/124) | — |
-| Todo | SEC-002 | SPEC-031 | backend | develop | `backend/SEC-002-cors-and-rate-limits` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
+| In Progress | SEC-002 | SPEC-031 | backend | develop | `backend/SEC-002-cors-and-rate-limits` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
 | Todo | SEC-003 | SPEC-031 | backend | develop | `backend/SEC-003-mfa-lockout-and-delivery` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
 | Blocked | SEC-004 | SPEC-031 | backend | develop | `backend/SEC-004-chat-request-validation-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |
 | Blocked | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |


### PR DESCRIPTION
## Summary
- Task ID: SEC-003
- Source tracker entry: `docs/specs/tracker.md` > Security Hardening Execution
- Source spec: `docs/specs/security-hardening-production-readiness.md`

Adds MFA failed-attempt lockout/expiry enforcement and wires non-test MFA delivery through a Resend-backed adapter, with development-only debug fallback kept out of production.

## Branching
- Base branch: `develop`
- Merge target: `develop`

## Acceptance
- Acceptance source: `docs/specs/security-hardening-production-readiness.md`
- Verification performed:
  - `cd backend && bun test src/modules/auth/application/index.test.ts src/adapters/outbound/mail/create-auth-mfa-message-port.test.ts src/bootstrap/container/create-container.test.ts` (`16 pass, 0 fail`)
  - `cd backend && bun test src/bootstrap/config/bootstrap-config.test.ts src/bootstrap/server.test.ts src/adapters/inbound/http/hono/*.test.ts` (`93 pass, 0 fail`)
  - `cd backend && bun run typecheck` (passed)
  - `cd backend && bun run verify:boundary` (passed)
- Required CI status checks: PR validation for `develop`

## Notes
- Deployment impact: production MFA now requires provider-backed delivery config when MFA is enabled; env examples and compose contract were updated.
- Revert impact: revert the SEC-003 commits to remove MFA attempt ceiling wiring, mail adapter, env contract changes, tests, and tracker updates.
- Follow-up tasks: first-wave security tasks can move toward review completion; later phase tasks remain governed by SPEC-031 dependencies.
