### PR TITLE
SEC-004 Chat request validation hardening

### DIFF
--- a/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
@@ -277,21 +277,34 @@ const createUploadFormData = ({
   body = "message body",
   bytes = new Uint8Array([1, 2, 3, 4]),
   fileName = "scan.png",
+  legacyAuthorHandleId,
+  legacyRoomId,
   mimeType = "image/png",
+  roomSessionId = "session_1",
   tone = "cyan",
 }: {
   body?: string;
   bytes?: Uint8Array;
   fileName?: string;
+  legacyAuthorHandleId?: string;
+  legacyRoomId?: string;
   mimeType?: string;
+  roomSessionId?: string;
   tone?: string;
 } = {}): FormData => {
   const formData = new FormData();
   const fileBytes = new Uint8Array(bytes.byteLength);
   fileBytes.set(bytes);
-  formData.append("roomId", "room_1");
-  formData.append("roomSessionId", "session_1");
-  formData.append("authorHandleId", "handle_1");
+  formData.append("roomSessionId", roomSessionId);
+
+  if (legacyRoomId) {
+    formData.append("roomId", legacyRoomId);
+  }
+
+  if (legacyAuthorHandleId) {
+    formData.append("authorHandleId", legacyAuthorHandleId);
+  }
+
   formData.append("body", body);
   formData.append("tone", tone);
   formData.append("file", new File([fileBytes.buffer], fileName, { type: mimeType }));
@@ -976,6 +989,36 @@ describe("chat routes", () => {
     expect(called).toBe(false);
   });
 
+  it("rejects text message requests over the 2000-character limit before calling the core", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeSendText: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/rooms/night-shift/messages", {
+      body: JSON.stringify({
+        body: "x".repeat(2001),
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-chat-room-session-id": "session_1",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_request",
+      field: "body",
+    });
+    expect(called).toBe(false);
+  });
+
   it("returns denied when text message access is invalid for the room session", async () => {
     const app = createHonoHttpAdapter(
       createTestContainer({
@@ -1004,18 +1047,38 @@ describe("chat routes", () => {
   });
 
   it("maps a valid upload request into the chat upload use case", async () => {
-    let capturedAuthorHandleId: string | undefined;
+    let capturedInput: UploadChatMessageWithImageInput | undefined;
     let capturedMimeType: string | undefined;
-    let capturedRoomId: string | undefined;
-    let capturedRoomSessionId: string | undefined;
+    let capturedResolveInput: ResolveChatRoomSessionInput | undefined;
     let capturedTone: "cyan" | "pink" | "system" | null | undefined;
     const app = createHonoHttpAdapter(
       createTestContainer({
+        executeResolve: async (input) => {
+          capturedResolveInput = input;
+
+          return {
+            participant: {
+              handle: "vinicius",
+              id: "handle_1",
+              status: "online",
+            },
+            room: {
+              id: "room_1",
+              slug: "night-shift",
+            },
+            session: {
+              expiresAt: "2026-04-25T12:00:00.000Z",
+              handleId: "handle_1",
+              id: "session_1",
+              joinedAt: "2026-04-24T12:00:00.000Z",
+              roomId: "room_1",
+              status: "active",
+            },
+          };
+        },
         executeUpload: async (input) => {
-          capturedAuthorHandleId = input.authorHandleId;
+          capturedInput = input;
           capturedMimeType = input.image.mimeType;
-          capturedRoomId = input.roomId;
-          capturedRoomSessionId = input.roomSessionId;
           capturedTone = input.tone;
 
           return defaultUploadResponse;
@@ -1024,7 +1087,10 @@ describe("chat routes", () => {
     );
 
     const response = await app.request("/api/chat/messages/upload", {
-      body: createUploadFormData(),
+      body: createUploadFormData({
+        legacyAuthorHandleId: "forged_handle",
+        legacyRoomId: "forged_room",
+      }),
       method: "POST",
     });
 
@@ -1045,11 +1111,48 @@ describe("chat routes", () => {
         tone: "cyan",
       },
     });
-    expect(capturedRoomId).toBe("room_1");
-    expect(capturedRoomSessionId).toBe("session_1");
-    expect(capturedAuthorHandleId).toBe("handle_1");
+    expect(capturedInput).toEqual({
+      body: "message body",
+      image: {
+        body: new Uint8Array([1, 2, 3, 4]),
+        displayFilename: "scan.png",
+        mimeType: "image/png",
+      },
+      roomSessionId: "session_1",
+      tone: "cyan",
+    });
+    expect(capturedResolveInput).toEqual({
+      roomSessionId: "session_1",
+      slug: "night-shift",
+    });
     expect(capturedTone).toBe("cyan");
     expect(capturedMimeType).toBe("image/png");
+  });
+
+  it("rejects upload requests missing roomSessionId before reaching the core", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeUpload: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/messages/upload", {
+      body: createUploadFormData({
+        roomSessionId: "   ",
+      }),
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_request",
+      field: "roomSessionId",
+    });
+    expect(called).toBe(false);
   });
 
   it("rejects invalid MIME types before reaching the core", async () => {
@@ -1132,7 +1235,7 @@ describe("chat routes", () => {
     expect(called).toBe(false);
   });
 
-  it("returns denied when the room session and author ids do not match", async () => {
+  it("returns denied when upload actor validation fails in the core", async () => {
     const app = createHonoHttpAdapter(
       createTestContainer({
         executeUpload: async () => {
@@ -1151,6 +1254,33 @@ describe("chat routes", () => {
       error: "denied",
       resource: "chat",
     });
+  });
+
+  it("returns denied when upload room-session validation fails before reaching the core", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeResolve: async () => {
+          throw new InvalidChatRoomSessionError();
+        },
+        executeUpload: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/messages/upload", {
+      body: createUploadFormData(),
+      method: "POST",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "denied",
+      resource: "chat",
+    });
+    expect(called).toBe(false);
   });
 
   it("rate limits repeated chat room join attempts", async () => {

--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -645,6 +645,8 @@ const supportedChatUploadMimeTypes: readonly ChatUploadMimeType[] = [
   "image/png",
   "image/webp",
 ];
+const MAX_CHAT_MESSAGE_BODY_LENGTH = 2000;
+const CHAT_UPLOAD_ROOM_SLUG = "night-shift";
 
 const isSupportedChatUploadMimeType = (value: string): value is ChatUploadMimeType => {
   return supportedChatUploadMimeTypes.includes(value as ChatUploadMimeType);
@@ -1229,6 +1231,16 @@ const createChatFamily = (
       return c.json(body.error, 400);
     }
 
+    if (body.value.length > MAX_CHAT_MESSAGE_BODY_LENGTH) {
+      return c.json(
+        {
+          error: "invalid_request",
+          field: "body",
+        },
+        400,
+      );
+    }
+
     const toneInput = parsedBody.value.tone;
 
     if (
@@ -1352,6 +1364,19 @@ const createChatFamily = (
       return limited;
     }
 
+    if (!resolveRoomSessionUseCase) {
+      return c.json<NotImplementedResponse>(
+        {
+          family: "chat",
+          method: c.req.method,
+          route: c.req.path,
+          service: serviceName,
+          status: "not_implemented",
+        },
+        501,
+      );
+    }
+
     let formData: FormData;
 
     try {
@@ -1366,22 +1391,34 @@ const createChatFamily = (
       );
     }
 
-    const roomId = getRequiredFormText(formData, "roomId");
-
-    if ("error" in roomId) {
-      return c.json(roomId.error, 400);
-    }
-
     const roomSessionId = getRequiredFormText(formData, "roomSessionId");
 
     if ("error" in roomSessionId) {
       return c.json(roomSessionId.error, 400);
     }
 
-    const authorHandleId = getRequiredFormText(formData, "authorHandleId");
+    let resolvedSession;
 
-    if ("error" in authorHandleId) {
-      return c.json(authorHandleId.error, 400);
+    try {
+      resolvedSession = await resolveRoomSessionUseCase.execute({
+        roomSessionId: roomSessionId.value,
+        slug: CHAT_UPLOAD_ROOM_SLUG,
+      });
+    } catch (error) {
+      if (
+        error instanceof InvalidChatRoomSessionError ||
+        error instanceof BannedChatHandleError
+      ) {
+        return c.json(
+          {
+            error: "denied",
+            resource: "chat",
+          },
+          403,
+        );
+      }
+
+      throw error;
     }
 
     const toneInput = getOptionalFormText(formData, "tone")?.trim();
@@ -1470,15 +1507,13 @@ const createChatFamily = (
 
     try {
       result = await container.chat.uploadMessageWithImage.execute({
-        authorHandleId: authorHandleId.value,
         body: getOptionalFormText(formData, "body"),
         image: {
           body: new Uint8Array(await uploadFile.arrayBuffer()),
           displayFilename: uploadFile.name.trim() || "upload",
           mimeType,
         },
-        roomId: roomId.value,
-        roomSessionId: roomSessionId.value,
+        roomSessionId: resolvedSession.session.id,
         tone,
       });
     } catch (error) {
@@ -1495,7 +1530,7 @@ const createChatFamily = (
       throw error;
     }
 
-    live.broadcastByRoomId(roomId.value, {
+    live.broadcastByRoomId(resolvedSession.room.id, {
       item: {
         attachment: result.attachment,
         author: result.author,

--- a/backend/src/modules/chat/application/index.test.ts
+++ b/backend/src/modules/chat/application/index.test.ts
@@ -1162,14 +1162,12 @@ describe("chat upload message with image use case", () => {
     });
 
     const output = await useCase.execute({
-      authorHandleId: "handle_1",
       body: "  post from bunker  ",
       image: {
         body: new TextEncoder().encode("upload-bytes"),
         displayFilename: "bunker.png",
         mimeType: "image/png",
       },
-      roomId: "room 123",
       roomSessionId: "session_1",
       tone: "cyan",
     });
@@ -1242,20 +1240,18 @@ describe("chat upload message with image use case", () => {
 
     await expect(
       useCase.execute({
-        authorHandleId: "handle_1",
         image: {
           body: new Uint8Array([1, 2, 3, 4]),
           displayFilename: "scan.webp",
           mimeType: "image/webp",
         },
-        roomId: "room-1",
         roomSessionId: "session_1",
       }),
     ).rejects.toThrow("database write failed");
     expect(deletedPaths).toEqual(["room_1/upload_1.webp"]);
   });
 
-  it("rejects uploads when the session does not match the requested room or handle", async () => {
+  it("rejects uploads when the session actor cannot be resolved as an active room handle", async () => {
     const useCase = createUploadChatMessageWithImageUseCase({
       repository: {
         createMessageWithUpload: async () => {
@@ -1264,7 +1260,7 @@ describe("chat upload message with image use case", () => {
         findHandleById: async () => ({
           createdAt: new Date("2026-04-24T00:00:00.000Z"),
           handle: "vinicius",
-          id: "handle_1",
+          id: "handle_2",
           normalizedHandle: "vinicius",
           roomId: "room_1",
           status: "active",
@@ -1294,13 +1290,11 @@ describe("chat upload message with image use case", () => {
 
     await expect(
       useCase.execute({
-        authorHandleId: "handle_1",
         image: {
           body: new Uint8Array([1, 2, 3, 4]),
           displayFilename: "scan.webp",
           mimeType: "image/webp",
         },
-        roomId: "room_1",
         roomSessionId: "session_1",
       }),
     ).rejects.toThrow("chat upload actor/session does not match the requested room");

--- a/backend/src/modules/chat/application/index.ts
+++ b/backend/src/modules/chat/application/index.ts
@@ -896,11 +896,7 @@ export const createUploadChatMessageWithImageUseCase = ({
   ): Promise<UploadChatMessageWithImageOutput> => {
     const session = await repository.findSessionById(input.roomSessionId);
 
-    if (
-      !session ||
-      !isRoomSessionActive(session, clock(), input.roomId) ||
-      session.handleId !== input.authorHandleId
-    ) {
+    if (!session || !isRoomSessionActive(session, clock(), session.roomId)) {
       throw new InvalidChatUploadActorError();
     }
 
@@ -909,15 +905,16 @@ export const createUploadChatMessageWithImageUseCase = ({
     if (
       !authorHandle ||
       authorHandle.status !== "active" ||
-      authorHandle.roomId !== input.roomId
+      authorHandle.roomId !== session.roomId
     ) {
       throw new InvalidChatUploadActorError();
     }
 
+    const roomId = authorHandle.roomId;
     const messageId = createId();
     const uploadId = createId();
     const sentAt = clock();
-    const storageKey = buildStorageKey(input.roomId, uploadId, input.image.mimeType);
+    const storageKey = buildStorageKey(roomId, uploadId, input.image.mimeType);
 
     const persistedBody = normalizeBody(input.body);
     const writtenUpload = await storage.writeUpload({
@@ -927,14 +924,14 @@ export const createUploadChatMessageWithImageUseCase = ({
 
     try {
       const created = await repository.createMessageWithUpload({
-        authorHandleId: input.authorHandleId,
+        authorHandleId: authorHandle.id,
         body: persistedBody,
         byteSize: writtenUpload.byteSize,
         displayFilename: input.image.displayFilename,
         messageId,
         mimeType: input.image.mimeType,
-        roomId: input.roomId,
-        roomSessionId: input.roomSessionId,
+        roomId,
+        roomSessionId: session.id,
         sentAt,
         storageKey: writtenUpload.storageKey,
         storagePath: writtenUpload.storagePath,

--- a/backend/src/modules/chat/ports/inbound/index.ts
+++ b/backend/src/modules/chat/ports/inbound/index.ts
@@ -227,10 +227,8 @@ export type UploadChatMessageImageInput = Readonly<{
 }>;
 
 export type UploadChatMessageWithImageInput = Readonly<{
-  authorHandleId: string;
   body?: string;
   image: UploadChatMessageImageInput;
-  roomId: string;
   roomSessionId: string;
   tone?: "cyan" | "pink" | "system" | null;
 }>;

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -35,8 +35,8 @@
 ## Next Task Queue
 1. Complete reviewer validation for `QA-008` follow-up PR [#117](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/117).
 2. Complete reviewer validation for `CHAT-010` PR [#122](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/122).
-3. Start `SEC-001` on `infra/SEC-001-production-secret-enforcement` from `develop`.
-4. Queue `SEC-002` and `SEC-003` as the remaining first-wave critical hardening tasks after `SEC-001` enters review.
+3. Execute `SEC-004` on `backend/SEC-004-chat-request-validation-hardening` from `develop`.
+4. Queue phase-2 security follow-ups (`SEC-005`, `SEC-006`, `SEC-008`) after `SEC-004` enters review.
 
 ## Current Executable Cluster
 ### Frontend Admin API Integration
@@ -107,7 +107,7 @@ Done criteria for `CHAT-010`:
 - upload validation remains aligned with MIME, size, and one-file-per-message rules
 
 ### Security Hardening Execution
-- Status: in progress; first-wave critical tasks are executing.
+- Status: in progress; first-wave critical tasks are complete and phase 2 execution has started with `SEC-004`.
 - Primary spec: `SPEC-031`.
 - Supporting specs: `frontend-structure.md`, `frontend-architecture.md`, `project-structure.md`, `backend-architecture.md`, `chat-room-live-integration.md`, `frontend-admin-auth-integration.md`, `media-storage.md`, `admin-cms.md`, `infra-deployment.md`, `verification.md`, and `git-workflow.md`.
 - Scope: execute the approved remediation wave from the 2026-05-03 security review with one task branch per finding cluster.
@@ -116,26 +116,32 @@ Done criteria for `CHAT-010`:
   - Start: branch `infra/SEC-001-production-secret-enforcement` moved to `In Progress`.
   - Blocker: none.
   - PR/Open review: PR [#124](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/124) opened against `develop`.
-  - Completion: production secret enforcement, compose env contract, and operator env docs updated; awaiting review/merge.
+  - Completion: production secret enforcement, compose env contract, and operator env docs landed via merged PR [#124](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/124).
 - SEC-002 status log:
   - Start: branch `backend/SEC-002-cors-and-rate-limits` moved to `In Progress`.
   - Blocker: none.
   - Local verification: adapter coverage for CORS and targeted auth/chat rate-limits plus `backend` boundary verification passed on 2026-05-04.
   - PR/Open review: PR [#125](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/125) opened against `develop`.
+  - Completion: CORS/rate-limit hardening landed via merged PR [#125](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/125).
 - SEC-003 status log:
   - Start: branch `backend/SEC-003-mfa-lockout-and-delivery` moved to `In Progress`.
   - Local execution: MFA challenge attempt ceiling + expiry enforcement and non-test delivery wiring were implemented with focused auth and delivery tests.
   - Blocker: none.
   - Local verification: auth use-case, delivery adapter, container/config, Hono adapter, typecheck, and boundary verification passed on 2026-05-04.
   - PR/Open review: PR [#126](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/126) opened against `develop`.
+  - Completion: MFA lockout/delivery hardening landed via merged PR [#126](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/126).
+- SEC-004 status log:
+  - Start: branch `backend/SEC-004-chat-request-validation-hardening` moved to `In Progress` after `SEC-001`, `SEC-002`, and `SEC-003` merged to `develop`.
+  - Blocker: none.
+  - Local execution: enforcing `2000`-character chat text limit and session-derived upload actor/room context in progress with adapter/use-case test updates.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Done | SPEC-031 | SPEC-031 | spec | develop | `spec/SPEC-031-security-hardening-production-readiness` | develop | `docs/specs/security-hardening-production-readiness.md` | [#123](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/123) merged | — |
-| In Review | SEC-001 | SPEC-031 | infra | develop | `infra/SEC-001-production-secret-enforcement` | develop | `docs/specs/security-hardening-production-readiness.md` | [#124](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/124) | — |
-| In Review | SEC-002 | SPEC-031 | backend | develop | `backend/SEC-002-cors-and-rate-limits` | develop | `docs/specs/security-hardening-production-readiness.md` | [#125](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/125) | — |
-| In Review | SEC-003 | SPEC-031 | backend | develop | `backend/SEC-003-mfa-lockout-and-delivery` | develop | `docs/specs/security-hardening-production-readiness.md` | [#126](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/126) | — |
-| Blocked | SEC-004 | SPEC-031 | backend | develop | `backend/SEC-004-chat-request-validation-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |
+| Done | SEC-001 | SPEC-031 | infra | develop | `infra/SEC-001-production-secret-enforcement` | develop | `docs/specs/security-hardening-production-readiness.md` | [#124](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/124) merged | — |
+| Done | SEC-002 | SPEC-031 | backend | develop | `backend/SEC-002-cors-and-rate-limits` | develop | `docs/specs/security-hardening-production-readiness.md` | [#125](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/125) merged | — |
+| Done | SEC-003 | SPEC-031 | backend | develop | `backend/SEC-003-mfa-lockout-and-delivery` | develop | `docs/specs/security-hardening-production-readiness.md` | [#126](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/126) merged | — |
+| In Progress | SEC-004 | SPEC-031 | backend | develop | `backend/SEC-004-chat-request-validation-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
 | Blocked | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |
 | Blocked | SEC-006 | SPEC-031 | backend | develop | `backend/SEC-006-websocket-auth-transport-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-002`; phase-ordered after first-wave critical tasks. |
 | Blocked | SEC-007 | SPEC-031 | frontend | develop | `frontend/SEC-007-chat-session-storage-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-006` handshake contract before frontend storage migration. |

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -133,7 +133,8 @@ Done criteria for `CHAT-010`:
 - SEC-004 status log:
   - Start: branch `backend/SEC-004-chat-request-validation-hardening` moved to `In Progress` after `SEC-001`, `SEC-002`, and `SEC-003` merged to `develop`.
   - Blocker: none.
-  - Local execution: enforcing `2000`-character chat text limit and session-derived upload actor/room context in progress with adapter/use-case test updates.
+  - Local verification: chat adapter/use-case tests, backend typecheck, and boundary verification passed on 2026-05-05.
+  - PR/Open review: PR [#127](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/127) opened against `develop`.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -141,7 +142,7 @@ Done criteria for `CHAT-010`:
 | Done | SEC-001 | SPEC-031 | infra | develop | `infra/SEC-001-production-secret-enforcement` | develop | `docs/specs/security-hardening-production-readiness.md` | [#124](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/124) merged | — |
 | Done | SEC-002 | SPEC-031 | backend | develop | `backend/SEC-002-cors-and-rate-limits` | develop | `docs/specs/security-hardening-production-readiness.md` | [#125](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/125) merged | — |
 | Done | SEC-003 | SPEC-031 | backend | develop | `backend/SEC-003-mfa-lockout-and-delivery` | develop | `docs/specs/security-hardening-production-readiness.md` | [#126](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/126) merged | — |
-| In Progress | SEC-004 | SPEC-031 | backend | develop | `backend/SEC-004-chat-request-validation-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
+| In Review | SEC-004 | SPEC-031 | backend | develop | `backend/SEC-004-chat-request-validation-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#127](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/127) | — |
 | Blocked | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |
 | Blocked | SEC-006 | SPEC-031 | backend | develop | `backend/SEC-006-websocket-auth-transport-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-002`; phase-ordered after first-wave critical tasks. |
 | Blocked | SEC-007 | SPEC-031 | frontend | develop | `frontend/SEC-007-chat-session-storage-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-006` handshake contract before frontend storage migration. |


### PR DESCRIPTION
## Summary
- Task ID: SEC-004
- Source tracker entry: `docs/specs/tracker.md` > Security Hardening Execution
- Source spec: `docs/specs/security-hardening-production-readiness.md`

Hardens chat request validation by enforcing the 2000-character text-message limit and removing trust in client-supplied internal upload identifiers. Uploads now resolve room/author context from the validated chat room session before entering the upload use case.

## Branching
- Base branch: `develop`
- Merge target: `develop`

## Acceptance
- Acceptance source: `docs/specs/security-hardening-production-readiness.md`
- Verification performed:
  - `cd backend && bun test src/adapters/inbound/http/hono/chat-routes.test.ts src/adapters/inbound/http/hono/chat-media-routes.test.ts src/modules/chat/application/index.test.ts` (`64 pass, 0 fail`)
  - `cd backend && bun run typecheck` (passed)
  - `cd backend && bun run verify:boundary` (passed)
- Required CI status checks: PR validation for `develop`

## Notes
- Deployment impact: chat send/upload request validation changes only; no migration or deploy automation changes.
- Revert impact: revert SEC-004 commits to restore previous upload request shape and text body validation behavior.
- Follow-up tasks: SEC-005 handles upload signature validation and protected media headers.
