### PR TITLE
SEC-005 Upload signature and protected media hardening

### DIFF
--- a/backend/src/adapters/inbound/http/hono/chat-media-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-media-routes.test.ts
@@ -192,6 +192,7 @@ describe("chat media routes", () => {
     expect(response.headers.get("cache-control")).toBe("private, no-store");
     expect(response.headers.get("content-type")).toBe("image/webp");
     expect(response.headers.get("content-length")).toBe(String(bytes.byteLength));
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
     expectChatMediaVaryHeader(response);
     await expect(response.text()).resolves.toBe("upload-bytes");
   });
@@ -213,6 +214,7 @@ describe("chat media routes", () => {
 
     expect(response.status).toBe(403);
     expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
     expectChatMediaVaryHeader(response);
     await expect(response.json()).resolves.toEqual({
       error: "denied",
@@ -230,6 +232,7 @@ describe("chat media routes", () => {
 
     expect(response.status).toBe(404);
     expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
     expectChatMediaVaryHeader(response);
     await expect(response.json()).resolves.toEqual({
       error: "not_found",
@@ -247,6 +250,7 @@ describe("chat media routes", () => {
 
     expect(response.status).toBe(400);
     expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
     expectChatMediaVaryHeader(response);
     await expect(response.json()).resolves.toEqual({
       error: "invalid_path",
@@ -260,6 +264,7 @@ describe("chat media routes", () => {
 
     expect(response.status).toBe(400);
     expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
     expectChatMediaVaryHeader(response);
     await expect(response.json()).resolves.toEqual({
       error: "invalid_request",

--- a/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
@@ -273,9 +273,15 @@ const createTestContainer = ({
   },
 });
 
+const jpegSignatureBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+const pngSignatureBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const webpSignatureBytes = new Uint8Array([
+  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+]);
+
 const createUploadFormData = ({
   body = "message body",
-  bytes = new Uint8Array([1, 2, 3, 4]),
+  bytes = pngSignatureBytes,
   fileName = "scan.png",
   legacyAuthorHandleId,
   legacyRoomId,
@@ -1114,7 +1120,7 @@ describe("chat routes", () => {
     expect(capturedInput).toEqual({
       body: "message body",
       image: {
-        body: new Uint8Array([1, 2, 3, 4]),
+        body: pngSignatureBytes,
         displayFilename: "scan.png",
         mimeType: "image/png",
       },
@@ -1179,6 +1185,75 @@ describe("chat routes", () => {
       error: "invalid_upload",
       field: "file",
       reason: "unsupported_mime_type",
+    });
+    expect(called).toBe(false);
+  });
+
+  it("accepts jpeg, png, and webp signatures for allowed MIME types", async () => {
+    const acceptedMimeTypes: string[] = [];
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeUpload: async (input) => {
+          acceptedMimeTypes.push(input.image.mimeType);
+          return defaultUploadResponse;
+        },
+      }),
+    );
+
+    const uploadCases = [
+      {
+        bytes: jpegSignatureBytes,
+        fileName: "scan.jpg",
+        mimeType: "image/jpeg",
+      },
+      {
+        bytes: pngSignatureBytes,
+        fileName: "scan.png",
+        mimeType: "image/png",
+      },
+      {
+        bytes: webpSignatureBytes,
+        fileName: "scan.webp",
+        mimeType: "image/webp",
+      },
+    ] as const;
+
+    for (const uploadCase of uploadCases) {
+      const response = await app.request("/api/chat/messages/upload", {
+        body: createUploadFormData(uploadCase),
+        method: "POST",
+      });
+
+      expect(response.status).toBe(201);
+    }
+
+    expect(acceptedMimeTypes).toEqual(["image/jpeg", "image/png", "image/webp"]);
+  });
+
+  it("rejects upload requests with MIME/signature mismatches", async () => {
+    let called = false;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeUpload: async () => {
+          called = true;
+          throw new Error("should not run");
+        },
+      }),
+    );
+
+    const response = await app.request("/api/chat/messages/upload", {
+      body: createUploadFormData({
+        bytes: jpegSignatureBytes,
+        mimeType: "image/png",
+      }),
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_upload",
+      field: "file",
+      reason: "mime_signature_mismatch",
     });
     expect(called).toBe(false);
   });

--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -652,6 +652,39 @@ const isSupportedChatUploadMimeType = (value: string): value is ChatUploadMimeTy
   return supportedChatUploadMimeTypes.includes(value as ChatUploadMimeType);
 };
 
+const hasLeadingBytes = (input: Uint8Array, signature: readonly number[]) => {
+  if (input.byteLength < signature.length) {
+    return false;
+  }
+
+  for (let index = 0; index < signature.length; index += 1) {
+    if (input[index] !== signature[index]) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const isChatUploadMimeSignatureValid = (mimeType: ChatUploadMimeType, bytes: Uint8Array) => {
+  if (mimeType === "image/jpeg") {
+    return hasLeadingBytes(bytes, [0xff, 0xd8, 0xff]);
+  }
+
+  if (mimeType === "image/png") {
+    return hasLeadingBytes(bytes, [0x89, 0x50, 0x4e, 0x47]);
+  }
+
+  return (
+    hasLeadingBytes(bytes, [0x52, 0x49, 0x46, 0x46]) &&
+    bytes.byteLength >= 12 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  );
+};
+
 const getRequiredFormText = (
   formData: FormData,
   field: string,
@@ -1295,6 +1328,7 @@ const createChatFamily = (
   chatApp.get("/uploads/:id/media", async (c) => {
     c.header("Cache-Control", "private, no-store");
     c.header("Vary", "x-chat-room-session-id");
+    c.header("X-Content-Type-Options", "nosniff");
 
     const id = c.req.param("id")?.trim();
 
@@ -1503,13 +1537,26 @@ const createChatFamily = (
       );
     }
 
+    const uploadBytes = new Uint8Array(await uploadFile.arrayBuffer());
+
+    if (!isChatUploadMimeSignatureValid(mimeType, uploadBytes)) {
+      return c.json(
+        {
+          error: "invalid_upload",
+          field: "file",
+          reason: "mime_signature_mismatch",
+        },
+        400,
+      );
+    }
+
     let result;
 
     try {
       result = await container.chat.uploadMessageWithImage.execute({
         body: getOptionalFormText(formData, "body"),
         image: {
-          body: new Uint8Array(await uploadFile.arrayBuffer()),
+          body: uploadBytes,
           displayFilename: uploadFile.name.trim() || "upload",
           mimeType,
         },

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -35,8 +35,8 @@
 ## Next Task Queue
 1. Complete reviewer validation for `QA-008` follow-up PR [#117](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/117).
 2. Complete reviewer validation for `CHAT-010` PR [#122](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/122).
-3. Execute `SEC-004` on `backend/SEC-004-chat-request-validation-hardening` from `develop`.
-4. Queue phase-2 security follow-ups (`SEC-005`, `SEC-006`, `SEC-008`) after `SEC-004` enters review.
+3. Execute `SEC-005` on `backend/SEC-005-upload-media-signature-hardening` from `develop`.
+4. Queue remaining phase-2 security follow-ups (`SEC-006`, `SEC-008`) after `SEC-005` enters review.
 
 ## Current Executable Cluster
 ### Frontend Admin API Integration
@@ -107,7 +107,7 @@ Done criteria for `CHAT-010`:
 - upload validation remains aligned with MIME, size, and one-file-per-message rules
 
 ### Security Hardening Execution
-- Status: in progress; first-wave critical tasks are complete and phase 2 execution has started with `SEC-004`.
+- Status: in progress; first-wave critical tasks are complete and phase 2 execution continues with `SEC-005` after `SEC-004` merged to `develop`.
 - Primary spec: `SPEC-031`.
 - Supporting specs: `frontend-structure.md`, `frontend-architecture.md`, `project-structure.md`, `backend-architecture.md`, `chat-room-live-integration.md`, `frontend-admin-auth-integration.md`, `media-storage.md`, `admin-cms.md`, `infra-deployment.md`, `verification.md`, and `git-workflow.md`.
 - Scope: execute the approved remediation wave from the 2026-05-03 security review with one task branch per finding cluster.
@@ -135,6 +135,12 @@ Done criteria for `CHAT-010`:
   - Blocker: none.
   - Local verification: chat adapter/use-case tests, backend typecheck, and boundary verification passed on 2026-05-05.
   - PR/Open review: PR [#127](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/127) opened against `develop`.
+  - Completion: chat request-validation hardening landed via merged PR [#127](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/127).
+- SEC-005 status log:
+  - Start: branch `backend/SEC-005-upload-media-signature-hardening` moved to `In Progress` after PR [#127](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/127) merged to `develop`.
+  - Blocker: none.
+  - Local execution: upload signature validation for JPEG/PNG/WebP plus protected chat media `nosniff` response headers were implemented in the Hono chat adapter.
+  - Local verification: chat upload/media adapter tests, backend typecheck, and boundary verification passed on 2026-05-05.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -142,8 +148,8 @@ Done criteria for `CHAT-010`:
 | Done | SEC-001 | SPEC-031 | infra | develop | `infra/SEC-001-production-secret-enforcement` | develop | `docs/specs/security-hardening-production-readiness.md` | [#124](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/124) merged | — |
 | Done | SEC-002 | SPEC-031 | backend | develop | `backend/SEC-002-cors-and-rate-limits` | develop | `docs/specs/security-hardening-production-readiness.md` | [#125](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/125) merged | — |
 | Done | SEC-003 | SPEC-031 | backend | develop | `backend/SEC-003-mfa-lockout-and-delivery` | develop | `docs/specs/security-hardening-production-readiness.md` | [#126](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/126) merged | — |
-| In Review | SEC-004 | SPEC-031 | backend | develop | `backend/SEC-004-chat-request-validation-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#127](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/127) | — |
-| Blocked | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |
+| Done | SEC-004 | SPEC-031 | backend | develop | `backend/SEC-004-chat-request-validation-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#127](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/127) merged | — |
+| In Progress | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
 | Blocked | SEC-006 | SPEC-031 | backend | develop | `backend/SEC-006-websocket-auth-transport-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-002`; phase-ordered after first-wave critical tasks. |
 | Blocked | SEC-007 | SPEC-031 | frontend | develop | `frontend/SEC-007-chat-session-storage-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-006` handshake contract before frontend storage migration. |
 | Blocked | SEC-008 | SPEC-031 | backend | develop | `backend/SEC-008-chat-crypto-and-audit-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -141,6 +141,7 @@ Done criteria for `CHAT-010`:
   - Blocker: none.
   - Local execution: upload signature validation for JPEG/PNG/WebP plus protected chat media `nosniff` response headers were implemented in the Hono chat adapter.
   - Local verification: chat upload/media adapter tests, backend typecheck, and boundary verification passed on 2026-05-05.
+  - PR/Open review: PR [#128](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/128) opened against `develop`.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -149,7 +150,7 @@ Done criteria for `CHAT-010`:
 | Done | SEC-002 | SPEC-031 | backend | develop | `backend/SEC-002-cors-and-rate-limits` | develop | `docs/specs/security-hardening-production-readiness.md` | [#125](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/125) merged | — |
 | Done | SEC-003 | SPEC-031 | backend | develop | `backend/SEC-003-mfa-lockout-and-delivery` | develop | `docs/specs/security-hardening-production-readiness.md` | [#126](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/126) merged | — |
 | Done | SEC-004 | SPEC-031 | backend | develop | `backend/SEC-004-chat-request-validation-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#127](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/127) merged | — |
-| In Progress | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
+| In Review | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#128](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/128) | — |
 | Blocked | SEC-006 | SPEC-031 | backend | develop | `backend/SEC-006-websocket-auth-transport-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-002`; phase-ordered after first-wave critical tasks. |
 | Blocked | SEC-007 | SPEC-031 | frontend | develop | `frontend/SEC-007-chat-session-storage-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-006` handshake contract before frontend storage migration. |
 | Blocked | SEC-008 | SPEC-031 | backend | develop | `backend/SEC-008-chat-crypto-and-audit-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |


### PR DESCRIPTION
## Summary
- Task ID: SEC-005
- Source tracker entry: `docs/specs/tracker.md` > Security Hardening Execution
- Source spec: `docs/specs/security-hardening-production-readiness.md`

Adds server-side magic-byte validation for chat image uploads and sets `X-Content-Type-Options: nosniff` on protected chat media responses.

## Branching
- Base branch: `develop`
- Merge target: `develop`

## Acceptance
- Acceptance source: `docs/specs/security-hardening-production-readiness.md`
- Verification performed:
  - `cd backend && bun test src/adapters/inbound/http/hono/chat-routes.test.ts src/adapters/inbound/http/hono/chat-media-routes.test.ts` (`38 pass, 0 fail`)
  - `cd backend && bun run typecheck` (passed)
  - `cd backend && bun run verify:boundary` (passed)
- Required CI status checks: PR validation for `develop`

## Notes
- Deployment impact: chat upload/media validation behavior only; no migration or deploy automation changes.
- Revert impact: revert SEC-005 commits to remove magic-byte checks and protected media nosniff header.
- Follow-up tasks: SEC-006 handles WebSocket auth transport hardening.
