### PR TITLE
SEC-006 WebSocket chat auth transport hardening

### DIFF
--- a/backend/src/adapters/inbound/http/hono/chat-live-contract.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-live-contract.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  buildChatLiveRoomSessionProtocol,
+  chatLiveTransportProtocol,
+  parseChatLiveWebSocketHandshake,
+} from "./chat-live-contract";
+
+describe("chat live websocket contract", () => {
+  it("parses websocket auth from sec-websocket-protocol", () => {
+    const parsed = parseChatLiveWebSocketHandshake(
+      `${chatLiveTransportProtocol}, ${buildChatLiveRoomSessionProtocol("session_1")}`,
+    );
+
+    if ("error" in parsed) {
+      throw new Error("expected websocket handshake to parse");
+    }
+
+    expect(parsed.value).toEqual({
+      roomSessionId: "session_1",
+      transportProtocol: chatLiveTransportProtocol,
+    });
+  });
+
+  it("rejects handshakes that do not include the transport subprotocol", () => {
+    const parsed = parseChatLiveWebSocketHandshake(buildChatLiveRoomSessionProtocol("session_1"));
+
+    expect(parsed).toEqual({
+      error: {
+        error: "invalid_request",
+        field: "sec-websocket-protocol",
+        reason: "missing_transport_protocol",
+      },
+    });
+  });
+
+  it("rejects handshakes that omit the room session subprotocol", () => {
+    const parsed = parseChatLiveWebSocketHandshake(chatLiveTransportProtocol);
+
+    expect(parsed).toEqual({
+      error: {
+        error: "invalid_request",
+        field: "sec-websocket-protocol",
+        reason: "missing_room_session_protocol",
+      },
+    });
+  });
+
+  it("rejects handshakes with an empty room session id", () => {
+    const parsed = parseChatLiveWebSocketHandshake(
+      `${chatLiveTransportProtocol}, ${buildChatLiveRoomSessionProtocol("   ")}`,
+    );
+
+    expect(parsed).toEqual({
+      error: {
+        error: "invalid_request",
+        field: "sec-websocket-protocol",
+        reason: "invalid_room_session_protocol",
+      },
+    });
+  });
+});

--- a/backend/src/adapters/inbound/http/hono/chat-live-contract.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-live-contract.ts
@@ -1,0 +1,73 @@
+const liveTransportProtocol = "chat-room-live.v1" as const;
+const liveSessionProtocolPrefix = "chat-room-session." as const;
+const liveProtocolHeaderField = "sec-websocket-protocol" as const;
+
+type LiveProtocolErrorReason =
+  | "missing_transport_protocol"
+  | "missing_room_session_protocol"
+  | "invalid_room_session_protocol";
+
+type LiveProtocolError = Readonly<{
+  error: "invalid_request";
+  field: typeof liveProtocolHeaderField;
+  reason: LiveProtocolErrorReason;
+}>;
+
+export type ChatLiveWebSocketHandshake = Readonly<{
+  roomSessionId: string;
+  transportProtocol: typeof liveTransportProtocol;
+}>;
+
+type ParseChatLiveWebSocketHandshakeResult =
+  | Readonly<{ value: ChatLiveWebSocketHandshake }>
+  | Readonly<{ error: LiveProtocolError }>;
+
+export const chatLiveTransportProtocol = liveTransportProtocol;
+
+export const buildChatLiveRoomSessionProtocol = (roomSessionId: string) =>
+  `${liveSessionProtocolPrefix}${roomSessionId}`;
+
+const parseWebSocketProtocolHeader = (value: string | undefined) =>
+  value
+    ?.split(",")
+    .map((candidate) => candidate.trim())
+    .filter((candidate) => candidate.length > 0) ?? [];
+
+const createLiveProtocolError = (reason: LiveProtocolErrorReason) => ({
+  error: {
+    error: "invalid_request" as const,
+    field: liveProtocolHeaderField,
+    reason,
+  },
+});
+
+export const parseChatLiveWebSocketHandshake = (
+  protocolHeader: string | undefined,
+): ParseChatLiveWebSocketHandshakeResult => {
+  const offeredProtocols = parseWebSocketProtocolHeader(protocolHeader);
+
+  if (!offeredProtocols.includes(liveTransportProtocol)) {
+    return createLiveProtocolError("missing_transport_protocol");
+  }
+
+  const roomSessionProtocols = offeredProtocols.filter((protocol) =>
+    protocol.startsWith(liveSessionProtocolPrefix),
+  );
+
+  if (roomSessionProtocols.length !== 1) {
+    return createLiveProtocolError("missing_room_session_protocol");
+  }
+
+  const roomSessionId = roomSessionProtocols[0].slice(liveSessionProtocolPrefix.length).trim();
+
+  if (roomSessionId.length === 0) {
+    return createLiveProtocolError("invalid_room_session_protocol");
+  }
+
+  return {
+    value: {
+      roomSessionId,
+      transportProtocol: liveTransportProtocol,
+    },
+  };
+};

--- a/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
@@ -26,6 +26,10 @@ import {
 } from "@/modules/chat/application";
 
 import { createHonoHttpAdapter } from "./http-adapter";
+import {
+  buildChatLiveRoomSessionProtocol,
+  chatLiveTransportProtocol,
+} from "./chat-live-contract";
 
 const defaultUploadResponse: UploadChatMessageWithImageOutput = {
   attachment: {
@@ -318,6 +322,16 @@ const createUploadFormData = ({
   return formData;
 };
 
+const createWebSocketUpgradeHeaders = (protocols: readonly string[]) => ({
+  connection: "Upgrade",
+  "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+  "sec-websocket-protocol": protocols.join(", "),
+  "sec-websocket-version": "13",
+  upgrade: "websocket",
+});
+
+const resolveWebSocketHandler = async () => (await import("hono/bun")).websocket;
+
 describe("chat routes", () => {
   it("maps a valid join request into the chat join use case", async () => {
     let capturedInput: JoinChatRoomSessionInput | undefined;
@@ -583,6 +597,151 @@ describe("chat routes", () => {
       error: "denied",
       resource: "chat",
     });
+  });
+
+  it("rejects live websocket requests that do not provide the websocket auth contract", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+
+    const response = await app.request("/api/chat/rooms/night-shift/live");
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_request",
+      field: "sec-websocket-protocol",
+      reason: "missing_transport_protocol",
+    });
+  });
+
+  it("accepts websocket live auth via sec-websocket-protocol without query-string session ids", async () => {
+    let capturedResolveInput: ResolveChatRoomSessionInput | undefined;
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeResolve: async (input) => {
+          capturedResolveInput = input;
+
+          return {
+            participant: {
+              handle: "vinicius",
+              id: "handle_1",
+              status: "online",
+            },
+            room: {
+              id: "room_1",
+              slug: "night-shift",
+            },
+            session: {
+              expiresAt: "2026-04-25T12:00:00.000Z",
+              handleId: "handle_1",
+              id: "session_1",
+              joinedAt: "2026-04-24T12:00:00.000Z",
+              roomId: "room_1",
+              status: "active",
+            },
+          };
+        },
+      }),
+    );
+    const websocket = await resolveWebSocketHandler();
+    const server = Bun.serve({
+      fetch: (request, bunServer) => app.fetch(request, bunServer),
+      port: 0,
+      websocket,
+    });
+    const protocols = [
+      chatLiveTransportProtocol,
+      buildChatLiveRoomSessionProtocol("session_1"),
+    ];
+
+    try {
+      const negotiated = await new Promise<{
+        message: unknown;
+        protocol: string;
+      }>((resolve, reject) => {
+        const socket = new WebSocket(
+          `ws://127.0.0.1:${server.port}/api/chat/rooms/night-shift/live`,
+          protocols,
+        );
+        const timeout = setTimeout(() => {
+          socket.close();
+          reject(new Error("timed out waiting for websocket participant snapshot"));
+        }, 2_000);
+        let settled = false;
+
+        socket.onmessage = (event) => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timeout);
+          socket.close();
+          resolve({
+            message: JSON.parse(String(event.data)),
+            protocol: socket.protocol,
+          });
+        };
+
+        socket.onerror = () => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timeout);
+          reject(new Error("failed to open websocket live connection"));
+        };
+      });
+
+      expect(negotiated.protocol).toBe(chatLiveTransportProtocol);
+      expect(negotiated.message).toEqual({
+        items: [
+          {
+            handle: "vinicius",
+            status: "online",
+          },
+        ],
+        type: "participant.snapshot",
+      });
+      expect(capturedResolveInput).toEqual({
+        roomSessionId: "session_1",
+        slug: "night-shift",
+      });
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  it("rejects live websocket upgrades when the room session is invalid", async () => {
+    const app = createHonoHttpAdapter(
+      createTestContainer({
+        executeResolve: async () => {
+          throw new InvalidChatRoomSessionError();
+        },
+      }),
+    );
+    const websocket = await resolveWebSocketHandler();
+    const server = Bun.serve({
+      fetch: (request, bunServer) => app.fetch(request, bunServer),
+      port: 0,
+      websocket,
+    });
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/api/chat/rooms/night-shift/live`, {
+        headers: createWebSocketUpgradeHeaders([
+          chatLiveTransportProtocol,
+          buildChatLiveRoomSessionProtocol("expired_session"),
+        ]),
+      });
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({
+        error: "denied",
+        resource: "chat",
+      });
+    } finally {
+      await server.stop(true);
+    }
   });
 
   it("maps a valid participants request into the participants use case", async () => {

--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -40,6 +40,7 @@ import type { BootstrapContainer } from "@/bootstrap/container";
 
 import { presentThoughtsRssFeed } from "./rss-presenter";
 import { presentSitemapXml } from "./sitemap-presenter";
+import { parseChatLiveWebSocketHandshake } from "./chat-live-contract";
 
 const serviceName = "vinicius.dev-backend";
 const defaultMediaContentType = "application/octet-stream";
@@ -1007,11 +1008,15 @@ const createChatFamily = (
       return c.json({ error: "invalid_path", field: "slug" }, 400);
     }
 
-    const roomSessionId = c.req.query("sessionId")?.trim();
+    const parsedHandshake = parseChatLiveWebSocketHandshake(
+      c.req.header("sec-websocket-protocol"),
+    );
 
-    if (!roomSessionId) {
-      return c.json({ error: "invalid_query", field: "sessionId" }, 400);
+    if ("error" in parsedHandshake) {
+      return c.json(parsedHandshake.error, 400);
     }
+
+    const roomSessionId = parsedHandshake.value.roomSessionId;
 
     if (!resolveRoomSessionUseCase || !container.chat.listRoomParticipants) {
       return c.json<NotImplementedResponse>(
@@ -1032,24 +1037,32 @@ const createChatFamily = (
         container.chat.listRoomParticipants.execute({ roomSessionId, slug }),
       ]);
 
-      return upgradeWebSocket(c, {
-        onClose: () => {
-          live.remove(slug, roomSessionId);
+      return upgradeWebSocket(
+        c,
+        {
+          onClose: () => {
+            live.remove(slug, roomSessionId);
+          },
+          onOpen: (_event, ws) => {
+            live.add({
+              roomId: resolvedSession.room.id,
+              roomSessionId,
+              roomSlug: slug,
+              socket: ws,
+            });
+            live.sendToSession(slug, roomSessionId, {
+              items: snapshot.items,
+              type: "participant.snapshot",
+            });
+            void broadcastParticipantSnapshot(slug, resolvedSession.session.id);
+          },
         },
-        onOpen: (_event, ws) => {
-          live.add({
-            roomId: resolvedSession.room.id,
-            roomSessionId,
-            roomSlug: slug,
-            socket: ws,
-          });
-          live.sendToSession(slug, roomSessionId, {
-            items: snapshot.items,
-            type: "participant.snapshot",
-          });
-          void broadcastParticipantSnapshot(slug, resolvedSession.session.id);
+        {
+          headers: {
+            "Sec-WebSocket-Protocol": parsedHandshake.value.transportProtocol,
+          },
         },
-      });
+      );
     } catch (error) {
       if (error instanceof InvalidChatRoomSessionError) {
         return c.json({ error: "denied", resource: "chat" }, 401);

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -35,8 +35,8 @@
 ## Next Task Queue
 1. Complete reviewer validation for `QA-008` follow-up PR [#117](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/117).
 2. Complete reviewer validation for `CHAT-010` PR [#122](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/122).
-3. Execute `SEC-005` on `backend/SEC-005-upload-media-signature-hardening` from `develop`.
-4. Queue remaining phase-2 security follow-ups (`SEC-006`, `SEC-008`) after `SEC-005` enters review.
+3. Execute `SEC-006` on `backend/SEC-006-websocket-auth-transport-hardening` from `develop`.
+4. Queue remaining phase-2 security follow-up `SEC-008` after `SEC-006` enters review.
 
 ## Current Executable Cluster
 ### Frontend Admin API Integration
@@ -107,7 +107,7 @@ Done criteria for `CHAT-010`:
 - upload validation remains aligned with MIME, size, and one-file-per-message rules
 
 ### Security Hardening Execution
-- Status: in progress; first-wave critical tasks are complete and phase 2 execution continues with `SEC-005` after `SEC-004` merged to `develop`.
+- Status: in progress; first-wave critical tasks are complete and phase 2 execution continues with `SEC-006` after `SEC-005` merged to `develop`.
 - Primary spec: `SPEC-031`.
 - Supporting specs: `frontend-structure.md`, `frontend-architecture.md`, `project-structure.md`, `backend-architecture.md`, `chat-room-live-integration.md`, `frontend-admin-auth-integration.md`, `media-storage.md`, `admin-cms.md`, `infra-deployment.md`, `verification.md`, and `git-workflow.md`.
 - Scope: execute the approved remediation wave from the 2026-05-03 security review with one task branch per finding cluster.
@@ -142,6 +142,12 @@ Done criteria for `CHAT-010`:
   - Local execution: upload signature validation for JPEG/PNG/WebP plus protected chat media `nosniff` response headers were implemented in the Hono chat adapter.
   - Local verification: chat upload/media adapter tests, backend typecheck, and boundary verification passed on 2026-05-05.
   - PR/Open review: PR [#128](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/128) opened against `develop`.
+  - Completion: upload signature and protected-media hardening landed via merged PR [#128](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/128).
+- SEC-006 status log:
+  - Start: branch `backend/SEC-006-websocket-auth-transport-hardening` moved to `In Progress` after PR [#128](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/128) merged to `develop`.
+  - Blocker: none.
+  - Local execution: the WebSocket room-session auth transport moved from query-string `sessionId` to the approved `Sec-WebSocket-Protocol` handshake contract.
+  - Local verification: websocket live contract tests plus backend typecheck and boundary verification are required before opening review.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -150,8 +156,8 @@ Done criteria for `CHAT-010`:
 | Done | SEC-002 | SPEC-031 | backend | develop | `backend/SEC-002-cors-and-rate-limits` | develop | `docs/specs/security-hardening-production-readiness.md` | [#125](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/125) merged | — |
 | Done | SEC-003 | SPEC-031 | backend | develop | `backend/SEC-003-mfa-lockout-and-delivery` | develop | `docs/specs/security-hardening-production-readiness.md` | [#126](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/126) merged | — |
 | Done | SEC-004 | SPEC-031 | backend | develop | `backend/SEC-004-chat-request-validation-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#127](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/127) merged | — |
-| In Review | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#128](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/128) | — |
-| Blocked | SEC-006 | SPEC-031 | backend | develop | `backend/SEC-006-websocket-auth-transport-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-002`; phase-ordered after first-wave critical tasks. |
+| Done | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#128](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/128) merged | — |
+| In Progress | SEC-006 | SPEC-031 | backend | develop | `backend/SEC-006-websocket-auth-transport-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
 | Blocked | SEC-007 | SPEC-031 | frontend | develop | `frontend/SEC-007-chat-session-storage-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-006` handshake contract before frontend storage migration. |
 | Blocked | SEC-008 | SPEC-031 | backend | develop | `backend/SEC-008-chat-crypto-and-audit-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |
 | Blocked | SEC-009 | SPEC-031 | infra | develop | `infra/SEC-009-edge-headers-and-production-compose` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-001` and is reserved for Phase 3 hardening. |

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -147,7 +147,8 @@ Done criteria for `CHAT-010`:
   - Start: branch `backend/SEC-006-websocket-auth-transport-hardening` moved to `In Progress` after PR [#128](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/128) merged to `develop`.
   - Blocker: none.
   - Local execution: the WebSocket room-session auth transport moved from query-string `sessionId` to the approved `Sec-WebSocket-Protocol` handshake contract.
-  - Local verification: websocket live contract tests plus backend typecheck and boundary verification are required before opening review.
+  - Local verification: websocket live contract tests, media verification, backend typecheck, and boundary verification passed on 2026-05-05.
+  - PR/Open review: PR [#129](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/129) opened against `develop`.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -157,7 +158,7 @@ Done criteria for `CHAT-010`:
 | Done | SEC-003 | SPEC-031 | backend | develop | `backend/SEC-003-mfa-lockout-and-delivery` | develop | `docs/specs/security-hardening-production-readiness.md` | [#126](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/126) merged | — |
 | Done | SEC-004 | SPEC-031 | backend | develop | `backend/SEC-004-chat-request-validation-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#127](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/127) merged | — |
 | Done | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#128](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/128) merged | — |
-| In Progress | SEC-006 | SPEC-031 | backend | develop | `backend/SEC-006-websocket-auth-transport-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
+| In Review | SEC-006 | SPEC-031 | backend | develop | `backend/SEC-006-websocket-auth-transport-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#129](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/129) | — |
 | Blocked | SEC-007 | SPEC-031 | frontend | develop | `frontend/SEC-007-chat-session-storage-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-006` handshake contract before frontend storage migration. |
 | Blocked | SEC-008 | SPEC-031 | backend | develop | `backend/SEC-008-chat-crypto-and-audit-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |
 | Blocked | SEC-009 | SPEC-031 | infra | develop | `infra/SEC-009-edge-headers-and-production-compose` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-001` and is reserved for Phase 3 hardening. |


### PR DESCRIPTION
## Summary
- Task ID: SEC-006
- Source tracker entry: `docs/specs/tracker.md` > Security Hardening Execution
- Source spec: `docs/specs/security-hardening-production-readiness.md`

Hardens chat live WebSocket authentication by moving the room session id out of the URL query string and into the `Sec-WebSocket-Protocol` handshake. The backend validates the session before upgrade and rejects invalid sessions before subscription.

## Branching
- Base branch: `develop`
- Merge target: `develop`

## Acceptance
- Acceptance source: `docs/specs/security-hardening-production-readiness.md`
- Verification performed:
  - `cd backend && bun test src/adapters/inbound/http/hono/chat-live-contract.test.ts src/adapters/inbound/http/hono/chat-routes.test.ts` (`40 pass, 0 fail`)
  - `cd backend && bun run verify:media` (`99 pass, 0 fail`)
  - `cd backend && bun run typecheck` (passed)
  - `cd backend && bun run verify:boundary` (passed)
- Required CI status checks: PR validation for `develop`

## Notes
- Deployment impact: backend WebSocket handshake contract changes; SEC-007 updates the frontend client to match.
- Revert impact: revert SEC-006 commits to restore query-string WebSocket auth.
- Follow-up tasks: SEC-007 migrates frontend chat session storage and live client handshake.
