### PR TITLE
SEC-008 Chat crypto and moderation audit hardening

### DIFF
--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it } from "bun:test";
+import { createCipheriv, createHash } from "node:crypto";
 
 import { createPrismaChatRepository } from "./chat-repository";
 import type { PrismaDatabaseClient } from "./prisma-client";
+
+const encryptLegacyReadablePassword = (plainText: string, secret: string): string => {
+  const iv = Buffer.from("00112233445566778899aabb", "hex");
+  const key = createHash("sha256").update(secret).digest();
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const encrypted = Buffer.concat([cipher.update(plainText, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  return `${iv.toString("base64url")}.${encrypted.toString("base64url")}.${tag.toString("base64url")}`;
+};
 
 describe("prisma chat repository", () => {
   it("maps a room session row for upload actor validation", async () => {
@@ -59,6 +70,128 @@ describe("prisma chat repository", () => {
       passwordVersion: 3,
       slug: "night-shift",
       updatedAt: new Date("2026-04-24T10:05:00.000Z"),
+    });
+  });
+
+  it("decrypts legacy room-password ciphertext for room access reads", async () => {
+    const roomPasswordSecret = "legacy-room-secret";
+    const repository = createPrismaChatRepository({
+      chatRoom: {
+        findUnique: async () => ({
+          currentPasswordCiphertext: encryptLegacyReadablePassword(
+            "night-runner-42",
+            roomPasswordSecret,
+          ),
+          id: "room_1",
+          passwordRotatedAt: new Date("2026-04-20T08:00:00.000Z"),
+          passwordVersion: 3,
+          slug: "night-shift",
+        }),
+      },
+    } as unknown as PrismaDatabaseClient, {
+      roomPasswordSecret,
+    });
+
+    await expect(repository.findRoomAccessBySlug("night-shift")).resolves.toEqual({
+      currentPassword: "night-runner-42",
+      id: "room_1",
+      passwordRotatedAt: new Date("2026-04-20T08:00:00.000Z"),
+      passwordVersion: 3,
+      slug: "night-shift",
+    });
+  });
+
+  it("writes versioned HKDF ciphertext and decrypts it through room access lookup", async () => {
+    const occurredAt = new Date("2026-04-28T12:10:00.000Z");
+    const roomPasswordSecret = "room-secret-v2";
+    let storedCiphertext = "";
+    const rotateRepository = createPrismaChatRepository({
+      $transaction: async <T>(
+        runInTransaction: (tx: {
+          chatModerationAuditRecord: {
+            create: (args: { data: Record<string, unknown>; select: { id: true } }) => Promise<{ id: string }>;
+          };
+          chatRoom: {
+            findUnique: (args: { where: { slug: string } }) => Promise<Record<string, unknown> | null>;
+            update: (args: { data: Record<string, unknown>; select: Record<string, true>; where: { id: string } }) => Promise<Record<string, unknown>>;
+          };
+          chatRoomPasswordRotation: {
+            create: (args: { data: Record<string, unknown>; select: { id: true; rotatedAt: true } }) => Promise<{ id: string; rotatedAt: Date }>;
+          };
+          chatRoomSession: {
+            updateMany: (args: { data: Record<string, unknown>; where: Record<string, unknown> }) => Promise<{ count: number }>;
+          };
+        }) => Promise<T>,
+      ) =>
+        runInTransaction({
+          chatModerationAuditRecord: {
+            create: async () => ({ id: "audit_1" }),
+          },
+          chatRoom: {
+            findUnique: async () => ({
+              createdAt: new Date("2026-04-24T10:00:00.000Z"),
+              id: "room_1",
+              passwordHash: "hash:old",
+              passwordRotatedAt: new Date("2026-04-20T10:00:00.000Z"),
+              passwordVersion: 3,
+              slug: "night-shift",
+              updatedAt: new Date("2026-04-24T10:00:00.000Z"),
+            }),
+            update: async ({ data }) => {
+              storedCiphertext = data.currentPasswordCiphertext as string;
+
+              return {
+                createdAt: new Date("2026-04-24T10:00:00.000Z"),
+                id: "room_1",
+                passwordHash: "hash:new",
+                passwordRotatedAt: occurredAt,
+                passwordVersion: 4,
+                slug: "night-shift",
+                updatedAt: occurredAt,
+              };
+            },
+          },
+          chatRoomPasswordRotation: {
+            create: async () => ({ id: "rotation_1", rotatedAt: occurredAt }),
+          },
+          chatRoomSession: {
+            updateMany: async () => ({ count: 0 }),
+          },
+        }),
+    } as unknown as PrismaDatabaseClient, {
+      roomPasswordSecret,
+    });
+
+    await rotateRepository.rotateRoomPassword({
+      actorAdminUserId: "admin_1",
+      nextPassword: "new-secret",
+      nextPasswordHash: "hash:new",
+      occurredAt,
+      slug: "night-shift",
+    });
+
+    expect(storedCiphertext).toMatch(/^v2\./);
+
+    const readRepository = createPrismaChatRepository({
+      chatRoom: {
+        findUnique: async () => ({
+          currentPasswordCiphertext: storedCiphertext,
+          id: "room_1",
+          passwordRotatedAt: occurredAt,
+          passwordVersion: 4,
+          slug: "night-shift",
+        }),
+      },
+    } as unknown as PrismaDatabaseClient, {
+      roomPasswordSecret,
+    });
+
+    await expect(readRepository.findRoomAccessBySlug("night-shift")).resolves.toEqual({
+      currentPassword: "new-secret",
+      id: "room_1",
+      passwordRotatedAt: occurredAt,
+      passwordVersion: 4,
+      slug: "night-shift",
     });
   });
 

--- a/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/chat-repository.ts
@@ -1,4 +1,4 @@
-import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
+import { createCipheriv, createDecipheriv, createHash, hkdfSync, randomBytes } from "node:crypto";
 
 import type {
   BanChatRoomHandleCommand,
@@ -34,7 +34,23 @@ import { ChatUploadMimeType } from "../../../../../generated/prisma/client";
 
 import type { PrismaDatabaseClient } from "./prisma-client";
 
+const ROOM_PASSWORD_CIPHERTEXT_VERSION = "v2";
+const ROOM_PASSWORD_HKDF_INFO = "vinicius.dev/chat-room-readable-password/aes-256-gcm";
+const ROOM_PASSWORD_HKDF_SALT = "vinicius.dev/chat-room-readable-password/salt";
+const ROOM_PASSWORD_KEY_LENGTH_BYTES = 32;
+
 const createReadablePasswordKey = (secret: string): Buffer =>
+  Buffer.from(
+    hkdfSync(
+      "sha256",
+      Buffer.from(secret, "utf8"),
+      Buffer.from(ROOM_PASSWORD_HKDF_SALT, "utf8"),
+      Buffer.from(ROOM_PASSWORD_HKDF_INFO, "utf8"),
+      ROOM_PASSWORD_KEY_LENGTH_BYTES,
+    ),
+  );
+
+const createLegacyReadablePasswordKey = (secret: string): Buffer =>
   createHash("sha256").update(secret).digest();
 
 const encryptReadablePassword = (plainText: string, secret: string): string => {
@@ -44,27 +60,57 @@ const encryptReadablePassword = (plainText: string, secret: string): string => {
   const encrypted = Buffer.concat([cipher.update(plainText, "utf8"), cipher.final()]);
   const tag = cipher.getAuthTag();
 
-  return `${iv.toString("base64url")}.${encrypted.toString("base64url")}.${tag.toString("base64url")}`;
+  return `${ROOM_PASSWORD_CIPHERTEXT_VERSION}.${iv.toString("base64url")}.${encrypted.toString("base64url")}.${tag.toString("base64url")}`;
 };
 
-const decryptReadablePassword = (ciphertext: string, secret: string): string => {
-  const [ivBase64, payloadBase64, tagBase64] = ciphertext.split(".");
-
-  if (!ivBase64 || !payloadBase64 || !tagBase64) {
-    throw new Error("Invalid encrypted room password payload");
-  }
-
-  const decipher = createDecipheriv(
-    "aes-256-gcm",
-    createReadablePasswordKey(secret),
-    Buffer.from(ivBase64, "base64url"),
-  );
+const decryptReadablePasswordPayload = (
+  ciphertextParts: readonly [string, string, string],
+  key: Buffer,
+): string => {
+  const [ivBase64, payloadBase64, tagBase64] = ciphertextParts;
+  const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(ivBase64, "base64url"));
   decipher.setAuthTag(Buffer.from(tagBase64, "base64url"));
 
   return Buffer.concat([
     decipher.update(Buffer.from(payloadBase64, "base64url")),
     decipher.final(),
   ]).toString("utf8");
+};
+
+const decryptReadablePassword = (ciphertext: string, secret: string): string => {
+  const parts = ciphertext.split(".");
+
+  if (parts[0] === ROOM_PASSWORD_CIPHERTEXT_VERSION) {
+    if (parts.length !== 4) {
+      throw new Error("Invalid encrypted room password payload");
+    }
+
+    const [, ivBase64, payloadBase64, tagBase64] = parts;
+
+    if (!ivBase64 || !payloadBase64 || !tagBase64) {
+      throw new Error("Invalid encrypted room password payload");
+    }
+
+    return decryptReadablePasswordPayload(
+      [ivBase64, payloadBase64, tagBase64],
+      createReadablePasswordKey(secret),
+    );
+  }
+
+  if (parts.length !== 3) {
+    throw new Error("Invalid encrypted room password payload");
+  }
+
+  const [ivBase64, payloadBase64, tagBase64] = parts;
+
+  if (!ivBase64 || !payloadBase64 || !tagBase64) {
+    throw new Error("Invalid encrypted room password payload");
+  }
+
+  return decryptReadablePasswordPayload(
+    [ivBase64, payloadBase64, tagBase64],
+    createLegacyReadablePasswordKey(secret),
+  );
 };
 
 const notImplemented = <T>(method: string): Promise<T> => {

--- a/backend/src/modules/chat/application/index.test.ts
+++ b/backend/src/modules/chat/application/index.test.ts
@@ -573,6 +573,68 @@ describe("chat moderation audits list use case", () => {
     });
   });
 
+  it("redacts unknown moderation audit state fields from API output", async () => {
+    const useCase = createListChatModerationAuditsUseCase({
+      repository: {
+        listModerationAudits: async () => ({
+          items: [
+            {
+              action: "delete_message",
+              actorAdminUserId: "admin_1",
+              createdAt: new Date("2026-04-28T12:06:00.000Z"),
+              id: "audit_1",
+              nextState: {
+                messageModerationState: "deleted",
+                secretInternalKey: "do-not-leak",
+              },
+              previousState: {
+                messageModerationState: "visible",
+                uploadStoragePath: "/srv/private/path.png",
+              },
+              reason: null,
+              roomId: "room_1",
+              targetBanId: null,
+              targetHandleId: null,
+              targetMessageId: "message_1",
+              targetRoomPasswordRotationId: null,
+              targetSessionId: null,
+              targetUploadId: "upload_1",
+            },
+          ],
+          nextCursor: null,
+        }),
+      },
+    });
+
+    await expect(useCase.execute({})).resolves.toEqual({
+      items: [
+        {
+          action: "delete_message",
+          actorAdminUserId: "admin_1",
+          createdAt: "2026-04-28T12:06:00.000Z",
+          id: "audit_1",
+          nextState: {
+            messageModerationState: "deleted",
+          },
+          previousState: {
+            messageModerationState: "visible",
+          },
+          reason: null,
+          roomId: "room_1",
+          targetBanId: null,
+          targetHandleId: null,
+          targetMessageId: "message_1",
+          targetRoomPasswordRotationId: null,
+          targetSessionId: null,
+          targetUploadId: "upload_1",
+        },
+      ],
+      pageInfo: {
+        nextCursor: null,
+      },
+    });
+  });
+
   it("rejects malformed moderation audit cursor input", async () => {
     const useCase = createListChatModerationAuditsUseCase({
       repository: {
@@ -987,6 +1049,55 @@ describe("chat handle ban use case", () => {
 });
 
 describe("chat room password rotation use case", () => {
+  it("uses a CSPRNG-generated default room password format when no password generator is injected", async () => {
+    const occurredAt = new Date("2026-04-28T12:08:00.000Z");
+    const generatedPasswords: string[] = [];
+    const useCase = createRotateChatRoomPasswordUseCase({
+      clock: () => occurredAt,
+      hashRoomPassword: async (plainText) => `hash:${plainText}`,
+      repository: {
+        rotateRoomPassword: async (input) => {
+          generatedPasswords.push(input.nextPassword);
+
+          return {
+            auditId: `audit_${generatedPasswords.length}`,
+            currentPassword: input.nextPassword,
+            revokedSessionCount: 0,
+            room: {
+              createdAt: occurredAt,
+              id: "room_1",
+              passwordHash: input.nextPasswordHash,
+              passwordRotatedAt: occurredAt,
+              passwordVersion: generatedPasswords.length,
+              slug: "night-shift",
+              updatedAt: occurredAt,
+            },
+            rotation: {
+              id: `rotation_${generatedPasswords.length}`,
+              rotatedAt: occurredAt,
+            },
+          };
+        },
+      },
+      sessionTtlHours: 24,
+    });
+
+    await useCase.execute({
+      actorAdminUserId: "admin_1",
+      slug: "night-shift",
+    });
+    await useCase.execute({
+      actorAdminUserId: "admin_1",
+      slug: "night-shift",
+    });
+
+    expect(generatedPasswords).toHaveLength(2);
+    for (const password of generatedPasswords) {
+      expect(password).toMatch(/^[A-HJ-NP-Za-km-z2-9]{4}-[A-HJ-NP-Za-km-z2-9]{4}-[A-HJ-NP-Za-km-z2-9]{4}$/);
+    }
+    expect(generatedPasswords[0]).not.toBe(generatedPasswords[1]);
+  });
+
   it("generates the next password, rotates the hash, and returns rotation metadata", async () => {
     const occurredAt = new Date("2026-04-28T12:08:00.000Z");
     const capturedCalls: Array<Record<string, unknown>> = [];

--- a/backend/src/modules/chat/application/index.ts
+++ b/backend/src/modules/chat/application/index.ts
@@ -6,6 +6,10 @@ import type { ChatRepositoryPort } from "@/modules/chat/ports/outbound";
 import type {
   BanChatRoomHandleInput,
   BanChatRoomHandleOutput,
+  ChatModerationAuditBanHandleStateOutput,
+  ChatModerationAuditOutput,
+  ChatModerationAuditRoomPasswordRotationStateOutput,
+  ChatModerationAuditVisibilityStateOutput,
   BanChatRoomHandlePort,
   ChatUploadMimeType,
   ChatRoomMessageOutput,
@@ -390,6 +394,160 @@ const mapChatMessageOutput = (input: Readonly<{
   sentAt: input.sentAt.toISOString(),
 });
 
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+};
+
+const readOptionalStringOrNull = (
+  source: Record<string, unknown>,
+  key: string,
+): string | null | undefined => {
+  const value = source[key];
+  return typeof value === "string" || value === null ? value : undefined;
+};
+
+const readOptionalModerationState = (
+  source: Record<string, unknown>,
+  key: string,
+): "visible" | "hidden" | "deleted" | null | undefined => {
+  const value = source[key];
+
+  if (value === null || value === "visible" || value === "hidden" || value === "deleted") {
+    return value;
+  }
+
+  return undefined;
+};
+
+const readOptionalHandleStatus = (
+  source: Record<string, unknown>,
+  key: string,
+): "active" | "banned" | null | undefined => {
+  const value = source[key];
+
+  if (value === null || value === "active" || value === "banned") {
+    return value;
+  }
+
+  return undefined;
+};
+
+const readOptionalNumber = (
+  source: Record<string, unknown>,
+  key: string,
+): number | undefined => {
+  const value = source[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+};
+
+const mapChatModerationVisibilityState = (
+  value: unknown,
+): ChatModerationAuditVisibilityStateOutput | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const messageDeletedAt = readOptionalStringOrNull(value, "messageDeletedAt");
+  const messageHiddenAt = readOptionalStringOrNull(value, "messageHiddenAt");
+  const messageModerationState = readOptionalModerationState(
+    value,
+    "messageModerationState",
+  );
+  const uploadDeletedAt = readOptionalStringOrNull(value, "uploadDeletedAt");
+  const uploadHiddenAt = readOptionalStringOrNull(value, "uploadHiddenAt");
+  const uploadModerationState = readOptionalModerationState(value, "uploadModerationState");
+  const state: ChatModerationAuditVisibilityStateOutput = {
+    ...(typeof messageDeletedAt !== "undefined"
+      ? {
+          messageDeletedAt,
+        }
+      : {}),
+    ...(typeof messageHiddenAt !== "undefined"
+      ? {
+          messageHiddenAt,
+        }
+      : {}),
+    ...(typeof messageModerationState !== "undefined"
+      ? {
+          messageModerationState,
+        }
+      : {}),
+    ...(typeof uploadDeletedAt !== "undefined"
+      ? {
+          uploadDeletedAt,
+        }
+      : {}),
+    ...(typeof uploadHiddenAt !== "undefined"
+      ? {
+          uploadHiddenAt,
+        }
+      : {}),
+    ...(typeof uploadModerationState !== "undefined"
+      ? {
+          uploadModerationState,
+        }
+      : {}),
+  };
+
+  return Object.keys(state).length > 0 ? state : null;
+};
+
+const mapChatModerationHandleState = (
+  value: unknown,
+): ChatModerationAuditBanHandleStateOutput | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const handleStatus = readOptionalHandleStatus(value, "handleStatus");
+  const revokedSessionCount = readOptionalNumber(value, "revokedSessionCount");
+  const state: ChatModerationAuditBanHandleStateOutput = {
+    ...(typeof handleStatus !== "undefined"
+      ? {
+          handleStatus,
+        }
+      : {}),
+    ...(typeof revokedSessionCount !== "undefined"
+      ? {
+          revokedSessionCount,
+        }
+      : {}),
+  };
+
+  return Object.keys(state).length > 0 ? state : null;
+};
+
+const mapChatModerationRoomPasswordState = (
+  value: unknown,
+): ChatModerationAuditRoomPasswordRotationStateOutput | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const passwordRotatedAt = readOptionalStringOrNull(value, "passwordRotatedAt");
+  const passwordVersion = readOptionalNumber(value, "passwordVersion");
+  const revokedSessionCount = readOptionalNumber(value, "revokedSessionCount");
+  const state: ChatModerationAuditRoomPasswordRotationStateOutput = {
+    ...(typeof passwordRotatedAt !== "undefined"
+      ? {
+          passwordRotatedAt,
+        }
+      : {}),
+    ...(typeof passwordVersion !== "undefined"
+      ? {
+          passwordVersion,
+        }
+      : {}),
+    ...(typeof revokedSessionCount !== "undefined"
+      ? {
+          revokedSessionCount,
+        }
+      : {}),
+  };
+
+  return Object.keys(state).length > 0 ? state : null;
+};
+
 const mapChatModerationAuditOutput = (input: Readonly<{
   action: "delete_message" | "hide_media_metadata" | "ban_handle" | "room_password_rotation";
   actorAdminUserId: string;
@@ -405,13 +563,11 @@ const mapChatModerationAuditOutput = (input: Readonly<{
   targetRoomPasswordRotationId: string | null;
   targetSessionId: string | null;
   targetUploadId: string | null;
-}>) => ({
-  action: input.action,
+}>): ChatModerationAuditOutput => {
+  const base = {
   actorAdminUserId: input.actorAdminUserId,
   createdAt: input.createdAt.toISOString(),
   id: input.id,
-  nextState: input.nextState,
-  previousState: input.previousState,
   reason: input.reason,
   roomId: input.roomId,
   targetBanId: input.targetBanId,
@@ -420,7 +576,33 @@ const mapChatModerationAuditOutput = (input: Readonly<{
   targetRoomPasswordRotationId: input.targetRoomPasswordRotationId,
   targetSessionId: input.targetSessionId,
   targetUploadId: input.targetUploadId,
-});
+  } as const;
+
+  if (input.action === "ban_handle") {
+    return {
+      ...base,
+      action: input.action,
+      nextState: mapChatModerationHandleState(input.nextState),
+      previousState: mapChatModerationHandleState(input.previousState),
+    };
+  }
+
+  if (input.action === "room_password_rotation") {
+    return {
+      ...base,
+      action: input.action,
+      nextState: mapChatModerationRoomPasswordState(input.nextState),
+      previousState: mapChatModerationRoomPasswordState(input.previousState),
+    };
+  }
+
+  return {
+    ...base,
+    action: input.action,
+    nextState: mapChatModerationVisibilityState(input.nextState),
+    previousState: mapChatModerationVisibilityState(input.previousState),
+  };
+};
 
 const resolveSessionExpiry = (joinedAt: Date, sessionMaxAgeSeconds: number): Date => {
   return new Date(joinedAt.getTime() + sessionMaxAgeSeconds * 1000);
@@ -835,8 +1017,19 @@ export const createGetChatRoomAccessUseCase = ({
 
 const createReadableRoomPassword = (): string => {
   const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789";
+  const maxByte = Math.floor(256 / alphabet.length) * alphabet.length;
+  const randomByte = new Uint8Array(1);
+  const nextCharacter = (): string => {
+    let sampled = 0;
+    do {
+      crypto.getRandomValues(randomByte);
+      sampled = randomByte[0]!;
+    } while (sampled >= maxByte);
+
+    return alphabet[sampled % alphabet.length]!;
+  };
   const segments = [4, 4, 4].map((segmentLength) =>
-    Array.from({ length: segmentLength }, () => alphabet[Math.floor(Math.random() * alphabet.length)]).join(""),
+    Array.from({ length: segmentLength }, () => nextCharacter()).join(""),
   );
 
   return segments.join("-");

--- a/backend/src/modules/chat/ports/inbound/index.ts
+++ b/backend/src/modules/chat/ports/inbound/index.ts
@@ -100,13 +100,30 @@ export type ListChatModerationAuditsInput = Readonly<{
   roomId?: string;
 }>;
 
-export type ChatModerationAuditOutput = Readonly<{
-  action: "delete_message" | "hide_media_metadata" | "ban_handle" | "room_password_rotation";
+export type ChatModerationAuditVisibilityStateOutput = Readonly<{
+  messageDeletedAt?: string | null;
+  messageHiddenAt?: string | null;
+  messageModerationState?: "visible" | "hidden" | "deleted" | null;
+  uploadDeletedAt?: string | null;
+  uploadHiddenAt?: string | null;
+  uploadModerationState?: "visible" | "hidden" | "deleted" | null;
+}>;
+
+export type ChatModerationAuditBanHandleStateOutput = Readonly<{
+  handleStatus?: "active" | "banned" | null;
+  revokedSessionCount?: number;
+}>;
+
+export type ChatModerationAuditRoomPasswordRotationStateOutput = Readonly<{
+  passwordRotatedAt?: string | null;
+  passwordVersion?: number;
+  revokedSessionCount?: number;
+}>;
+
+type BaseChatModerationAuditOutput = Readonly<{
   actorAdminUserId: string;
   createdAt: string;
   id: string;
-  nextState: unknown | null;
-  previousState: unknown | null;
   reason: string | null;
   roomId: string | null;
   targetBanId: string | null;
@@ -116,6 +133,23 @@ export type ChatModerationAuditOutput = Readonly<{
   targetSessionId: string | null;
   targetUploadId: string | null;
 }>;
+
+export type ChatModerationAuditOutput =
+  | (BaseChatModerationAuditOutput & Readonly<{
+      action: "delete_message" | "hide_media_metadata";
+      nextState: ChatModerationAuditVisibilityStateOutput | null;
+      previousState: ChatModerationAuditVisibilityStateOutput | null;
+    }>)
+  | (BaseChatModerationAuditOutput & Readonly<{
+      action: "ban_handle";
+      nextState: ChatModerationAuditBanHandleStateOutput | null;
+      previousState: ChatModerationAuditBanHandleStateOutput | null;
+    }>)
+  | (BaseChatModerationAuditOutput & Readonly<{
+      action: "room_password_rotation";
+      nextState: ChatModerationAuditRoomPasswordRotationStateOutput | null;
+      previousState: ChatModerationAuditRoomPasswordRotationStateOutput | null;
+    }>);
 
 export type ListChatModerationAuditsOutput = Readonly<{
   items: readonly ChatModerationAuditOutput[];

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -35,8 +35,8 @@
 ## Next Task Queue
 1. Complete reviewer validation for `QA-008` follow-up PR [#117](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/117).
 2. Complete reviewer validation for `CHAT-010` PR [#122](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/122).
-3. Execute `SEC-007` on `frontend/SEC-007-chat-session-storage-hardening` from `develop`.
-4. Queue remaining phase-2 security follow-up `SEC-008` after `SEC-007` enters review.
+3. Execute `SEC-008` on `backend/SEC-008-chat-crypto-and-audit-hardening` from `develop`.
+4. Queue phase-3 hardening follow-up `SEC-009` after `SEC-008` enters review.
 
 ## Current Executable Cluster
 ### Frontend Admin API Integration
@@ -107,7 +107,7 @@ Done criteria for `CHAT-010`:
 - upload validation remains aligned with MIME, size, and one-file-per-message rules
 
 ### Security Hardening Execution
-- Status: in progress; first-wave critical tasks are complete and phase 2 execution continues with `SEC-007` after `SEC-006` merged to `develop`.
+- Status: in progress; first-wave critical tasks are complete and phase 2 execution continues with `SEC-008` after `SEC-007` merged to `develop`.
 - Primary spec: `SPEC-031`.
 - Supporting specs: `frontend-structure.md`, `frontend-architecture.md`, `project-structure.md`, `backend-architecture.md`, `chat-room-live-integration.md`, `frontend-admin-auth-integration.md`, `media-storage.md`, `admin-cms.md`, `infra-deployment.md`, `verification.md`, and `git-workflow.md`.
 - Scope: execute the approved remediation wave from the 2026-05-03 security review with one task branch per finding cluster.
@@ -156,6 +156,13 @@ Done criteria for `CHAT-010`:
   - Local execution: migrate active room-session persistence from `localStorage` to `sessionStorage` and align frontend WebSocket handshake with the SEC-006 subprotocol contract.
   - Local verification: frontend lint/build plus static checks for no `localStorage` or WebSocket `sessionId` query usage passed on 2026-05-05.
   - PR/Open review: PR [#130](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/130) opened against `develop`.
+  - Completion: chat session-storage hardening landed via merged PR [#130](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/130).
+- SEC-008 status log:
+  - Start: branch `backend/SEC-008-chat-crypto-and-audit-hardening` moved to `In Progress` after PR [#130](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/130) merged to `develop`.
+  - Blocker: none.
+  - Local execution: replace `Math.random()` room-password generation with a CSPRNG, replace raw SHA-256 readable-password key derivation with HKDF (with legacy decrypt compatibility), and map moderation audit API states through explicit typed/redacted DTOs.
+  - Local verification: chat use-case, admin-route, and Prisma repository tests plus backend typecheck and boundary verification passed on 2026-05-05.
+  - PR/Open review: not opened yet (coordinator publish/review flow pending).
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -166,8 +173,8 @@ Done criteria for `CHAT-010`:
 | Done | SEC-004 | SPEC-031 | backend | develop | `backend/SEC-004-chat-request-validation-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#127](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/127) merged | — |
 | Done | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#128](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/128) merged | — |
 | Done | SEC-006 | SPEC-031 | backend | develop | `backend/SEC-006-websocket-auth-transport-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#129](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/129) merged | — |
-| In Review | SEC-007 | SPEC-031 | frontend | develop | `frontend/SEC-007-chat-session-storage-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#130](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/130) | — |
-| Blocked | SEC-008 | SPEC-031 | backend | develop | `backend/SEC-008-chat-crypto-and-audit-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Phase 2 sequencing: queued after first-wave critical tasks (`SEC-001` to `SEC-003`). |
+| Done | SEC-007 | SPEC-031 | frontend | develop | `frontend/SEC-007-chat-session-storage-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#130](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/130) merged | — |
+| In Progress | SEC-008 | SPEC-031 | backend | develop | `backend/SEC-008-chat-crypto-and-audit-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
 | Blocked | SEC-009 | SPEC-031 | infra | develop | `infra/SEC-009-edge-headers-and-production-compose` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-001` and is reserved for Phase 3 hardening. |
 
 Done criteria for `SPEC-031`:

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -162,7 +162,7 @@ Done criteria for `CHAT-010`:
   - Blocker: none.
   - Local execution: replace `Math.random()` room-password generation with a CSPRNG, replace raw SHA-256 readable-password key derivation with HKDF (with legacy decrypt compatibility), and map moderation audit API states through explicit typed/redacted DTOs.
   - Local verification: chat use-case, admin-route, and Prisma repository tests plus backend typecheck and boundary verification passed on 2026-05-05.
-  - PR/Open review: not opened yet (coordinator publish/review flow pending).
+  - PR/Open review: PR [#131](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/131) opened against `develop`.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -174,7 +174,7 @@ Done criteria for `CHAT-010`:
 | Done | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#128](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/128) merged | — |
 | Done | SEC-006 | SPEC-031 | backend | develop | `backend/SEC-006-websocket-auth-transport-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#129](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/129) merged | — |
 | Done | SEC-007 | SPEC-031 | frontend | develop | `frontend/SEC-007-chat-session-storage-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#130](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/130) merged | — |
-| In Progress | SEC-008 | SPEC-031 | backend | develop | `backend/SEC-008-chat-crypto-and-audit-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
+| In Review | SEC-008 | SPEC-031 | backend | develop | `backend/SEC-008-chat-crypto-and-audit-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#131](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/131) | — |
 | Blocked | SEC-009 | SPEC-031 | infra | develop | `infra/SEC-009-edge-headers-and-production-compose` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-001` and is reserved for Phase 3 hardening. |
 
 Done criteria for `SPEC-031`:


### PR DESCRIPTION
## Summary
- Task ID: SEC-008
- Source tracker entry: `docs/specs/tracker.md` > Security Hardening Execution
- Source spec: `docs/specs/security-hardening-production-readiness.md`

Hardens chat room crypto and moderation audit output by replacing room-password `Math.random()` generation with CSPRNG sampling, switching readable room-password encryption key derivation to HKDF with legacy decrypt compatibility, and narrowing moderation audit state into explicit typed/redacted DTOs.

## Branching
- Base branch: `develop`
- Merge target: `develop`

## Acceptance
- Acceptance source: `docs/specs/security-hardening-production-readiness.md`
- Verification performed:
  - `cd backend && bun test src/modules/chat src/adapters/inbound/http/hono/admin-routes.test.ts src/adapters/outbound/persistence/prisma/chat-repository.test.ts` (`72 pass, 0 fail`)
  - `cd backend && bun run typecheck` (passed)
  - `cd backend && bun run verify:boundary` (passed)
- Required CI status checks: PR validation for `develop`

## Notes
- Deployment impact: new readable room password ciphertexts are versioned `v2`; existing legacy ciphertexts remain decryptable.
- Revert impact: revert SEC-008 commits to restore previous room password generation/key derivation and audit output mapping.
- Follow-up tasks: SEC-009 handles edge headers and production compose hardening.
