### PR TITLE
SEC-009 Edge headers and production compose hardening

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.codex
+
+**/node_modules
+**/dist
+backend/generated
+
+.env
+.env.*
+!.env.example
+!.env.dev.example
+!.env.prod.example

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM oven/bun:1.3.11-alpine
+
+WORKDIR /app/backend
+
+COPY backend/package.json backend/bun.lock backend/prisma.config.ts ./
+COPY backend/prisma ./prisma
+RUN bun install --frozen-lockfile
+RUN bun run prisma:generate
+
+COPY backend/src ./src
+
+CMD ["bun", "run", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,10 +18,11 @@ services:
       - app_net
 
   backend:
-    image: oven/bun:1.3.11-alpine
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    image: vinicius-dev-backend:local
     restart: unless-stopped
-    working_dir: /app/backend
-    command: sh -c "bun run start"
     environment:
       NODE_ENV: ${BACKEND_NODE_ENV:-production}
       PORT: ${BACKEND_PORT:-3000}
@@ -45,10 +46,11 @@ services:
       - app_net
 
   frontend:
-    image: oven/bun:1.3.11-alpine
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    image: vinicius-dev-frontend:local
     restart: unless-stopped
-    working_dir: /app/frontend
-    command: sh -c "bun run dev --host 0.0.0.0 --port ${FRONTEND_PORT:-5173}"
     depends_on:
       backend:
         condition: service_started

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -35,8 +35,8 @@
 ## Next Task Queue
 1. Complete reviewer validation for `QA-008` follow-up PR [#117](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/117).
 2. Complete reviewer validation for `CHAT-010` PR [#122](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/122).
-3. Execute `SEC-008` on `backend/SEC-008-chat-crypto-and-audit-hardening` from `develop`.
-4. Queue phase-3 hardening follow-up `SEC-009` after `SEC-008` enters review.
+3. Execute `SEC-009` on `infra/SEC-009-edge-headers-and-production-compose` from `develop`.
+4. Queue review handoff for `SEC-009` once Caddy/compose hardening verification is complete.
 
 ## Current Executable Cluster
 ### Frontend Admin API Integration
@@ -107,7 +107,7 @@ Done criteria for `CHAT-010`:
 - upload validation remains aligned with MIME, size, and one-file-per-message rules
 
 ### Security Hardening Execution
-- Status: in progress; first-wave critical tasks are complete and phase 2 execution continues with `SEC-008` after `SEC-007` merged to `develop`.
+- Status: in progress; first-wave and phase 2 tasks are complete, and phase 3 execution is active on `SEC-009`.
 - Primary spec: `SPEC-031`.
 - Supporting specs: `frontend-structure.md`, `frontend-architecture.md`, `project-structure.md`, `backend-architecture.md`, `chat-room-live-integration.md`, `frontend-admin-auth-integration.md`, `media-storage.md`, `admin-cms.md`, `infra-deployment.md`, `verification.md`, and `git-workflow.md`.
 - Scope: execute the approved remediation wave from the 2026-05-03 security review with one task branch per finding cluster.
@@ -163,6 +163,12 @@ Done criteria for `CHAT-010`:
   - Local execution: replace `Math.random()` room-password generation with a CSPRNG, replace raw SHA-256 readable-password key derivation with HKDF (with legacy decrypt compatibility), and map moderation audit API states through explicit typed/redacted DTOs.
   - Local verification: chat use-case, admin-route, and Prisma repository tests plus backend typecheck and boundary verification passed on 2026-05-05.
   - PR/Open review: PR [#131](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/131) opened against `develop`.
+  - Completion: chat crypto and moderation-audit hardening landed via merged PR [#131](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/131).
+- SEC-009 status log:
+  - Start: branch `infra/SEC-009-edge-headers-and-production-compose` moved to `In Progress` after PR [#131](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/131) merged to `develop`.
+  - Blocker: none.
+  - Local execution: add the Caddy edge security-header baseline, move production compose frontend/backend to Dockerfile builds with frozen-lock installs, and serve frontend runtime from built `dist` artifacts.
+  - Local verification: production/dev compose config rendering (`--env-file`), Caddy config validation, frontend build/lint + static-route fallback smoke checks (`/`, `/admin`, `/chat`), and `backend` verify/deploy-readiness checks passed on 2026-05-05.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -174,8 +180,8 @@ Done criteria for `CHAT-010`:
 | Done | SEC-005 | SPEC-031 | backend | develop | `backend/SEC-005-upload-media-signature-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#128](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/128) merged | — |
 | Done | SEC-006 | SPEC-031 | backend | develop | `backend/SEC-006-websocket-auth-transport-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#129](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/129) merged | — |
 | Done | SEC-007 | SPEC-031 | frontend | develop | `frontend/SEC-007-chat-session-storage-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#130](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/130) merged | — |
-| In Review | SEC-008 | SPEC-031 | backend | develop | `backend/SEC-008-chat-crypto-and-audit-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#131](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/131) | — |
-| Blocked | SEC-009 | SPEC-031 | infra | develop | `infra/SEC-009-edge-headers-and-production-compose` | develop | `docs/specs/security-hardening-production-readiness.md` | — | Depends on `SEC-001` and is reserved for Phase 3 hardening. |
+| Done | SEC-008 | SPEC-031 | backend | develop | `backend/SEC-008-chat-crypto-and-audit-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#131](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/131) merged | — |
+| In Progress | SEC-009 | SPEC-031 | infra | develop | `infra/SEC-009-edge-headers-and-production-compose` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
 
 Done criteria for `SPEC-031`:
 - `docs/specs/security-hardening-production-readiness.md` exists and follows the harness section template

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -169,6 +169,7 @@ Done criteria for `CHAT-010`:
   - Blocker: none.
   - Local execution: add the Caddy edge security-header baseline, move production compose frontend/backend to Dockerfile builds with frozen-lock installs, and serve frontend runtime from built `dist` artifacts.
   - Local verification: production/dev compose config rendering (`--env-file`), Caddy config validation, frontend build/lint + static-route fallback smoke checks (`/`, `/admin`, `/chat`), and `backend` verify/deploy-readiness checks passed on 2026-05-05.
+  - PR/Open review: PR [#132](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/132) opened against `develop`.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -181,7 +182,7 @@ Done criteria for `CHAT-010`:
 | Done | SEC-006 | SPEC-031 | backend | develop | `backend/SEC-006-websocket-auth-transport-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#129](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/129) merged | — |
 | Done | SEC-007 | SPEC-031 | frontend | develop | `frontend/SEC-007-chat-session-storage-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#130](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/130) merged | — |
 | Done | SEC-008 | SPEC-031 | backend | develop | `backend/SEC-008-chat-crypto-and-audit-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#131](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/131) merged | — |
-| In Progress | SEC-009 | SPEC-031 | infra | develop | `infra/SEC-009-edge-headers-and-production-compose` | develop | `docs/specs/security-hardening-production-readiness.md` | — | — |
+| In Review | SEC-009 | SPEC-031 | infra | develop | `infra/SEC-009-edge-headers-and-production-compose` | develop | `docs/specs/security-hardening-production-readiness.md` | [#132](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/132) | — |
 
 Done criteria for `SPEC-031`:
 - `docs/specs/security-hardening-production-readiness.md` exists and follows the harness section template

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM oven/bun:1.3.11-alpine
+
+WORKDIR /app/frontend
+
+COPY frontend/package.json frontend/bun.lock ./
+RUN bun install --frozen-lockfile
+
+COPY frontend/. .
+RUN bun run build
+
+CMD ["bun", "scripts/serve-dist.ts"]

--- a/frontend/scripts/serve-dist.ts
+++ b/frontend/scripts/serve-dist.ts
@@ -1,0 +1,55 @@
+import path from "node:path";
+import { stat } from "node:fs/promises";
+
+const DIST_ROOT = path.resolve(import.meta.dir, "..", "dist");
+const DIST_ROOT_PREFIX = `${DIST_ROOT}${path.sep}`;
+const INDEX_FILE = Bun.file(path.join(DIST_ROOT, "index.html"));
+const PORT = Number.parseInt(process.env.FRONTEND_PORT ?? "5173", 10);
+
+function resolvePathFromRequest(pathname: string): string | null {
+  let decodedPath = pathname;
+  try {
+    decodedPath = decodeURIComponent(pathname);
+  } catch {
+    return null;
+  }
+
+  const normalizedPath = path.normalize(`.${decodedPath}`);
+  const resolvedPath = path.resolve(DIST_ROOT, normalizedPath);
+
+  if (resolvedPath !== DIST_ROOT && !resolvedPath.startsWith(DIST_ROOT_PREFIX)) {
+    return null;
+  }
+
+  return resolvedPath;
+}
+
+async function isFile(filePath: string): Promise<boolean> {
+  try {
+    return (await stat(filePath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+Bun.serve({
+  hostname: "0.0.0.0",
+  port: Number.isFinite(PORT) ? PORT : 5173,
+  async fetch(request) {
+    const requestUrl = new URL(request.url);
+    const resolvedPath = resolvePathFromRequest(requestUrl.pathname);
+
+    if (resolvedPath) {
+      const nestedIndexPath = path.join(resolvedPath, "index.html");
+      if (await isFile(nestedIndexPath)) {
+        return new Response(Bun.file(nestedIndexPath));
+      }
+
+      if (await isFile(resolvedPath)) {
+        return new Response(Bun.file(resolvedPath));
+      }
+    }
+
+    return new Response(INDEX_FILE);
+  },
+});

--- a/infra/README.md
+++ b/infra/README.md
@@ -11,6 +11,11 @@
 - Base: `docker-compose.yml` (shared and production-safe defaults).
 - Development override: `docker-compose.dev.yml` (source bind mounts and install-on-start workflow).
 
+## Production runtime baseline
+
+- Backend image is built from `backend/Dockerfile` with `bun install --frozen-lockfile` and Prisma client generation during image build.
+- Frontend image is built from `frontend/Dockerfile`, runs `bun run build` during image build, and serves the built `dist/` artifact at runtime.
+
 ## Env templates
 
 - Development template: `.env.dev.example`

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,4 +1,13 @@
 development.viniciuslab.dev, viniciuslab.dev, :80 {
+	header {
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "SAMEORIGIN"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), microphone=(), payment=(), usb=()"
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		Content-Security-Policy "default-src 'self'; base-uri 'self'; frame-ancestors 'self'; object-src 'none'; form-action 'self'; connect-src 'self' wss:; img-src 'self' blob: data:; style-src 'self' 'unsafe-inline'; script-src 'self'"
+	}
+
 	handle /api/* {
 		reverse_proxy backend:3000
 	}


### PR DESCRIPTION
## Summary
- Task ID: SEC-009
- Source tracker entry: `docs/specs/tracker.md` > Security Hardening Execution
- Source spec: `docs/specs/security-hardening-production-readiness.md`

Adds the Caddy edge security-header baseline and replaces production ad-hoc Bun/Vite runtime commands with Dockerfile-built backend/frontend images. The frontend now serves the built `dist/` artifact through a small Bun static server with React Router fallback.

## Branching
- Base branch: `develop`
- Merge target: `develop`

## Acceptance
- Acceptance source: `docs/specs/security-hardening-production-readiness.md`
- Verification performed:
  - `docker compose --env-file .env.prod.example -f docker-compose.yml config` (passed)
  - `docker compose --env-file .env.dev.example -f docker-compose.yml -f docker-compose.dev.yml config` (passed)
  - `docker run ... caddy validate --config /etc/caddy/Caddyfile` (passed)
  - `cd frontend && bun install --frozen-lockfile && bun run build` (passed)
  - `cd frontend && bun run lint` (passed)
  - `cd backend && bun install --frozen-lockfile && bun run prisma:generate && bun run typecheck` (passed)
  - `cd backend && bun run verify` (passed)
  - Frontend static serving smoke for `/`, `/admin`, `/chat`, and built asset path (passed)
- Required CI status checks: PR validation for `develop`

## Notes
- Deployment impact: production compose now builds backend/frontend images from Dockerfiles and no longer runs Vite dev in production.
- Revert impact: revert SEC-009 commits to restore previous compose/Caddy production runtime behavior.
- Follow-up tasks: none for SPEC-031 first remediation wave.
- Lockfile/reproducibility: tracked `backend/bun.lock` and `frontend/bun.lock` already address the missing-lockfile part of the review; Dockerfiles now use `bun install --frozen-lockfile` and `.dockerignore` excludes local generated artifacts/dependencies from build context.
- Local Docker image build note: `docker build` was attempted locally but stalled while fetching Docker metadata from Docker Desktop, before repo build layers; it was canceled. Compose render, Caddy validation, package install/build, backend verify, and static serving smoke passed.
