### PR TITLE
SEC-009 Fix development CSP for Vite runtime

### DIFF
--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -169,6 +169,9 @@ Done criteria for `CHAT-010`:
   - Local verification: production/dev compose config rendering (`--env-file`), Caddy config validation, frontend build/lint + static-route fallback smoke checks (`/`, `/admin`, `/chat`), and `backend` verify/deploy-readiness checks passed on 2026-05-05.
   - PR/Open review: PR [#132](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/132) opened against `develop`.
   - Completion: edge security headers and production compose/runtime hardening landed via merged PR [#132](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/132).
+  - Follow-up start: branch `infra/SEC-009-development-csp-vite-fix` opened to fix the development host CSP regression where Vite's React-refresh preamble was blocked.
+  - Follow-up local verification: production/dev compose config rendering and Caddy config validation passed on 2026-05-05.
+  - Follow-up PR/Open review: PR [#134](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/134) opened against `develop`.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,13 +1,26 @@
-development.viniciuslab.dev, viniciuslab.dev, :80 {
+(common_security_headers) {
 	header {
 		X-Content-Type-Options "nosniff"
 		X-Frame-Options "SAMEORIGIN"
 		Referrer-Policy "strict-origin-when-cross-origin"
 		Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), microphone=(), payment=(), usb=()"
 		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+	}
+}
+
+(production_csp) {
+	header {
 		Content-Security-Policy "default-src 'self'; base-uri 'self'; frame-ancestors 'self'; object-src 'none'; form-action 'self'; connect-src 'self' wss:; img-src 'self' blob: data:; style-src 'self' 'unsafe-inline'; script-src 'self'"
 	}
+}
 
+(development_csp) {
+	header {
+		Content-Security-Policy "default-src 'self'; base-uri 'self'; frame-ancestors 'self'; object-src 'none'; form-action 'self'; connect-src 'self' ws: wss:; img-src 'self' blob: data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'"
+	}
+}
+
+(app_routes) {
 	handle /api/* {
 		reverse_proxy backend:3000
 	}
@@ -24,4 +37,16 @@ development.viniciuslab.dev, viniciuslab.dev, :80 {
 	handle {
 		reverse_proxy frontend:5173
 	}
+}
+
+development.viniciuslab.dev, :80 {
+	import common_security_headers
+	import development_csp
+	import app_routes
+}
+
+viniciuslab.dev {
+	import common_security_headers
+	import production_csp
+	import app_routes
 }


### PR DESCRIPTION
## Summary
- Task ID: SEC-009
- Source tracker entry: docs/specs/tracker.md, SEC-009 follow-up status log
- Source spec: docs/specs/security-hardening-production-readiness.md

## Branching
- Base branch: develop
- Merge target: develop

## Acceptance
- Acceptance source: docs/specs/security-hardening-production-readiness.md
- Verification performed: production compose config render, development compose config render, Caddy config validation, Caddy adapted-config inspection for host-specific CSP
- Required CI status checks: repository defaults

## Notes
- Deployment impact: fixes development.viniciuslab.dev when it serves the Vite dev runtime through Caddy
- Revert impact: development host would again block Vite React-refresh inline preamble under CSP
- Follow-up tasks: manually redeploy development after merge and clear browser cache if the old CSP is cached

## Root Cause
The SEC-009 Caddy CSP used one strict policy for both production and development. The development compose override serves Vite, and Vite React-refresh requires its inline preamble to run. Production can keep `script-src 'self'`, but the development host needs a dev-only CSP with `unsafe-inline` and `ws:` support.
