### PR TITLE
SPEC-033 Photo Catalog And Admin Upload spec

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -71,6 +71,7 @@ No backend-facing spec may move to `Tasked` until [project-structure.md](/Users/
 - [ci-cd.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/ci-cd.md)
 - [ci-workflow-maintenance.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/ci-workflow-maintenance.md)
 - [testing-coverage-foundation.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/testing-coverage-foundation.md)
+- [photo-catalog-gallery.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/photo-catalog-gallery.md)
 - [verification.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/verification.md)
 
 ## Task Authoring Rules

--- a/docs/specs/photo-catalog-gallery.md
+++ b/docs/specs/photo-catalog-gallery.md
@@ -1,0 +1,89 @@
+# Photo Catalog And Admin Upload
+
+## Purpose
+Define the v1 photo catalog implementation across public gallery browsing, admin original uploads, photo metadata, and public original delivery.
+
+## Scope
+This spec covers admin photo original upload, draft-first photo creation, metadata editing, publish/feature controls, public gallery API integration, public pagination/filtering, and real uploaded image rendering.
+
+This spec does not cover thumbnail generation, EXIF extraction, CDN/object storage, bulk upload, drag sorting, analytics, or a dedicated public photo detail route.
+
+## Locked Decisions
+- Admin photo uploads accept `image/jpeg`, `image/png`, and `image/webp`.
+- Admin photo originals are limited to `25 MB`.
+- Uploaded photos are created as `draft` and `featured=false`.
+- Public photo cards and lightbox render real original media URLs with lazy loading.
+- Public photo originals remain originals-only in v1 and use `/media/photos/:id/original`.
+- Public gallery filtering is server-side for year, location, and search.
+- Public gallery pagination is page/page-size based.
+- Public gallery filter options come from backend-provided photo facets, not from one visible page of results.
+- Admin upload writes originals to `MEDIA_PHOTOS_ROOT` through the media storage outbound port.
+- Filesystem paths are relative storage keys, sanitized, and safe under the configured root.
+
+## Interfaces And Responsibilities
+- Backend admin HTTP exposes `POST /api/admin/photos` as a private multipart endpoint.
+- Required upload fields are `file`, `title`, `frame`, `date`, `location`, and `tone`.
+- Optional upload fields are `tags`, `caption`, `camera`, and `film`.
+- Backend validates MIME type, file signature, byte size, required metadata, and valid ISO-like date input before creating a durable photo record.
+- Backend creates the photo id before storage so the original key can be deterministic, such as `YYYY/MM/<photo-id>.<ext>`.
+- Backend cleans up a written original if database creation fails.
+- Prisma stores nullable original display filename, MIME type, and byte size metadata so existing rows remain valid.
+- Public `/api/photos` returns `items`, `pageInfo`, and `facets: { years, locations }`.
+- Admin `/admin/photos` loads the private photo list, supports upload, and uses existing metadata and curation endpoints for edits, publish/unpublish, and feature/unfeature.
+- Frontend public `/photos` stores filters and page in URL query params and reloads through React Router Data Mode.
+
+## Data/Contracts Touched
+- `Photo` Prisma metadata fields
+- admin photo create inbound and outbound ports
+- media photo storage outbound port
+- admin photo multipart request contract
+- public photo list DTO and facets
+- frontend photo entity DTOs and mappers
+- `/admin/photos` route, loader, action, and UI state
+- `/photos` route loader, filter params, pagination, cards, and lightbox
+
+## Acceptance Checklist
+- [ ] `Photo` supports nullable original filename, MIME type, and byte-size metadata without breaking existing rows.
+- [ ] Admin upload creates a draft, unfeatured photo with required metadata and a stored original reference.
+- [ ] Admin upload rejects missing file, missing required metadata, unsupported MIME, MIME signature mismatch, invalid date, and files larger than `25 MB`.
+- [ ] Admin upload deletes a written file if persistence fails.
+- [ ] Public `/api/photos` returns paginated published photos plus stable year and location facets.
+- [ ] Public `/photos` uses backend data, URL-backed filters, page pagination, and real image URLs.
+- [ ] Public photo images lazy-load and fall back to the existing film-frame styling on image failure.
+- [ ] Admin `/admin/photos` is session-protected and available from admin navigation.
+- [ ] Admin `/admin/photos` supports upload, paginated listing, metadata edits, publish/unpublish, and feature/unfeature.
+- [ ] Published originals are served from `/media/photos/:id/original`; unpublished originals remain denied.
+- [ ] Backend tests cover use case, repository, filesystem storage, admin route validation, public facets, and media delivery regressions.
+- [ ] Frontend tests cover photo API mapping, public gallery loader/UI behavior, admin route/action behavior, and admin photo UI states.
+- [ ] Frontend lint/build and backend typecheck/boundary/media verification pass.
+
+## Dependencies
+- [product-scope.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/product-scope.md)
+- [frontend-structure.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-structure.md)
+- [frontend-architecture.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-architecture.md)
+- [project-structure.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/project-structure.md)
+- [backend-architecture.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/backend-architecture.md)
+- [data-model.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/data-model.md)
+- [media-storage.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/media-storage.md)
+- [admin-cms.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/admin-cms.md)
+- [verification.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/verification.md)
+- [git-workflow.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/git-workflow.md)
+- [acceptance-criteria.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/acceptance-criteria.md)
+
+## Open Questions
+- Whether a later version should generate thumbnails or extract EXIF metadata remains outside v1.
+- Whether a public photo detail route is needed can be decided after the gallery is live.
+
+## Task-Splitting Notes
+- Split schema/storage/API work before frontend public and admin UI tasks.
+- Keep public gallery integration separate from admin management UI.
+- Keep upload behavior limited to public photo originals; do not mix chat upload behavior into this cluster.
+- Use backend route and repository tests as the acceptance source for upload safety.
+
+## Git Branch Implications
+- Spec work uses `spec/SPEC-033-photo-catalog-gallery`.
+- Schema work uses `data/PHOTO-001-photo-original-metadata`.
+- Backend upload API work uses `backend/PHOTO-002-admin-photo-upload-api`.
+- Public gallery work uses `frontend/PHOTO-003-public-photo-gallery-api`.
+- Admin UI work uses `admin/PHOTO-004-admin-photo-management-screen`.
+- All branches base from `develop`, merge to `develop`, include task IDs in commits and PR titles, and require review.

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -37,6 +37,7 @@
 1. Complete reviewer validation for `QA-008` follow-up PR [#117](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/117).
 2. Complete reviewer validation for `CHAT-010` PR [#122](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/122).
 3. Execute `SPEC-032` testing coverage foundation tasks `QA-009` through `QA-013`.
+4. Execute `SPEC-033` photo catalog and admin upload tasks `PHOTO-001` through `PHOTO-004`.
 
 ## Current Executable Cluster
 ### Frontend Admin API Integration
@@ -239,6 +240,48 @@ Done criteria for `QA-013`:
 - coverage commands are available but report-only
 - CI YAML stays concise and does not add E2E or deployment changes
 
+### Photo Catalog And Admin Upload
+- Status: tasked locally; implementation branches are being split for separate review.
+- Primary spec: `SPEC-033`.
+- Supporting specs: `product-scope.md`, `frontend-structure.md`, `frontend-architecture.md`, `project-structure.md`, `backend-architecture.md`, `data-model.md`, `media-storage.md`, `admin-cms.md`, `verification.md`, `git-workflow.md`, and `acceptance-criteria.md`.
+- Scope: draft-first admin original uploads, photo original metadata, public photo list facets, public real-image gallery integration, and admin photo management UI.
+- Non-scope: thumbnail generation, EXIF extraction, CDN/object storage, bulk upload, drag sorting, analytics, and a dedicated public photo detail route.
+
+| Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| In Progress | SPEC-033 | SPEC-033 | spec | develop | `spec/SPEC-033-photo-catalog-gallery` | develop | `docs/specs/photo-catalog-gallery.md` | not opened | — |
+| In Progress | PHOTO-001 | SPEC-033 | data | develop | `data/PHOTO-001-photo-original-metadata` | develop | `docs/specs/photo-catalog-gallery.md` | not opened | — |
+| In Progress | PHOTO-002 | SPEC-033 | backend | develop | `backend/PHOTO-002-admin-photo-upload-api` | develop | `docs/specs/photo-catalog-gallery.md` | not opened | — |
+| In Progress | PHOTO-003 | SPEC-033 | frontend | develop | `frontend/PHOTO-003-public-photo-gallery-api` | develop | `docs/specs/photo-catalog-gallery.md` | not opened | — |
+| In Progress | PHOTO-004 | SPEC-033 | admin | develop | `admin/PHOTO-004-admin-photo-management-screen` | develop | `docs/specs/photo-catalog-gallery.md` | not opened | — |
+
+Done criteria for `SPEC-033`:
+- `docs/specs/photo-catalog-gallery.md` exists and follows the harness section template.
+- task IDs, branch names, dependencies, acceptance source, and verification methods are defined.
+- `docs/specs/tracker.md` and `docs/specs/README.md` register the spec and implementation queue.
+
+Done criteria for `PHOTO-001`:
+- `Photo` has nullable original display filename, MIME type, and byte-size metadata.
+- existing photo rows and public media delivery remain compatible.
+- Prisma schema, migration, generated client, and repository tests cover metadata mapping.
+
+Done criteria for `PHOTO-002`:
+- `POST /api/admin/photos` creates draft, unfeatured photo records with stored originals.
+- upload validation covers required fields, MIME type, magic bytes, date parsing, max `25 MB`, and safe storage paths.
+- written originals are cleaned up when persistence fails.
+- backend route, use-case, repository, storage, typecheck, boundary, and media verification pass.
+
+Done criteria for `PHOTO-003`:
+- public `/photos` loads from `/api/photos` via React Router loader.
+- URL-backed filters and page pagination drive server-side queries.
+- cards and lightbox render real original URLs with lazy loading and film-frame fallback.
+- frontend tests, lint, and build pass.
+
+Done criteria for `PHOTO-004`:
+- `/admin/photos` is session-protected and linked from admin navigation.
+- admin can upload a draft photo, inspect paginated records, edit metadata, publish/unpublish, and feature/unfeature.
+- admin route/action/component tests, frontend lint, and frontend build pass.
+
 ## Spec Table
 | Spec ID | Title | Layer | Status | Depends on | Blocks | Git workflow defined | Ready for task split | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -247,6 +290,7 @@ Done criteria for `QA-013`:
 | SPEC-030 | Chat Room Live Integration | Cross-layer | Tasked | `frontend-structure.md`, `frontend-architecture.md`, `frontend-admin-auth-integration.md`, `project-structure.md`, `backend-architecture.md`, `data-model.md`, `media-storage.md`, `admin-cms.md`, `verification.md`, `git-workflow.md`, `acceptance-criteria.md` | `CHAT-008`, `CHAT-009`, `CHAT-010` | yes | yes | Replaces the mock chat room with backend join/session contracts, realtime delivery, and protected upload/viewer behavior while adding backend-generated room password management to the admin dashboard. |
 | SPEC-031 | Security Hardening and Production Readiness | Cross-layer | Tasked | `frontend-structure.md`, `frontend-architecture.md`, `project-structure.md`, `backend-architecture.md`, `chat-room-live-integration.md`, `frontend-admin-auth-integration.md`, `media-storage.md`, `admin-cms.md`, `infra-deployment.md`, `verification.md`, `git-workflow.md`, `acceptance-criteria.md` | `SEC-001`, `SEC-002`, `SEC-003`, `SEC-004`, `SEC-005`, `SEC-006`, `SEC-007`, `SEC-008`, `SEC-009` | yes | yes | Approved remediation spec from the 2026-05-03 security/bug review; implementation queue is registered with first-wave critical tasks unblocked first. |
 | SPEC-032 | Testing Coverage Foundation | Cross-layer | Tasked | `verification.md`, `ci-cd.md`, `project-structure.md`, `backend-architecture.md`, `frontend-structure.md`, `frontend-architecture.md`, `git-workflow.md`, `acceptance-criteria.md` | `QA-009`, `QA-010`, `QA-011`, `QA-012`, `QA-013` | yes | yes | Adds the first cross-layer coverage baseline: backend coverage improvements, frontend Vitest coverage, focused Prisma/Postgres CI contracts, and report-only coverage commands. |
+| SPEC-033 | Photo Catalog And Admin Upload | Cross-layer | Tasked | `product-scope.md`, `frontend-structure.md`, `frontend-architecture.md`, `project-structure.md`, `backend-architecture.md`, `data-model.md`, `media-storage.md`, `admin-cms.md`, `verification.md`, `git-workflow.md`, `acceptance-criteria.md` | `PHOTO-001`, `PHOTO-002`, `PHOTO-003`, `PHOTO-004` | yes | yes | Adds draft-first admin photo original uploads, public gallery API integration with real images and facets, and admin photo management. |
 
 ## Tasking Rule
 A spec may only move to `Tasked` when:


### PR DESCRIPTION
## Summary

Adds the approved cross-layer spec for the Photo Catalog And Admin Upload cluster and registers the task split in the repo spec harness.

## Source spec and acceptance

- Source spec: `docs/specs/photo-catalog-gallery.md`
- Base branch: `develop`
- Merge target: `develop`
- Branch: `spec/SPEC-033-photo-catalog-gallery`
- Task ID: `SPEC-033`

## Changes

- Adds `docs/specs/photo-catalog-gallery.md` with v1 scope, locked decisions, contracts, acceptance criteria, dependencies, and branch implications.
- Registers the spec in `docs/specs/README.md`.
- Adds the `SPEC-033` executable cluster and `PHOTO-001` through `PHOTO-004` task split to `docs/specs/tracker.md`.

## Impact

This gives implementation agents a canonical acceptance source for the photo catalog work and keeps the branch/task model aligned with `docs/specs/git-workflow.md`.

## Verification

- `git diff --check` passed in the task worktree.
- No runtime tests required for spec-only changes.

## Notes

This PR is intended to merge first. Implementation PRs depend on this tracker/spec registration.