### PR TITLE
PHOTO-001 Add photo original metadata

### DIFF
--- a/backend/prisma/migrations/20260506000100_photo-original-metadata/migration.sql
+++ b/backend/prisma/migrations/20260506000100_photo-original-metadata/migration.sql
@@ -1,0 +1,5 @@
+-- PHOTO-001: store nullable original upload metadata for admin-managed photo records.
+ALTER TABLE "Photo"
+ADD COLUMN "originalDisplayFilename" TEXT,
+ADD COLUMN "originalMimeType" TEXT,
+ADD COLUMN "originalByteSize" INTEGER;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -414,6 +414,9 @@ model Photo {
   camera                  String?
   film                    String?
   originalPath            String
+  originalDisplayFilename String?
+  originalMimeType        String?
+  originalByteSize        Int?
   originalReferencePolicy PhotoOriginalReferencePolicy @default(backend_media_route)
   status                  PhotoStatus                  @default(draft)
   featured                Boolean                      @default(false)

--- a/backend/src/adapters/outbound/persistence/prisma/media-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/media-repository.test.ts
@@ -13,6 +13,9 @@ describe("prisma media repository", () => {
         findFirst: async () => ({
           createdAt: new Date("2026-03-22T00:00:00.000Z"),
           id: "p-2026-014",
+          originalByteSize: 482113,
+          originalDisplayFilename: "paulista-0214.webp",
+          originalMimeType: "image/webp",
           originalPath: "published/p-2026-014.jpg",
           originalReferencePolicy: "filesystem_reference" as const,
           title: "paulista at 02:14",
@@ -26,6 +29,9 @@ describe("prisma media repository", () => {
     expect(photo).toEqual({
       createdAt: new Date("2026-03-22T00:00:00.000Z"),
       id: "p-2026-014",
+      originalByteSize: 482113,
+      originalDisplayFilename: "paulista-0214.webp",
+      originalMimeType: "image/webp",
       originalReference: "published/p-2026-014.jpg",
       originalReferencePolicy: "filesystem_reference",
       title: "paulista at 02:14",

--- a/backend/src/adapters/outbound/persistence/prisma/media-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/media-repository.ts
@@ -13,6 +13,9 @@ import type { PrismaDatabaseClient } from "./prisma-client";
 const mapPhotoMediaRow = (row: {
   createdAt: Date;
   id: string;
+  originalByteSize: number | null;
+  originalDisplayFilename: string | null;
+  originalMimeType: string | null;
   originalPath: string;
   originalReferencePolicy: PhotoOriginalReferencePolicy;
   title: string;
@@ -20,6 +23,9 @@ const mapPhotoMediaRow = (row: {
 }): PhotoMediaRepositoryRow => ({
   createdAt: row.createdAt,
   id: row.id,
+  originalByteSize: row.originalByteSize,
+  originalDisplayFilename: row.originalDisplayFilename,
+  originalMimeType: row.originalMimeType,
   originalReference: row.originalPath,
   originalReferencePolicy: row.originalReferencePolicy,
   title: row.title,
@@ -61,6 +67,9 @@ export const createPrismaMediaRepository = (client: PrismaDatabaseClient): Media
       select: {
         createdAt: true,
         id: true,
+        originalByteSize: true,
+        originalDisplayFilename: true,
+        originalMimeType: true,
         originalPath: true,
         originalReferencePolicy: true,
         title: true,

--- a/backend/src/modules/media/ports/outbound/index.ts
+++ b/backend/src/modules/media/ports/outbound/index.ts
@@ -3,6 +3,9 @@ export type PhotoMediaRepositoryRow = Readonly<{
   title: string;
   originalReferencePolicy: "backend_media_route" | "filesystem_reference";
   originalReference: string;
+  originalDisplayFilename: string | null;
+  originalMimeType: string | null;
+  originalByteSize: number | null;
   createdAt: Date;
   updatedAt: Date;
 }>;
@@ -31,6 +34,17 @@ export type MediaStorageObject = Readonly<{
   stream: ReadableStream<Uint8Array>;
 }>;
 
+export type PhotoOriginalStorageWriteRequest = Readonly<{
+  body: Uint8Array;
+  storageKey: string;
+}>;
+
+export type PhotoOriginalStorageWriteResult = Readonly<{
+  byteSize: number;
+  storageKey: string;
+  storagePath: string;
+}>;
+
 export type ChatUploadStorageWriteRequest = Readonly<{
   body: Uint8Array;
   storageKey: string;
@@ -43,7 +57,9 @@ export type ChatUploadStorageWriteResult = Readonly<{
 }>;
 
 export interface PhotoMediaStoragePort {
+  deleteOriginal?(storagePath: string): Promise<void>;
   openOriginal(reference: string): Promise<MediaStorageObject | null>;
+  writeOriginal?(input: PhotoOriginalStorageWriteRequest): Promise<PhotoOriginalStorageWriteResult>;
 }
 
 export interface ChatUploadStoragePort {


### PR DESCRIPTION
## Summary

Adds nullable metadata fields for uploaded photo originals so the system can persist an admin-facing display filename, MIME type, and byte size without invalidating existing `Photo` rows.

## Source spec and acceptance

- Source spec: `docs/specs/photo-catalog-gallery.md`
- Base branch: `develop`
- Merge target: `develop`
- Branch: `data/PHOTO-001-photo-original-metadata`
- Task ID: `PHOTO-001`

## Changes

- Extends the Prisma `Photo` model with nullable original metadata fields:
  - `originalDisplayFilename`
  - `originalMimeType`
  - `originalByteSize`
- Adds the matching Prisma migration under `backend/prisma/migrations/20260506000100_photo-original-metadata/`.
- Extends media repository mapping and media outbound contracts so original metadata can be returned alongside existing media references.
- Adds repository test coverage for the new metadata mapping.

## Impact

Existing photo records remain valid because all new fields are nullable. This creates the data contract needed by later upload and admin UI work without changing public behavior by itself.

## Verification

- `git diff --check` passed in the task worktree.
- `bunx prisma generate` was attempted in the fresh worktree but could not run because dependencies were not installed there (`dotenv/config` missing from that isolated checkout).
- Full backend verification still needs to run after dependencies are available in the branch worktree or CI.

## Notes

Merge after `SPEC-033` and before `PHOTO-002`, because backend upload persistence depends on these schema fields.