### PR TITLE
PHOTO-002 Add admin photo upload API

### DIFF
--- a/backend/prisma/migrations/20260506000100_photo-original-metadata/migration.sql
+++ b/backend/prisma/migrations/20260506000100_photo-original-metadata/migration.sql
@@ -1,0 +1,5 @@
+-- PHOTO-001: store nullable original upload metadata for admin-managed photo records.
+ALTER TABLE "Photo"
+ADD COLUMN "originalDisplayFilename" TEXT,
+ADD COLUMN "originalMimeType" TEXT,
+ADD COLUMN "originalByteSize" INTEGER;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -414,6 +414,9 @@ model Photo {
   camera                  String?
   film                    String?
   originalPath            String
+  originalDisplayFilename String?
+  originalMimeType        String?
+  originalByteSize        Int?
   originalReferencePolicy PhotoOriginalReferencePolicy @default(backend_media_route)
   status                  PhotoStatus                  @default(draft)
   featured                Boolean                      @default(false)

--- a/backend/src/adapters/inbound/http/hono/admin-photo-media-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/admin-photo-media-routes.test.ts
@@ -1,0 +1,491 @@
+import { describe, expect, it } from "bun:test";
+
+import type { BootstrapContainer } from "@/bootstrap/container";
+
+import { createHonoHttpAdapter } from "./http-adapter";
+
+const encoder = new TextEncoder();
+
+type TestContainerOptions = Readonly<{
+  draftPhotoIds?: readonly string[];
+  filesByReference?: Readonly<
+    Record<
+      string,
+      Readonly<{
+        absolutePath: string;
+        body: string;
+      }>
+    >
+  >;
+  mediaById?: Readonly<
+    Record<
+      string,
+      Readonly<{
+        originalReference: string;
+      }>
+    >
+  >;
+  publishedPhotoIds?: readonly string[];
+}>;
+
+const createAdminPhotoItem = (
+  id: string,
+  status: "draft" | "published",
+) => ({
+  camera: "Canon T7+",
+  caption: "Night street frame.",
+  date: "2026-03-22",
+  featured: false,
+  film: "digital",
+  frame: "014",
+  id,
+  location: "Sao Paulo",
+  original: {
+    byteSize: 10,
+    displayFilename: "photo.jpg",
+    mimeType: "image/jpeg",
+  },
+  status,
+  tags: ["night", "street"],
+  title: "paulista at 02:14",
+  tone: "sunset" as const,
+  updatedAt: "2026-04-28T12:00:00.000Z",
+});
+
+const createPublishedPhotoDetail = (id: string) => ({
+  camera: "Canon T7+",
+  caption: "Night street frame.",
+  date: "2026-03-22",
+  film: "digital",
+  frame: "014",
+  id,
+  location: "Sao Paulo",
+  originalUrl: `/media/photos/${id}/original`,
+  tags: ["night", "street"],
+  title: "paulista at 02:14",
+  tone: "sunset" as const,
+});
+
+const createTestContainer = (options: TestContainerOptions = {}): BootstrapContainer => {
+  const publishedPhotoIds = new Set(options.publishedPhotoIds ?? ["p-2026-014"]);
+  const draftPhotoIds = new Set(options.draftPhotoIds ?? ["p-draft-001"]);
+  const mediaById = options.mediaById ?? {
+    "p-2026-014": {
+      originalReference: "published/p-2026-014.jpg",
+    },
+    "p-draft-001": {
+      originalReference: "draft/p-draft-001.jpg",
+    },
+  };
+  const filesByReference = options.filesByReference ?? {
+    "published/p-2026-014.jpg": {
+      absolutePath: "/tmp/photos/p-2026-014.jpg",
+      body: "jpeg-bytes",
+    },
+    "draft/p-draft-001.jpg": {
+      absolutePath: "/tmp/photos/p-draft-001.jpg",
+      body: "draft-bytes",
+    },
+  };
+
+  return {
+    admin: {
+      createPhoto: {
+        execute: async () => ({
+          item: createAdminPhotoItem("created-photo", "draft"),
+        }),
+      },
+      getDashboardSummary: {
+        execute: async () => ({
+          moderationCommands: ["delete_message", "ban_handle", "rotate_room_password"] as const,
+          panels: {
+            chatFlags: 0,
+            draftThoughts: 0,
+            featuredSlots: 0,
+            photoRecords: 0,
+            statusStripEntries: 0,
+          },
+          queues: {
+            content: [],
+          },
+        }),
+      },
+      getPhotoById: {
+        execute: async ({ id }) => {
+          if (publishedPhotoIds.has(id)) {
+            return {
+              item: createAdminPhotoItem(id, "published"),
+            };
+          }
+
+          if (draftPhotoIds.has(id)) {
+            return {
+              item: createAdminPhotoItem(id, "draft"),
+            };
+          }
+
+          return null;
+        },
+      },
+      listPhotos: {
+        execute: async () => ({
+          items: [],
+          pageInfo: {
+            page: 1,
+            pageSize: 20,
+            totalItems: 0,
+            totalPages: 1,
+          },
+        }),
+      },
+      listProjects: {
+        execute: async () => ({
+          items: [],
+          pageInfo: {
+            page: 1,
+            pageSize: 20,
+            totalItems: 0,
+            totalPages: 1,
+          },
+        }),
+      },
+      listStatusStripEntries: {
+        execute: async () => ({
+          items: [],
+        }),
+      },
+      listThoughts: {
+        execute: async () => ({
+          items: [],
+          pageInfo: {
+            page: 1,
+            pageSize: 20,
+            totalItems: 0,
+            totalPages: 1,
+          },
+        }),
+      },
+      replaceStatusStripEntries: {
+        execute: async () => ({
+          items: [],
+        }),
+      },
+      updatePhotoCuration: {
+        execute: async () => null,
+      },
+      updatePhotoMetadata: {
+        execute: async () => null,
+      },
+      updateProjectCuration: {
+        execute: async () => null,
+      },
+      updateThoughtCuration: {
+        execute: async () => null,
+      },
+    },
+    auth: {
+      loginWithCredentials: {
+        execute: async () => ({
+          challenge: {
+            delivery: "email" as const,
+            expiresAt: "2026-04-28T12:10:00.000Z",
+            id: "challenge_1",
+            maskedEmail: "ad***@example.com",
+          },
+          state: "mfa_required" as const,
+        }),
+      },
+      logoutAdminSession: {
+        execute: async () => ({
+          status: "revoked" as const,
+        }),
+      },
+      refreshAdminSession: {
+        execute: async () => ({
+          admin: {
+            email: "admin@example.com",
+            id: "admin_1",
+          },
+          session: {
+            expiresAt: "2026-04-28T12:10:00.000Z",
+            id: "session_1",
+          },
+          sessionToken: "session-token-1",
+          state: "ready" as const,
+        }),
+      },
+      resolveAdminSession: {
+        execute: async () => ({
+          admin: {
+            email: "admin@example.com",
+            id: "admin_1",
+          },
+          session: {
+            expiresAt: "2026-04-28T12:10:00.000Z",
+            id: "session_1",
+          },
+        }),
+      },
+      verifyMfaChallenge: {
+        execute: async () => ({
+          admin: {
+            email: "admin@example.com",
+            id: "admin_1",
+          },
+          session: {
+            expiresAt: "2026-04-28T12:10:00.000Z",
+            id: "session_1",
+          },
+          sessionToken: "session-token-1",
+          state: "ready" as const,
+        }),
+      },
+    },
+    chat: {
+      moderateUploadRetention: {
+        execute: async () => null,
+      },
+      openUploadMedia: {
+        execute: async () => null,
+      },
+      uploadMessageWithImage: {
+        execute: async () => ({
+          attachment: {
+            byteSize: 0,
+            fileName: "upload.webp",
+            id: "upload_1",
+            kind: "image" as const,
+            mimeType: "image/webp" as const,
+          },
+          author: "vinicius",
+          body: "uploaded an image without a caption",
+          id: "message_1",
+          sentAt: "2026-04-24T00:00:00.000Z",
+          tone: null,
+        }),
+      },
+    },
+    config: {
+      auth: {
+        mfaCodeMaxAgeSeconds: 600,
+        mfaMaxAttempts: 5,
+        roomPasswordSecret: "test-room-secret",
+        sessionCookieName: "vinicius.dev-session",
+        sessionMaxAgeSeconds: 604800,
+        sessionSecret: "test-session-secret",
+      },
+      cors: {
+        allowCredentials: true,
+        allowedOrigins: [],
+      },
+      media: {
+        chatRoot: "/tmp/chat",
+        chatUploadAllowedMimeTypes: ["image/jpeg", "image/png", "image/webp"],
+        chatUploadMaxBytes: 5 * 1024 * 1024,
+        chatUploadMaxFilesPerMessage: 1,
+        photosRoot: "/tmp/photos",
+        publicUrlBase: "/media",
+      },
+      server: {
+        apiBasePath: "/api",
+        mediaPhotoOriginalPath: "/media/photos/:id/original",
+        nodeEnv: "test",
+        port: 4000,
+      },
+    },
+    content: {
+      getPublishedProjectBySlug: {
+        execute: async () => null,
+      },
+      getPublishedPhotoById: {
+        execute: async ({ id }) => (publishedPhotoIds.has(id) ? createPublishedPhotoDetail(id) : null),
+      },
+      getPublishedThoughtBySlug: {
+        execute: async () => null,
+      },
+      listPublishedPhotos: {
+        execute: async () => ({
+          facets: {
+            locations: [],
+            years: [],
+          },
+          items: [],
+          pageInfo: {
+            page: 1,
+            pageSize: 24,
+            totalItems: 0,
+            totalPages: 1,
+          },
+        }),
+      },
+      listPublishedProjects: {
+        execute: async () => ({
+          items: [],
+          pageInfo: {
+            page: 1,
+            pageSize: 12,
+            totalItems: 0,
+            totalPages: 1,
+          },
+        }),
+      },
+      listPublishedThoughts: {
+        execute: async () => ({
+          items: [],
+          pageInfo: {
+            nextCursor: null,
+          },
+        }),
+      },
+      listStatusStripEntries: {
+        execute: async () => ({
+          items: [],
+        }),
+      },
+    },
+    media: {
+      repository: {
+        findChatUploadMediaById: async () => null,
+        findPhotoMediaById: async (id) => {
+          const media = mediaById[id];
+
+          if (!media) {
+            return null;
+          }
+
+          return {
+            createdAt: new Date("2026-03-22T00:00:00.000Z"),
+            id,
+            originalByteSize: 10,
+            originalDisplayFilename: "photo.jpg",
+            originalMimeType: "image/jpeg",
+            originalReference: media.originalReference,
+            originalReferencePolicy: "backend_media_route" as const,
+            title: "paulista at 02:14",
+            updatedAt: new Date("2026-03-23T00:00:00.000Z"),
+          };
+        },
+      },
+      storage: {
+        chatUploads: {
+          deleteUpload: async () => {},
+          openUpload: async () => null,
+          writeUpload: async () => ({
+            byteSize: 0,
+            storageKey: "upload_1",
+            storagePath: "upload_1",
+          }),
+        },
+        photos: {
+          openOriginal: async (reference) => {
+            const file = filesByReference[reference];
+
+            if (!file) {
+              return null;
+            }
+
+            const bytes = encoder.encode(file.body);
+
+            return {
+              absolutePath: file.absolutePath,
+              byteSize: bytes.byteLength,
+              stream: new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.enqueue(bytes);
+                  controller.close();
+                },
+              }),
+            };
+          },
+        },
+      },
+    },
+  };
+};
+
+describe("admin photo routes", () => {
+  it("returns an admin photo detail for draft records", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/api/admin/photos/p-draft-001", {
+      headers: {
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      item: {
+        camera: "Canon T7+",
+        caption: "Night street frame.",
+        date: "2026-03-22",
+        featured: false,
+        film: "digital",
+        frame: "014",
+        id: "p-draft-001",
+        location: "Sao Paulo",
+        original: {
+          byteSize: 10,
+          displayFilename: "photo.jpg",
+          mimeType: "image/jpeg",
+        },
+        status: "draft",
+        tags: ["night", "street"],
+        title: "paulista at 02:14",
+        tone: "sunset",
+        updatedAt: "2026-04-28T12:00:00.000Z",
+      },
+    });
+  });
+
+  it("returns not_found for unknown admin photo ids", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/api/admin/photos/unknown", {
+      headers: {
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "not_found",
+      resource: "photo",
+    });
+  });
+
+  it("serves private admin originals for draft photos", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/api/admin/photos/p-draft-001/original", {
+      headers: {
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("content-type")).toBe("image/jpeg");
+    expect(response.headers.get("content-length")).toBe("11");
+    await expect(response.text()).resolves.toBe("draft-bytes");
+  });
+
+  it("requires an admin session for private originals", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/api/admin/photos/p-draft-001/original");
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: "denied",
+      resource: "auth",
+    });
+  });
+
+  it("keeps public photo originals publish-only", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const response = await app.request("/media/photos/p-draft-001/original");
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "denied",
+      resource: "photo",
+    });
+  });
+});

--- a/backend/src/adapters/inbound/http/hono/admin-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/admin-routes.test.ts
@@ -245,6 +245,30 @@ const createTestContainer = (
         };
       },
     },
+    createPhoto: {
+      execute: async () => ({
+        item: {
+          camera: "Canon",
+          caption: "Night street frame.",
+          date: "2026-03-22",
+          featured: false,
+          film: "digital",
+          frame: "014",
+          id: "photo_1",
+          location: "Sao Paulo",
+          original: {
+            byteSize: 16,
+            displayFilename: "photo.jpg",
+            mimeType: "image/jpeg",
+          },
+          status: "draft",
+          tags: ["night"],
+          title: "paulista at 02:14",
+          tone: "sunset",
+          updatedAt: "2026-03-22T00:00:00.000Z",
+        },
+      }),
+    },
     updateProjectCuration: {
       execute: async () => null,
     },
@@ -453,7 +477,13 @@ const createTestContainer = (
         }),
       },
       photos: {
+        deleteOriginal: async () => {},
         openOriginal: async () => null,
+        writeOriginal: async (input) => ({
+          byteSize: input.body.byteLength,
+          storageKey: input.storageKey,
+          storagePath: input.storageKey,
+        }),
       },
     },
   },
@@ -485,6 +515,68 @@ describe("admin routes", () => {
         chatFlags: 2,
         draftThoughts: 3,
       },
+    });
+  });
+
+  it("uploads admin photos as draft records", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const formData = new FormData();
+    formData.set("file", new File([new Uint8Array([0xff, 0xd8, 0xff, 0x00])], "photo.jpg", {
+      type: "image/jpeg",
+    }));
+    formData.set("title", "paulista at 02:14");
+    formData.set("frame", "014");
+    formData.set("date", "2026-03-22");
+    formData.set("location", "Sao Paulo");
+    formData.set("tone", "sunset");
+    formData.set("tags", "night, street");
+
+    const response = await app.request("/api/admin/photos", {
+      body: formData,
+      headers: {
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      item: {
+        featured: false,
+        original: {
+          displayFilename: "photo.jpg",
+          mimeType: "image/jpeg",
+        },
+        status: "draft",
+      },
+    });
+  });
+
+  it("rejects admin photo uploads when the signature does not match the MIME type", async () => {
+    const app = createHonoHttpAdapter(createTestContainer());
+    const formData = new FormData();
+    formData.set("file", new File([new Uint8Array([0x00, 0x01, 0x02])], "photo.jpg", {
+      type: "image/jpeg",
+    }));
+    formData.set("title", "paulista at 02:14");
+    formData.set("frame", "014");
+    formData.set("date", "2026-03-22");
+    formData.set("location", "Sao Paulo");
+    formData.set("tone", "sunset");
+
+    const response = await app.request("/api/admin/photos", {
+      body: formData,
+      headers: {
+        cookie: "vinicius.dev-session=session-token-1",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_upload",
+      field: "file",
+      reason: "mime_signature_mismatch",
     });
   });
 

--- a/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/chat-routes.test.ts
@@ -31,6 +31,13 @@ import {
   chatLiveTransportProtocol,
 } from "./chat-live-contract";
 
+let testServerPort = 38_710;
+
+const nextTestServerPort = () => {
+  testServerPort += 1;
+  return testServerPort;
+};
+
 const defaultUploadResponse: UploadChatMessageWithImageOutput = {
   attachment: {
     byteSize: 4,
@@ -644,7 +651,7 @@ describe("chat routes", () => {
     const websocket = await resolveWebSocketHandler();
     const server = Bun.serve({
       fetch: (request, bunServer) => app.fetch(request, bunServer),
-      port: 0,
+      port: nextTestServerPort(),
       websocket,
     });
     const protocols = [
@@ -722,7 +729,7 @@ describe("chat routes", () => {
     const websocket = await resolveWebSocketHandler();
     const server = Bun.serve({
       fetch: (request, bunServer) => app.fetch(request, bunServer),
-      port: 0,
+      port: nextTestServerPort(),
       websocket,
     });
 

--- a/backend/src/adapters/inbound/http/hono/http-adapter.ts
+++ b/backend/src/adapters/inbound/http/hono/http-adapter.ts
@@ -299,6 +299,16 @@ const parsePositiveInteger = (value: string | undefined): number | undefined => 
 const inferMediaContentType = (absolutePath: string): string =>
   mediaContentTypeByExtension[extname(absolutePath).toLowerCase()] ?? defaultMediaContentType;
 
+const openPhotoOriginalFromStorage = async (container: BootstrapContainer, id: string) => {
+  const photoMedia = await container.media.repository.findPhotoMediaById(id);
+
+  if (!photoMedia) {
+    return null;
+  }
+
+  return container.media.storage.photos.openOriginal(photoMedia.originalReference);
+};
+
 const parseThoughtQuery = (query: Record<string, string | undefined>) => {
   const type = query.type;
 
@@ -646,11 +656,36 @@ const supportedChatUploadMimeTypes: readonly ChatUploadMimeType[] = [
   "image/png",
   "image/webp",
 ];
+const ADMIN_PHOTO_UPLOAD_MAX_BYTES = 25 * 1024 * 1024;
+const IMAGE_EXTENSION_BY_MIME_TYPE: Record<ChatUploadMimeType, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+};
 const MAX_CHAT_MESSAGE_BODY_LENGTH = 2000;
 const CHAT_UPLOAD_ROOM_SLUG = "night-shift";
 
 const isSupportedChatUploadMimeType = (value: string): value is ChatUploadMimeType => {
   return supportedChatUploadMimeTypes.includes(value as ChatUploadMimeType);
+};
+
+const buildPhotoOriginalStorageKey = (date: Date, photoId: string, mimeType: ChatUploadMimeType) => {
+  const year = String(date.getUTCFullYear()).padStart(4, "0");
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const safePhotoId = photoId.replaceAll(/[^a-zA-Z0-9_-]/g, "");
+
+  return `${year}/${month}/${safePhotoId}.${IMAGE_EXTENSION_BY_MIME_TYPE[mimeType]}`;
+};
+
+const parseTagsText = (value: string | undefined): readonly string[] => {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(/[,\n]/)
+    .map((tag) => tag.trim())
+    .filter(Boolean);
 };
 
 const hasLeadingBytes = (input: Uint8Array, signature: readonly number[]) => {
@@ -2006,6 +2041,7 @@ const createAdminFamily = (
   const rotateRoomPasswordUseCase = (container.chat as {
     rotateRoomPassword?: RotateChatRoomPasswordPort;
   }).rotateRoomPassword;
+  const getPhotoByIdUseCase = admin.getPhotoById;
 
   const resolveSession = async (c: Context) => {
     const sessionToken = readSessionTokenFromCookie(
@@ -2253,6 +2289,134 @@ const createAdminFamily = (
     return c.json(result);
   });
 
+  adminApp.post("/photos", async (c) => {
+    const session = await resolveSession(c);
+
+    if ("error" in session) {
+      return session.error;
+    }
+
+    const formData = await c.req.formData();
+    const title = getRequiredFormText(formData, "title");
+    const frame = getRequiredFormText(formData, "frame");
+    const date = getRequiredFormText(formData, "date");
+    const location = getRequiredFormText(formData, "location");
+    const tone = getRequiredFormText(formData, "tone");
+    const file = formData.get("file");
+
+    if ("error" in title) {
+      return c.json(title.error, 400);
+    }
+
+    if ("error" in frame) {
+      return c.json(frame.error, 400);
+    }
+
+    if ("error" in date) {
+      return c.json(date.error, 400);
+    }
+
+    if ("error" in location) {
+      return c.json(location.error, 400);
+    }
+
+    if ("error" in tone) {
+      return c.json(tone.error, 400);
+    }
+
+    if (!(file instanceof File) || file.size <= 0) {
+      return c.json({ error: "invalid_upload", field: "file", reason: "missing_file" }, 400);
+    }
+
+    if (
+      tone.value !== "amber" &&
+      tone.value !== "cyan" &&
+      tone.value !== "mono" &&
+      tone.value !== "sunset" &&
+      tone.value !== "violet"
+    ) {
+      return c.json({ error: "invalid_request", field: "tone" }, 400);
+    }
+
+    const parsedDate = new Date(date.value);
+
+    if (Number.isNaN(parsedDate.getTime())) {
+      return c.json({ error: "invalid_request", field: "date" }, 400);
+    }
+
+    const mimeType = file.type.trim().toLowerCase();
+
+    if (!isSupportedChatUploadMimeType(mimeType)) {
+      return c.json({ error: "invalid_upload", field: "file", reason: "unsupported_mime_type" }, 400);
+    }
+
+    if (file.size > ADMIN_PHOTO_UPLOAD_MAX_BYTES) {
+      return c.json({ error: "invalid_upload", field: "file", reason: "file_too_large" }, 413);
+    }
+
+    const uploadBytes = new Uint8Array(await file.arrayBuffer());
+
+    if (!isChatUploadMimeSignatureValid(mimeType, uploadBytes)) {
+      return c.json(
+        { error: "invalid_upload", field: "file", reason: "mime_signature_mismatch" },
+        400,
+      );
+    }
+
+    const photoStorage = container.media.storage.photos;
+
+    if (!photoStorage.writeOriginal || !photoStorage.deleteOriginal) {
+      return c.json<NotImplementedResponse>(
+        {
+          family: "admin",
+          method: c.req.method,
+          route: c.req.path,
+          service: serviceName,
+          status: "not_implemented",
+        },
+        501,
+      );
+    }
+
+    const photoId = crypto.randomUUID();
+    const storageKey = buildPhotoOriginalStorageKey(parsedDate, photoId, mimeType);
+    const written = await photoStorage.writeOriginal({
+      body: uploadBytes,
+      storageKey,
+    });
+
+    try {
+      const response = await admin.createPhoto.execute({
+        camera: getOptionalFormText(formData, "camera")?.trim() || null,
+        caption: getOptionalFormText(formData, "caption")?.trim() || null,
+        date: date.value,
+        film: getOptionalFormText(formData, "film")?.trim() || null,
+        frame: frame.value,
+        id: photoId,
+        location: location.value,
+        original: {
+          byteSize: written.byteSize,
+          displayFilename: file.name.trim() || "photo",
+          mimeType,
+          path: written.storagePath,
+        },
+        tags: parseTagsText(getOptionalFormText(formData, "tags")),
+        title: title.value,
+        tone: tone.value,
+      });
+
+      return c.json(response, 201);
+    } catch (error) {
+      await photoStorage.deleteOriginal(written.storagePath).catch(() => undefined);
+
+      if (error instanceof InvalidAdminPhotoMetadataDateError) {
+        return c.json({ error: "invalid_request", field: "date" }, 400);
+      }
+
+      throw error;
+    }
+  });
+
   adminApp.get("/photos", async (c) => {
     const session = await resolveSession(c);
 
@@ -2297,6 +2461,87 @@ const createAdminFamily = (
     });
 
     return c.json(response);
+  });
+
+  adminApp.get("/photos/:id", async (c) => {
+    const session = await resolveSession(c);
+
+    if ("error" in session) {
+      return session.error;
+    }
+
+    if (!getPhotoByIdUseCase) {
+      return c.json<NotImplementedResponse>(
+        {
+          family: "admin",
+          method: c.req.method,
+          route: c.req.path,
+          service: serviceName,
+          status: "not_implemented",
+        },
+        501,
+      );
+    }
+
+    const id = c.req.param("id")?.trim();
+
+    if (!id) {
+      return c.json({ error: "invalid_path", field: "id" }, 400);
+    }
+
+    const result = await getPhotoByIdUseCase.execute({ id });
+
+    if (!result) {
+      return c.json({ error: "not_found", resource: "photo" }, 404);
+    }
+
+    return c.json(result);
+  });
+
+  adminApp.get("/photos/:id/original", async (c) => {
+    const session = await resolveSession(c);
+
+    if ("error" in session) {
+      return session.error;
+    }
+
+    if (!getPhotoByIdUseCase) {
+      return c.json<NotImplementedResponse>(
+        {
+          family: "admin",
+          method: c.req.method,
+          route: c.req.path,
+          service: serviceName,
+          status: "not_implemented",
+        },
+        501,
+      );
+    }
+
+    const id = c.req.param("id")?.trim();
+
+    if (!id) {
+      return c.json({ error: "invalid_path", field: "id" }, 400);
+    }
+
+    const photo = await getPhotoByIdUseCase.execute({ id });
+
+    if (!photo) {
+      return c.json({ error: "not_found", resource: "photo" }, 404);
+    }
+
+    const originalMedia = await openPhotoOriginalFromStorage(container, id);
+
+    if (!originalMedia) {
+      return c.json({ error: "not_found", resource: "photo" }, 404);
+    }
+
+    c.header("Cache-Control", "private, no-store");
+
+    return c.body(originalMedia.stream, 200, {
+      "Content-Length": String(originalMedia.byteSize),
+      "Content-Type": inferMediaContentType(originalMedia.absolutePath),
+    });
   });
 
   adminApp.patch("/photos/:id/curation", async (c) => {

--- a/backend/src/adapters/inbound/http/hono/photo-media-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/photo-media-routes.test.ts
@@ -168,6 +168,9 @@ const createTestContainer = (options: TestContainerOptions = {}): BootstrapConta
           return {
             createdAt: new Date("2026-03-22T00:00:00.000Z"),
             id,
+            originalByteSize: null,
+            originalDisplayFilename: null,
+            originalMimeType: null,
             originalReference: media.originalReference,
             originalReferencePolicy: media.originalReferencePolicy ?? "backend_media_route",
             title: "paulista at 02:14",

--- a/backend/src/adapters/inbound/http/hono/photos-routes.test.ts
+++ b/backend/src/adapters/inbound/http/hono/photos-routes.test.ts
@@ -84,6 +84,10 @@ const createTestContainer = (): BootstrapContainer => ({
     },
     listPublishedPhotos: {
       execute: async ({ location, page, pageSize, search, year }) => ({
+        facets: {
+          locations: ["Sao Paulo", "Tokyo"],
+          years: [2026, 2025],
+        },
         items: [
           {
             date: "2026-03-22",
@@ -160,6 +164,10 @@ describe("photos routes", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
+      facets: {
+        locations: ["Sao Paulo", "Tokyo"],
+        years: [2026, 2025],
+      },
       items: [
         {
           date: "2026-03-22",

--- a/backend/src/adapters/outbound/persistence/prisma/admin-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/admin-repository.test.ts
@@ -156,6 +156,64 @@ describe("prisma admin repository", () => {
     });
   });
 
+  it("returns one photo for admin curation by id with original metadata", async () => {
+    const client = {
+      photo: {
+        findUnique: async () => ({
+          camera: "Canon",
+          caption: "Night street frame.",
+          date: new Date("2026-03-22T00:00:00.000Z"),
+          featured: false,
+          film: "digital",
+          frame: "014",
+          id: "photo_1",
+          location: "Sao Paulo",
+          originalByteSize: 1204,
+          originalDisplayFilename: "photo.jpg",
+          originalMimeType: "image/jpeg",
+          status: "draft",
+          tags: ["night", "street"],
+          title: "paulista at 02:14",
+          tone: "sunset",
+          updatedAt: new Date("2026-04-28T12:00:00.000Z"),
+        }),
+      },
+    } as unknown as PrismaDatabaseClient;
+
+    const repository = createPrismaAdminRepository(client);
+
+    await expect(repository.findPhotoForCurationById("photo_1")).resolves.toEqual({
+      camera: "Canon",
+      caption: "Night street frame.",
+      date: new Date("2026-03-22T00:00:00.000Z"),
+      featured: false,
+      film: "digital",
+      frame: "014",
+      id: "photo_1",
+      location: "Sao Paulo",
+      originalByteSize: 1204,
+      originalDisplayFilename: "photo.jpg",
+      originalMimeType: "image/jpeg",
+      status: "draft",
+      tags: ["night", "street"],
+      title: "paulista at 02:14",
+      tone: "sunset",
+      updatedAt: new Date("2026-04-28T12:00:00.000Z"),
+    });
+  });
+
+  it("returns null when a curation photo id cannot be found", async () => {
+    const client = {
+      photo: {
+        findUnique: async () => null,
+      },
+    } as unknown as PrismaDatabaseClient;
+
+    const repository = createPrismaAdminRepository(client);
+
+    await expect(repository.findPhotoForCurationById("missing")).resolves.toBeNull();
+  });
+
   it("replaces status strip entries and returns ordered rows", async () => {
     const createCalls: Array<Record<string, unknown>> = [];
     const upsertCalls: Array<Record<string, unknown>> = [];

--- a/backend/src/adapters/outbound/persistence/prisma/admin-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/admin-repository.ts
@@ -14,6 +14,7 @@ import type {
   AdminThoughtCurationListQuery,
   AdminThoughtCurationRow,
   AdminUserRepositoryRow,
+  CreateAdminPhotoCommand,
   ReplaceAdminStatusStripEntryInput,
   UpdateAdminPhotoCurationCommand,
   UpdateAdminPhotoMetadataCommand,
@@ -182,6 +183,9 @@ const mapPhotoCurationRow = (row: {
   caption: string | null;
   camera: string | null;
   film: string | null;
+  originalDisplayFilename: string | null;
+  originalMimeType: string | null;
+  originalByteSize: number | null;
   tags: string[];
   updatedAt: Date;
 }): AdminPhotoCurationRow => ({
@@ -193,6 +197,9 @@ const mapPhotoCurationRow = (row: {
   frame: row.frame,
   id: row.id,
   location: row.location,
+  originalByteSize: row.originalByteSize,
+  originalDisplayFilename: row.originalDisplayFilename,
+  originalMimeType: row.originalMimeType,
   status: row.status,
   tags: [...row.tags],
   title: row.title,
@@ -811,6 +818,75 @@ export const createPrismaAdminRepository = (client: PrismaDatabaseClient): Admin
 
     return mapProjectCurationRow(updated);
   },
+  createPhoto: async (input: CreateAdminPhotoCommand): Promise<AdminPhotoCurationRow> => {
+    const created = await client.photo.create({
+      data: {
+        camera: input.camera,
+        caption: input.caption,
+        date: input.date,
+        featured: false,
+        film: input.film,
+        frame: input.frame,
+        id: input.id,
+        location: input.location,
+        originalByteSize: input.originalByteSize,
+        originalDisplayFilename: input.originalDisplayFilename,
+        originalMimeType: input.originalMimeType,
+        originalPath: input.originalPath,
+        status: PhotoStatus.draft,
+        tags: [...input.tags],
+        title: input.title,
+        tone: input.tone,
+      },
+      select: {
+        camera: true,
+        caption: true,
+        date: true,
+        featured: true,
+        film: true,
+        frame: true,
+        id: true,
+        location: true,
+        originalByteSize: true,
+        originalDisplayFilename: true,
+        originalMimeType: true,
+        status: true,
+        tags: true,
+        title: true,
+        tone: true,
+        updatedAt: true,
+      },
+    });
+
+    return mapPhotoCurationRow(created);
+  },
+  findPhotoForCurationById: async (id: string): Promise<AdminPhotoCurationRow | null> => {
+    const row = await client.photo.findUnique({
+      select: {
+        camera: true,
+        caption: true,
+        date: true,
+        featured: true,
+        film: true,
+        frame: true,
+        id: true,
+        location: true,
+        originalByteSize: true,
+        originalDisplayFilename: true,
+        originalMimeType: true,
+        status: true,
+        tags: true,
+        title: true,
+        tone: true,
+        updatedAt: true,
+      },
+      where: {
+        id,
+      },
+    });
+
+    return row ? mapPhotoCurationRow(row) : null;
+  },
   listPhotosForCuration: async (query): Promise<AdminPhotoCurationListPage> => {
     const rows = await client.photo.findMany({
       orderBy: [{ updatedAt: "desc" }],
@@ -823,6 +899,9 @@ export const createPrismaAdminRepository = (client: PrismaDatabaseClient): Admin
         frame: true,
         id: true,
         location: true,
+        originalByteSize: true,
+        originalDisplayFilename: true,
+        originalMimeType: true,
         status: true,
         tags: true,
         title: true,
@@ -865,6 +944,9 @@ export const createPrismaAdminRepository = (client: PrismaDatabaseClient): Admin
         frame: true,
         id: true,
         location: true,
+        originalByteSize: true,
+        originalDisplayFilename: true,
+        originalMimeType: true,
         status: true,
         tags: true,
         title: true,
@@ -949,6 +1031,9 @@ export const createPrismaAdminRepository = (client: PrismaDatabaseClient): Admin
         frame: true,
         id: true,
         location: true,
+        originalByteSize: true,
+        originalDisplayFilename: true,
+        originalMimeType: true,
         status: true,
         tags: true,
         title: true,

--- a/backend/src/adapters/outbound/persistence/prisma/content-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/content-repository.ts
@@ -430,7 +430,8 @@ export const createPrismaContentRepository = (client: PrismaDatabaseClient): Con
   findPublishedPhotos: async (query: PhotoListQuery): Promise<PhotoListPage> => {
     const page = query.page ?? 1;
     const pageSize = query.pageSize ?? 24;
-    const rows = await client.photo.findMany({
+    const [rows, facetRows] = await Promise.all([
+      client.photo.findMany({
       orderBy: [{ date: "desc" }, { id: "desc" }],
       select: {
         caption: true,
@@ -461,7 +462,18 @@ export const createPrismaContentRepository = (client: PrismaDatabaseClient): Con
           : {}),
         status: PhotoStatus.published,
       },
-    });
+      }),
+      client.photo.findMany({
+        orderBy: [{ date: "desc" }, { id: "desc" }],
+        select: {
+          date: true,
+          location: true,
+        },
+        where: {
+          status: PhotoStatus.published,
+        },
+      }),
+    ]);
 
     const normalizedSearch = query.search?.trim().toLowerCase();
     const filteredRows = normalizedSearch
@@ -479,6 +491,14 @@ export const createPrismaContentRepository = (client: PrismaDatabaseClient): Con
     const startIndex = (page - 1) * pageSize;
 
     return {
+      facets: {
+        locations: Array.from(new Set(facetRows.map((row) => row.location))).sort((left, right) =>
+          left.localeCompare(right),
+        ),
+        years: Array.from(new Set(facetRows.map((row) => row.date.getUTCFullYear()))).sort(
+          (left, right) => right - left,
+        ),
+      },
       items: filteredRows.slice(startIndex, startIndex + pageSize).map(mapPhotoRow),
       page,
       pageSize,

--- a/backend/src/adapters/outbound/persistence/prisma/media-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/media-repository.test.ts
@@ -13,6 +13,9 @@ describe("prisma media repository", () => {
         findFirst: async () => ({
           createdAt: new Date("2026-03-22T00:00:00.000Z"),
           id: "p-2026-014",
+          originalByteSize: 482113,
+          originalDisplayFilename: "paulista-0214.webp",
+          originalMimeType: "image/webp",
           originalPath: "published/p-2026-014.jpg",
           originalReferencePolicy: "filesystem_reference" as const,
           title: "paulista at 02:14",
@@ -26,6 +29,9 @@ describe("prisma media repository", () => {
     expect(photo).toEqual({
       createdAt: new Date("2026-03-22T00:00:00.000Z"),
       id: "p-2026-014",
+      originalByteSize: 482113,
+      originalDisplayFilename: "paulista-0214.webp",
+      originalMimeType: "image/webp",
       originalReference: "published/p-2026-014.jpg",
       originalReferencePolicy: "filesystem_reference",
       title: "paulista at 02:14",

--- a/backend/src/adapters/outbound/persistence/prisma/media-repository.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/media-repository.ts
@@ -13,6 +13,9 @@ import type { PrismaDatabaseClient } from "./prisma-client";
 const mapPhotoMediaRow = (row: {
   createdAt: Date;
   id: string;
+  originalByteSize: number | null;
+  originalDisplayFilename: string | null;
+  originalMimeType: string | null;
   originalPath: string;
   originalReferencePolicy: PhotoOriginalReferencePolicy;
   title: string;
@@ -20,6 +23,9 @@ const mapPhotoMediaRow = (row: {
 }): PhotoMediaRepositoryRow => ({
   createdAt: row.createdAt,
   id: row.id,
+  originalByteSize: row.originalByteSize,
+  originalDisplayFilename: row.originalDisplayFilename,
+  originalMimeType: row.originalMimeType,
   originalReference: row.originalPath,
   originalReferencePolicy: row.originalReferencePolicy,
   title: row.title,
@@ -61,6 +67,9 @@ export const createPrismaMediaRepository = (client: PrismaDatabaseClient): Media
       select: {
         createdAt: true,
         id: true,
+        originalByteSize: true,
+        originalDisplayFilename: true,
+        originalMimeType: true,
         originalPath: true,
         originalReferencePolicy: true,
         title: true,

--- a/backend/src/adapters/outbound/persistence/prisma/photo-repository.test.ts
+++ b/backend/src/adapters/outbound/persistence/prisma/photo-repository.test.ts
@@ -54,6 +54,10 @@ describe("prisma photo repository", () => {
     });
 
     expect(page).toEqual({
+      facets: {
+        locations: ["Sao Paulo"],
+        years: [2026],
+      },
       items: [
         {
           caption: "Night street frame.",

--- a/backend/src/adapters/outbound/storage/filesystem/create-filesystem-media-storage-adapter.test.ts
+++ b/backend/src/adapters/outbound/storage/filesystem/create-filesystem-media-storage-adapter.test.ts
@@ -40,6 +40,32 @@ describe("filesystem media storage adapter", () => {
     await expect(readStorageObjectText(file!.stream)).resolves.toBe("photo-bytes");
   });
 
+  it("writes and deletes photo originals under the configured photos root", async () => {
+    const photosRoot = await createTempRoot("photos");
+    const chatRoot = await createTempRoot("chat");
+    const adapter = createFilesystemMediaStorageAdapter({
+      chatRoot,
+      photosRoot,
+    });
+
+    const written = await adapter.photos.writeOriginal!({
+      body: new TextEncoder().encode("photo-upload-bytes"),
+      storageKey: "2026/03/photo_123.webp",
+    });
+
+    expect(written).toEqual({
+      byteSize: 18,
+      storageKey: "2026/03/photo_123.webp",
+      storagePath: "2026/03/photo_123.webp",
+    });
+
+    const reopened = await adapter.photos.openOriginal(written.storagePath);
+    await expect(readStorageObjectText(reopened!.stream)).resolves.toBe("photo-upload-bytes");
+
+    await adapter.photos.deleteOriginal!(written.storagePath);
+    await expect(adapter.photos.openOriginal(written.storagePath)).resolves.toBeNull();
+  });
+
   it("writes chat uploads under the configured chat root and reopens them", async () => {
     const photosRoot = await createTempRoot("photos");
     const chatRoot = await createTempRoot("chat");
@@ -80,6 +106,12 @@ describe("filesystem media storage adapter", () => {
       adapter.chatUploads.writeUpload({
         body: new TextEncoder().encode("x"),
         storageKey: "../outside.webp",
+      }),
+    ).rejects.toThrow("Storage path escapes configured root");
+    await expect(
+      adapter.photos.writeOriginal!({
+        body: new TextEncoder().encode("x"),
+        storageKey: "../outside.jpg",
       }),
     ).rejects.toThrow("Storage path escapes configured root");
   });

--- a/backend/src/adapters/outbound/storage/filesystem/create-filesystem-media-storage-adapter.ts
+++ b/backend/src/adapters/outbound/storage/filesystem/create-filesystem-media-storage-adapter.ts
@@ -6,6 +6,8 @@ import type {
   ChatUploadStorageWriteRequest,
   ChatUploadStorageWriteResult,
   MediaStorageObject,
+  PhotoOriginalStorageWriteRequest,
+  PhotoOriginalStorageWriteResult,
   PhotoMediaStoragePort,
 } from "@/modules/media/ports/outbound";
 
@@ -105,10 +107,35 @@ const createPhotoMediaStorage = (photosRoot: string): PhotoMediaStoragePort => {
   const resolvePhotoPath = createSafeStoragePathResolver(photosRoot);
 
   return {
+    deleteOriginal: async (storagePath) => {
+      const { absolutePath } = await resolvePhotoPath(storagePath);
+
+      try {
+        await unlink(absolutePath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+      }
+    },
     openOriginal: async (reference) => {
       const { absolutePath } = await resolvePhotoPath(reference);
 
       return openStorageObject(absolutePath);
+    },
+    writeOriginal: async (
+      input: PhotoOriginalStorageWriteRequest,
+    ): Promise<PhotoOriginalStorageWriteResult> => {
+      const { absolutePath, storagePath } = await resolvePhotoPath(input.storageKey);
+
+      await mkdir(dirname(absolutePath), { recursive: true });
+      await writeFile(absolutePath, input.body);
+
+      return {
+        byteSize: input.body.byteLength,
+        storageKey: input.storageKey,
+        storagePath,
+      };
     },
   };
 };

--- a/backend/src/bootstrap/container/create-container.ts
+++ b/backend/src/bootstrap/container/create-container.ts
@@ -5,7 +5,9 @@ import {
 } from "@/adapters/outbound/mail";
 import { createFilesystemMediaStorageAdapter } from "@/adapters/outbound/storage/filesystem";
 import {
+  createCreateAdminPhotoUseCase,
   createGetAdminDashboardSummaryUseCase,
+  createGetAdminPhotoByIdUseCase,
   createListAdminPhotosUseCase,
   createListAdminProjectsUseCase,
   createListAdminStatusStripEntriesUseCase,
@@ -17,7 +19,9 @@ import {
   createUpdateAdminThoughtCurationUseCase,
 } from "@/modules/admin/application";
 import type {
+  CreateAdminPhotoPort,
   GetAdminDashboardSummaryPort,
+  GetAdminPhotoByIdPort,
   ListAdminPhotosPort,
   ListAdminProjectsPort,
   ListAdminStatusStripEntriesPort,
@@ -104,7 +108,9 @@ import { loadBootstrapConfig, type BootstrapConfig } from "../config";
 
 export type BootstrapContainer = Readonly<{
   admin?: Readonly<{
+    createPhoto: CreateAdminPhotoPort;
     getDashboardSummary: GetAdminDashboardSummaryPort;
+    getPhotoById?: GetAdminPhotoByIdPort;
     listPhotos: ListAdminPhotosPort;
     listProjects: ListAdminProjectsPort;
     listStatusStripEntries: ListAdminStatusStripEntriesPort;
@@ -211,7 +217,13 @@ export const createContainer = (env: BootstrapEnv = Bun.env): BootstrapContainer
 
   return {
     admin: {
+      createPhoto: createCreateAdminPhotoUseCase({
+        repository: persistence.admin,
+      }),
       getDashboardSummary: createGetAdminDashboardSummaryUseCase({
+        repository: persistence.admin,
+      }),
+      getPhotoById: createGetAdminPhotoByIdUseCase({
         repository: persistence.admin,
       }),
       listPhotos: createListAdminPhotosUseCase({

--- a/backend/src/modules/admin/application/index.test.ts
+++ b/backend/src/modules/admin/application/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import {
   createGetAdminDashboardSummaryUseCase,
+  createGetAdminPhotoByIdUseCase,
   createListAdminPhotosUseCase,
   createListAdminProjectsUseCase,
   createListAdminStatusStripEntriesUseCase,
@@ -23,10 +24,14 @@ const createRepository = (
   createAdminSession: async () => {
     throw new Error("unused");
   },
+  createPhoto: async () => {
+    throw new Error("unused");
+  },
   createMfaChallenge: async () => {
     throw new Error("unused");
   },
   findAdminSessionByTokenHash: async () => null,
+  findPhotoForCurationById: async () => null,
   findAdminUserByEmail: async () => null,
   findMfaChallengeById: async () => null,
   incrementMfaChallengeAttempts: async () => {},
@@ -499,6 +504,57 @@ describe("admin application", () => {
         id: "missing",
       }),
     ).resolves.toBeNull();
+  });
+
+  it("maps admin photo detail results and forwards not-found as null", async () => {
+    const repository = createRepository({
+      findPhotoForCurationById: async (id) =>
+        id === "missing"
+          ? null
+          : {
+              camera: "Canon",
+              caption: "Night street frame.",
+              date: new Date("2026-03-22T00:00:00.000Z"),
+              featured: false,
+              film: "digital",
+              frame: "014",
+              id,
+              location: "Sao Paulo",
+              originalByteSize: 1204,
+              originalDisplayFilename: "photo.jpg",
+              originalMimeType: "image/jpeg",
+              status: "draft",
+              tags: ["night", "street"],
+              title: "paulista at 02:14",
+              tone: "sunset",
+              updatedAt: now,
+            },
+    });
+    const useCase = createGetAdminPhotoByIdUseCase({ repository });
+
+    await expect(useCase.execute({ id: " photo_1 " })).resolves.toEqual({
+      item: {
+        camera: "Canon",
+        caption: "Night street frame.",
+        date: "2026-03-22",
+        featured: false,
+        film: "digital",
+        frame: "014",
+        id: "photo_1",
+        location: "Sao Paulo",
+        original: {
+          byteSize: 1204,
+          displayFilename: "photo.jpg",
+          mimeType: "image/jpeg",
+        },
+        status: "draft",
+        tags: ["night", "street"],
+        title: "paulista at 02:14",
+        tone: "sunset",
+        updatedAt: "2026-04-28T12:00:00.000Z",
+      },
+    });
+    await expect(useCase.execute({ id: "missing" })).resolves.toBeNull();
   });
 
   it("maps valid photo metadata updates and null metadata results", async () => {

--- a/backend/src/modules/admin/application/index.ts
+++ b/backend/src/modules/admin/application/index.ts
@@ -1,6 +1,12 @@
 import type {
   AdminDashboardSummaryOutput,
+  CreateAdminPhotoInput,
+  CreateAdminPhotoOutput,
+  CreateAdminPhotoPort,
   GetAdminDashboardSummaryPort,
+  GetAdminPhotoByIdInput,
+  GetAdminPhotoByIdOutput,
+  GetAdminPhotoByIdPort,
   ListAdminPhotosInput,
   ListAdminPhotosOutput,
   ListAdminPhotosPort,
@@ -123,6 +129,11 @@ const mapPhotoItem = (item: AdminPhotoCurationRow) => ({
   frame: item.frame,
   id: item.id,
   location: item.location,
+  original: {
+    byteSize: item.originalByteSize ?? null,
+    displayFilename: item.originalDisplayFilename ?? null,
+    mimeType: item.originalMimeType ?? null,
+  },
   status: item.status,
   tags: [...item.tags],
   title: item.title,
@@ -276,6 +287,57 @@ export const createListAdminPhotosUseCase = ({
         totalItems: result.totalItems,
         totalPages: result.totalPages,
       },
+    };
+  },
+});
+
+export const createGetAdminPhotoByIdUseCase = ({
+  repository,
+}: AdminApplicationDependencies): GetAdminPhotoByIdPort => ({
+  execute: async (
+    input: GetAdminPhotoByIdInput,
+  ): Promise<GetAdminPhotoByIdOutput | null> => {
+    const photo = await repository.findPhotoForCurationById(input.id.trim());
+
+    if (!photo) {
+      return null;
+    }
+
+    return {
+      item: mapPhotoItem(photo),
+    };
+  },
+});
+
+export const createCreateAdminPhotoUseCase = ({
+  repository,
+}: AdminApplicationDependencies): CreateAdminPhotoPort => ({
+  execute: async (input: CreateAdminPhotoInput): Promise<CreateAdminPhotoOutput> => {
+    const date = new Date(input.date);
+
+    if (Number.isNaN(date.getTime())) {
+      throw new InvalidAdminPhotoMetadataDateError();
+    }
+
+    const created = await repository.createPhoto({
+      camera: input.camera ?? null,
+      caption: input.caption ?? null,
+      date,
+      film: input.film ?? null,
+      frame: input.frame.trim(),
+      id: input.id.trim(),
+      location: input.location.trim(),
+      originalByteSize: input.original.byteSize,
+      originalDisplayFilename: input.original.displayFilename.trim() || "photo",
+      originalMimeType: input.original.mimeType,
+      originalPath: input.original.path,
+      tags: input.tags?.map((tag) => tag.trim()).filter(Boolean) ?? [],
+      title: input.title.trim(),
+      tone: input.tone,
+    });
+
+    return {
+      item: mapPhotoItem(created),
     };
   },
 });

--- a/backend/src/modules/admin/ports/inbound/index.ts
+++ b/backend/src/modules/admin/ports/inbound/index.ts
@@ -128,6 +128,11 @@ export type AdminPhotoCurationItem = Readonly<{
   caption: string | null;
   camera: string | null;
   film: string | null;
+  original?: Readonly<{
+    displayFilename: string | null;
+    mimeType: string | null;
+    byteSize: number | null;
+  }>;
   tags: readonly string[];
   updatedAt: string;
 }>;
@@ -154,6 +159,43 @@ export type ListAdminPhotosOutput = Readonly<{
 
 export interface ListAdminPhotosPort
   extends UseCase<ListAdminPhotosInput, ListAdminPhotosOutput> {}
+
+export type GetAdminPhotoByIdInput = Readonly<{
+  id: string;
+}>;
+
+export type GetAdminPhotoByIdOutput = Readonly<{
+  item: AdminPhotoCurationItem;
+}>;
+
+export interface GetAdminPhotoByIdPort
+  extends UseCase<GetAdminPhotoByIdInput, GetAdminPhotoByIdOutput | null> {}
+
+export type CreateAdminPhotoInput = Readonly<{
+  id: string;
+  title: string;
+  frame: string;
+  date: string;
+  location: string;
+  tags?: readonly string[];
+  tone: "amber" | "cyan" | "mono" | "sunset" | "violet";
+  caption?: string | null;
+  camera?: string | null;
+  film?: string | null;
+  original: Readonly<{
+    path: string;
+    displayFilename: string;
+    mimeType: string;
+    byteSize: number;
+  }>;
+}>;
+
+export type CreateAdminPhotoOutput = Readonly<{
+  item: AdminPhotoCurationItem;
+}>;
+
+export interface CreateAdminPhotoPort
+  extends UseCase<CreateAdminPhotoInput, CreateAdminPhotoOutput> {}
 
 export type UpdateAdminPhotoCurationInput = Readonly<{
   id: string;

--- a/backend/src/modules/admin/ports/outbound/index.ts
+++ b/backend/src/modules/admin/ports/outbound/index.ts
@@ -174,6 +174,9 @@ export type AdminPhotoCurationRow = Readonly<{
   caption: string | null;
   camera: string | null;
   film: string | null;
+  originalDisplayFilename?: string | null;
+  originalMimeType?: string | null;
+  originalByteSize?: number | null;
   tags: readonly string[];
   updatedAt: Date;
 }>;
@@ -213,6 +216,23 @@ export type UpdateAdminPhotoMetadataCommand = Readonly<{
   caption?: string | null;
   camera?: string | null;
   film?: string | null;
+}>;
+
+export type CreateAdminPhotoCommand = Readonly<{
+  id: string;
+  title: string;
+  frame: string;
+  date: Date;
+  location: string;
+  tags: readonly string[];
+  tone: "amber" | "cyan" | "mono" | "sunset" | "violet";
+  caption: string | null;
+  camera: string | null;
+  film: string | null;
+  originalPath: string;
+  originalDisplayFilename: string;
+  originalMimeType: string;
+  originalByteSize: number;
 }>;
 
 export type AdminStatusStripEntryRepositoryRow = Readonly<{
@@ -258,6 +278,8 @@ export interface AdminRepositoryPort {
   updateThoughtCuration(input: UpdateAdminThoughtCurationCommand): Promise<AdminThoughtCurationRow | null>;
   listProjectsForCuration(query: AdminProjectCurationListQuery): Promise<AdminProjectCurationListPage>;
   updateProjectCuration(input: UpdateAdminProjectCurationCommand): Promise<AdminProjectCurationRow | null>;
+  createPhoto(input: CreateAdminPhotoCommand): Promise<AdminPhotoCurationRow>;
+  findPhotoForCurationById(id: string): Promise<AdminPhotoCurationRow | null>;
   listPhotosForCuration(query: AdminPhotoCurationListQuery): Promise<AdminPhotoCurationListPage>;
   updatePhotoCuration(input: UpdateAdminPhotoCurationCommand): Promise<AdminPhotoCurationRow | null>;
   updatePhotoMetadata(input: UpdateAdminPhotoMetadataCommand): Promise<AdminPhotoCurationRow | null>;

--- a/backend/src/modules/content/application/index.ts
+++ b/backend/src/modules/content/application/index.ts
@@ -318,6 +318,10 @@ export const createListPublishedPhotosUseCase = ({
     });
 
     return {
+      facets: {
+        locations: [...(result.facets?.locations ?? [])],
+        years: [...(result.facets?.years ?? [])],
+      },
       items: result.items.map(mapPhotoSummary),
       pageInfo: {
         page: result.page,

--- a/backend/src/modules/content/ports/inbound/index.ts
+++ b/backend/src/modules/content/ports/inbound/index.ts
@@ -126,6 +126,10 @@ export type ListPublishedPhotosInput = Readonly<{
 
 export type ListPublishedPhotosOutput = Readonly<{
   items: readonly PublishedPhotoSummary[];
+  facets?: Readonly<{
+    years: readonly number[];
+    locations: readonly string[];
+  }>;
   pageInfo: Readonly<{
     page: number;
     pageSize: number;

--- a/backend/src/modules/content/ports/outbound/index.ts
+++ b/backend/src/modules/content/ports/outbound/index.ts
@@ -85,6 +85,10 @@ export type PhotoDetailRepositoryRow = PhotoRepositoryRow &
 
 export type PhotoListPage = Readonly<{
   items: readonly PhotoRepositoryRow[];
+  facets?: Readonly<{
+    years: readonly number[];
+    locations: readonly string[];
+  }>;
   page: number;
   pageSize: number;
   totalItems: number;

--- a/backend/src/modules/media/ports/outbound/index.ts
+++ b/backend/src/modules/media/ports/outbound/index.ts
@@ -3,6 +3,9 @@ export type PhotoMediaRepositoryRow = Readonly<{
   title: string;
   originalReferencePolicy: "backend_media_route" | "filesystem_reference";
   originalReference: string;
+  originalDisplayFilename: string | null;
+  originalMimeType: string | null;
+  originalByteSize: number | null;
   createdAt: Date;
   updatedAt: Date;
 }>;
@@ -31,6 +34,17 @@ export type MediaStorageObject = Readonly<{
   stream: ReadableStream<Uint8Array>;
 }>;
 
+export type PhotoOriginalStorageWriteRequest = Readonly<{
+  body: Uint8Array;
+  storageKey: string;
+}>;
+
+export type PhotoOriginalStorageWriteResult = Readonly<{
+  byteSize: number;
+  storageKey: string;
+  storagePath: string;
+}>;
+
 export type ChatUploadStorageWriteRequest = Readonly<{
   body: Uint8Array;
   storageKey: string;
@@ -43,7 +57,9 @@ export type ChatUploadStorageWriteResult = Readonly<{
 }>;
 
 export interface PhotoMediaStoragePort {
+  deleteOriginal?(storagePath: string): Promise<void>;
   openOriginal(reference: string): Promise<MediaStorageObject | null>;
+  writeOriginal?(input: PhotoOriginalStorageWriteRequest): Promise<PhotoOriginalStorageWriteResult>;
 }
 
 export interface ChatUploadStoragePort {


### PR DESCRIPTION
## Summary

Adds backend support for admin photo original uploads, including multipart validation, deterministic storage keys, draft-first photo creation, cleanup on persistence failure, public photo facets, and admin/private original media access.

## Source spec and acceptance

- Source spec: `docs/specs/photo-catalog-gallery.md`
- Base branch: `develop`
- Merge target: `develop`
- Branch: `backend/PHOTO-002-admin-photo-upload-api`
- Task ID: `PHOTO-002`

## Changes

- Adds `POST /api/admin/photos` for authenticated multipart photo creation.
- Requires `file`, `title`, `frame`, `date`, `location`, and `tone`; accepts optional `tags`, `caption`, `camera`, and `film`.
- Validates JPEG/PNG/WebP MIME type, image magic bytes, required metadata, valid dates, supported tones, and the `25 MB` admin upload limit.
- Creates uploaded records as `draft` and `featured=false`.
- Writes originals through the media storage port under deterministic `YYYY/MM/<photo-id>.<ext>` keys.
- Deletes a written original when DB creation fails.
- Extends filesystem photo storage with original write/delete operations.
- Extends admin repository/use cases/ports for photo creation and admin photo detail lookup.
- Extends public photo list output with stable `facets: { years, locations }`.
- Adds backend tests for upload validation, storage behavior, repository mapping, public facets, and media delivery regressions.

## Impact

Admins can create private draft photo records backed by real stored originals. Public consumers continue to see only published photos, while public list responses gain stable facets for server-side filtering.

## Verification

- `git diff --check` passed in the task worktree.
- `bunx prisma generate` was attempted in the fresh worktree but could not complete because that isolated checkout did not have dependencies installed.
- Full backend checks still need to run in CI or after installing dependencies in the branch worktree:
  - `bunx prisma generate`
  - `bun run typecheck`
  - `bun test`
  - `bun run verify:boundary`
  - `bun run verify:media`
  - `bun run verify`

## Notes

Merge after `PHOTO-001`. This branch intentionally carries the backend schema migration too so it is reviewable as a standalone backend upload slice if needed, but the normal integration order should land the data PR first.