### PR TITLE
PHOTO-004 proxy public photo media in Vite dev server

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
         changeOrigin: true,
         ws: true,
       },
+      '/media/photos': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary
- Task ID: PHOTO-004
- Source tracker entry: Photo Catalog And Admin Upload
- Source spec: docs/specs/photo-catalog-gallery.md
- Adds a Vite dev-server proxy for `/media/photos` so public gallery image URLs resolve to the backend during local development.
- Keeps the public photo DTO contract unchanged: public photos still use `/media/photos/:id/original`.

## Branching
- Base branch: admin/PHOTO-004-admin-photo-management-screen
- Merge target: develop

## Acceptance
- Acceptance source: docs/specs/photo-catalog-gallery.md
- Verification performed:
  - `cd frontend && bun run lint`
  - `cd frontend && bun run build`
- Required CI status checks: standard PR validation for frontend lint/build.

## Notes
- Deployment impact: none expected. Production already routes `/media/photos/*/original` through Caddy to the backend.
- Revert impact: local Vite development would again fail to proxy public photo original URLs, causing public gallery images to fall back to placeholders.
- Follow-up tasks: none for this fix.
