### PR TITLE
INFRA-004 configure development host origins

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -8,6 +8,7 @@ POSTGRES_PASSWORD=change-me-dev
 BACKEND_NODE_ENV=development
 BACKEND_PORT=3000
 FRONTEND_PORT=5173
+FRONTEND_DEV_ALLOWED_HOSTS=development.viniciuslab.dev
 
 # Development placeholders
 AUTH_SESSION_SECRET=development-session-secret
@@ -19,3 +20,7 @@ AUTH_MFA_CODE_MAX_AGE_SECONDS=600
 AUTH_MFA_MAX_ATTEMPTS=5
 AUTH_MFA_RESEND_FROM_EMAIL=
 AUTH_MFA_RESEND_API_KEY=
+
+# Browser origin policy
+CORS_ALLOW_CREDENTIALS=true
+CORS_ALLOWED_ORIGINS=http://localhost:5173,https://development.viniciuslab.dev

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ POSTGRES_PASSWORD=change-me
 BACKEND_NODE_ENV=development
 BACKEND_PORT=3000
 FRONTEND_PORT=5173
+FRONTEND_DEV_ALLOWED_HOSTS=development.viniciuslab.dev
 
 # Required when BACKEND_NODE_ENV=production
 AUTH_SESSION_SECRET=change-me-session-secret
@@ -22,3 +23,7 @@ AUTH_MFA_CODE_MAX_AGE_SECONDS=600
 AUTH_MFA_MAX_ATTEMPTS=5
 AUTH_MFA_RESEND_FROM_EMAIL=Vinicius Dev <no-reply@example.com>
 AUTH_MFA_RESEND_API_KEY=
+
+# Browser origin policy
+CORS_ALLOW_CREDENTIALS=true
+CORS_ALLOWED_ORIGINS=http://localhost:5173,https://development.viniciuslab.dev

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -19,3 +19,7 @@ AUTH_MFA_CODE_MAX_AGE_SECONDS=600
 AUTH_MFA_MAX_ATTEMPTS=5
 AUTH_MFA_RESEND_FROM_EMAIL=Vinicius Dev <no-reply@example.com>
 AUTH_MFA_RESEND_API_KEY=replace-with-resend-api-key
+
+# Browser origin policy
+CORS_ALLOW_CREDENTIALS=true
+CORS_ALLOWED_ORIGINS=https://viniciuslab.dev

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,5 +8,7 @@ services:
 
   frontend:
     command: sh -c "bun install --frozen-lockfile && bun run dev --host 0.0.0.0 --port ${FRONTEND_PORT:-5173}"
+    environment:
+      FRONTEND_DEV_ALLOWED_HOSTS: ${FRONTEND_DEV_ALLOWED_HOSTS:-}
     volumes:
       - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       AUTH_MFA_MAX_ATTEMPTS: ${AUTH_MFA_MAX_ATTEMPTS:-5}
       AUTH_MFA_RESEND_FROM_EMAIL: ${AUTH_MFA_RESEND_FROM_EMAIL:-}
       AUTH_MFA_RESEND_API_KEY: ${AUTH_MFA_RESEND_API_KEY:-}
+      CORS_ALLOW_CREDENTIALS: ${CORS_ALLOW_CREDENTIALS:-true}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
       MEDIA_PHOTOS_ROOT: /var/lib/vinicius.dev/media/photos
       MEDIA_CHAT_ROOT: /var/lib/vinicius.dev/media/chat
     depends_on:

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -178,6 +178,11 @@ Done criteria for `CHAT-010`:
   - Follow-up start: branch `infra/SEC-009-development-csp-vite-fix` opened to fix the development host CSP regression where Vite's React-refresh preamble was blocked.
   - Follow-up local verification: production/dev compose config rendering and Caddy config validation passed on 2026-05-05.
   - Follow-up PR/Open review: PR [#134](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/134) opened against `develop`.
+- INFRA-004 status log:
+  - Start: branch `infra/INFRA-004-development-host-origin-config` moved to `In Progress`.
+  - Blocker: none.
+  - Scope: add explicit Vite development host allowlisting for `development.viniciuslab.dev`, pass backend CORS env through compose, and document the development runtime env contract.
+  - Local verification: frontend lint/build plus development and production compose config rendering passed on 2026-05-05.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -191,6 +196,7 @@ Done criteria for `CHAT-010`:
 | Done | SEC-007 | SPEC-031 | frontend | develop | `frontend/SEC-007-chat-session-storage-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#130](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/130) merged | — |
 | Done | SEC-008 | SPEC-031 | backend | develop | `backend/SEC-008-chat-crypto-and-audit-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#131](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/131) merged | — |
 | Done | SEC-009 | SPEC-031 | infra | develop | `infra/SEC-009-edge-headers-and-production-compose` | develop | `docs/specs/security-hardening-production-readiness.md` | [#132](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/132) merged | — |
+| In Progress | INFRA-004 | SPEC-031 | infra | develop | `infra/INFRA-004-development-host-origin-config` | develop | `docs/specs/infra-deployment.md`, `docs/specs/security-hardening-production-readiness.md` | not opened | — |
 
 Done criteria for `SPEC-031`:
 - `docs/specs/security-hardening-production-readiness.md` exists and follows the harness section template
@@ -198,6 +204,13 @@ Done criteria for `SPEC-031`:
 - task IDs, branch names, dependencies, and verification methods are defined for the remediation wave
 - `docs/specs/tracker.md` and `docs/specs/README.md` are updated to register the spec and implementation task queue
 - implementation tasks are registered in the tracker with branch metadata, acceptance source, and execution order
+
+Done criteria for `INFRA-004`:
+- Vite development server allowlists `development.viniciuslab.dev` through an explicit server-only env value, not a wildcard host policy.
+- Development compose passes the Vite host allowlist to the frontend service.
+- Backend CORS env is wired through compose and sample env files include development and production origin policies.
+- Infra docs explain the development Vite host requirement.
+- Frontend lint/build and development/production compose config rendering pass.
 
 ### Testing Coverage Foundation
 - Status: tasked locally; implementation branches are being split for separate review.

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -183,6 +183,7 @@ Done criteria for `CHAT-010`:
   - Blocker: none.
   - Scope: add explicit Vite development host allowlisting for `development.viniciuslab.dev`, pass backend CORS env through compose, and document the development runtime env contract.
   - Local verification: frontend lint/build plus development and production compose config rendering passed on 2026-05-05.
+  - PR/Open review: PR [#149](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/149) opened against `develop`.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -196,7 +197,7 @@ Done criteria for `CHAT-010`:
 | Done | SEC-007 | SPEC-031 | frontend | develop | `frontend/SEC-007-chat-session-storage-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#130](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/130) merged | — |
 | Done | SEC-008 | SPEC-031 | backend | develop | `backend/SEC-008-chat-crypto-and-audit-hardening` | develop | `docs/specs/security-hardening-production-readiness.md` | [#131](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/131) merged | — |
 | Done | SEC-009 | SPEC-031 | infra | develop | `infra/SEC-009-edge-headers-and-production-compose` | develop | `docs/specs/security-hardening-production-readiness.md` | [#132](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/132) merged | — |
-| In Progress | INFRA-004 | SPEC-031 | infra | develop | `infra/INFRA-004-development-host-origin-config` | develop | `docs/specs/infra-deployment.md`, `docs/specs/security-hardening-production-readiness.md` | not opened | — |
+| In Review | INFRA-004 | SPEC-031 | infra | develop | `infra/INFRA-004-development-host-origin-config` | develop | `docs/specs/infra-deployment.md`, `docs/specs/security-hardening-production-readiness.md` | [#149](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/149) | — |
 
 Done criteria for `SPEC-031`:
 - `docs/specs/security-hardening-production-readiness.md` exists and follows the harness section template

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const parseAllowedHosts = (value: string | undefined) =>
+  value
+    ?.split(',')
+    .map((host) => host.trim())
+    .filter((host) => host.length > 0) ?? []
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
+    allowedHosts: parseAllowedHosts(process.env.FRONTEND_DEV_ALLOWED_HOSTS),
     proxy: {
       '/api': {
         target: 'http://localhost:3000',

--- a/infra/README.md
+++ b/infra/README.md
@@ -11,6 +11,8 @@
 - Base: `docker-compose.yml` (shared and production-safe defaults).
 - Development override: `docker-compose.dev.yml` (source bind mounts and install-on-start workflow).
 
+The development override runs the Vite dev server behind Caddy for `development.viniciuslab.dev`, so `FRONTEND_DEV_ALLOWED_HOSTS` must explicitly include that hostname.
+
 ## Production runtime baseline
 
 - Backend image is built from `backend/Dockerfile` with `bun install --frozen-lockfile` and Prisma client generation during image build.


### PR DESCRIPTION
## Summary

Configure the development VPS runtime origins for `INFRA-004` under `SPEC-031`.

This PR adds explicit Vite dev-server host allowlisting for `development.viniciuslab.dev`, passes backend CORS policy through Docker Compose, updates env examples for development and production origin policy, and documents the development host requirement in the infra README.

## Source And Acceptance

- Source spec: `SPEC-031`
- Acceptance sources: `docs/specs/infra-deployment.md`, `docs/specs/security-hardening-production-readiness.md`
- Base branch: `develop`
- Merge target: `develop`

## Motivation

The VPS development host needs an explicit Vite allowed-host configuration and backend CORS env contract so browser requests from `development.viniciuslab.dev` work without broad wildcard host/origin policy.

## Verification

- `frontend`: `bun run lint`
- `frontend`: `bun run build`
- repo root: `docker compose --env-file .env.dev.example -f docker-compose.yml -f docker-compose.dev.yml config`
- repo root: `docker compose --env-file .env.prod.example -f docker-compose.yml config`

The dev compose render includes `FRONTEND_DEV_ALLOWED_HOSTS=development.viniciuslab.dev` and `CORS_ALLOWED_ORIGINS=http://localhost:5173,https://development.viniciuslab.dev`. The production compose render includes `CORS_ALLOWED_ORIGINS=https://viniciuslab.dev`.