### PR TITLE
INFRA-004 default development Vite host allowlist

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,6 +9,6 @@ services:
   frontend:
     command: sh -c "bun install --frozen-lockfile && bun run dev --host 0.0.0.0 --port ${FRONTEND_PORT:-5173}"
     environment:
-      FRONTEND_DEV_ALLOWED_HOSTS: ${FRONTEND_DEV_ALLOWED_HOSTS:-}
+      FRONTEND_DEV_ALLOWED_HOSTS: ${FRONTEND_DEV_ALLOWED_HOSTS:-development.viniciuslab.dev}
     volumes:
       - .:/app

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -184,6 +184,7 @@ Done criteria for `CHAT-010`:
   - Scope: add explicit Vite development host allowlisting for `development.viniciuslab.dev`, pass backend CORS env through compose, and document the development runtime env contract.
   - Local verification: frontend lint/build plus development and production compose config rendering passed on 2026-05-05.
   - PR/Open review: PR [#149](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/149) opened against `develop`.
+  - Follow-up local execution: development compose now defaults the Vite host allowlist to `development.viniciuslab.dev` when the VPS env file omits `FRONTEND_DEV_ALLOWED_HOSTS`.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -185,6 +185,7 @@ Done criteria for `CHAT-010`:
   - Local verification: frontend lint/build plus development and production compose config rendering passed on 2026-05-05.
   - PR/Open review: PR [#149](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/149) opened against `develop`.
   - Follow-up local execution: development compose now defaults the Vite host allowlist to `development.viniciuslab.dev` when the VPS env file omits `FRONTEND_DEV_ALLOWED_HOSTS`.
+  - Follow-up PR/Open review: PR [#150](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/150) opened against `develop`.
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/infra/README.md
+++ b/infra/README.md
@@ -11,7 +11,7 @@
 - Base: `docker-compose.yml` (shared and production-safe defaults).
 - Development override: `docker-compose.dev.yml` (source bind mounts and install-on-start workflow).
 
-The development override runs the Vite dev server behind Caddy for `development.viniciuslab.dev`, so `FRONTEND_DEV_ALLOWED_HOSTS` must explicitly include that hostname.
+The development override runs the Vite dev server behind Caddy for `development.viniciuslab.dev`, so `FRONTEND_DEV_ALLOWED_HOSTS` must explicitly include that hostname. The override defaults to `development.viniciuslab.dev` to keep the manual VPS deployment working when an older development env file has not been updated yet.
 
 ## Production runtime baseline
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #149 for `INFRA-004`.

This PR defaults the development Docker Compose Vite host allowlist to `development.viniciuslab.dev` when `FRONTEND_DEV_ALLOWED_HOSTS` is omitted by the VPS env file. It also documents the fallback in the infra README and records the follow-up in the spec tracker.

## Source And Acceptance

- Source spec: `SPEC-031`
- Acceptance sources: `docs/specs/infra-deployment.md`, `docs/specs/security-hardening-production-readiness.md`
- Base branch: `develop`
- Merge target: `develop`
- Branch: `infra/INFRA-004-development-host-origin-config`

## Motivation

The previous fix passed `FRONTEND_DEV_ALLOWED_HOSTS` through compose, but the development override defaulted it to an empty value. If the VPS env file was not updated before redeploy, Vite still rejected `development.viniciuslab.dev` with the allowed-hosts error. This keeps the host policy explicit without relying on a wildcard or a perfectly current env file.

## Verification

- `frontend`: `bun run lint`
- `frontend`: `bun run build`
- repo root: `FRONTEND_DEV_ALLOWED_HOSTS= docker compose --env-file .env.dev.example -f docker-compose.yml -f docker-compose.dev.yml config frontend`
- repo root: `docker compose --env-file .env.prod.example -f docker-compose.yml config frontend`

The development compose render includes `FRONTEND_DEV_ALLOWED_HOSTS: development.viniciuslab.dev` even when the invoking environment sets it empty. The production compose render remains on the built frontend service path.