### PR TITLE
SPEC-034 Agent onboarding docs refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ pnpm-debug.log*
 
 # Local overrides
 /docker-compose.override.yml
+.agents/
 
 # OS/editor files
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,138 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents working in this repository. Read it before tasking, branching, or implementing.
+
+## Hard guardrails
+
+- Never read inside `node_modules`.
+- Never run `git push origin master`.
+- Before any Git command, read [docs/specs/git-workflow.md](docs/specs/git-workflow.md).
+- Do not rewrite shared history or revert user changes unless the user explicitly asks for that operation.
+
+## Repository overview
+
+`vinicius.dev` is a personal site driven by a spec harness in [docs/specs/](docs/specs/). Treat the harness as the source of truth before creating tasks, branches, or implementation changes.
+
+Current repo areas:
+
+- [frontend/](frontend/) - Vite + React 19 + TypeScript + Bun app using strict Feature-Sliced Design, React Router Data Mode, and public/admin shells.
+- [backend/](backend/) - Bun + Hono + Prisma + Postgres service using a hexagonal layout with modules at the core and adapters at the edge.
+- [infra/](infra/) - Caddy and deployment-facing infrastructure docs/config.
+- [.github/workflows/](.github/workflows/) - CI validation and tag-based production deployment workflows.
+- [docs/specs/](docs/specs/) - canonical specs, tracker, acceptance rules, Git workflow, and verification policy.
+- [.agents/skills/](.agents/skills/) - local agent skills, including the Vinicius.Dev design system skill.
+- [scripts/](scripts/) - repo-root GitHub Project/task helper scripts.
+
+## Source of truth: the spec harness
+
+Always start at [docs/specs/README.md](docs/specs/README.md). The order to read is fixed there:
+
+1. [tracker.md](docs/specs/tracker.md) - gate statuses, global decisions, and approved work.
+2. [git-workflow.md](docs/specs/git-workflow.md) - mandatory branching/review rules. Read this before any Git command.
+3. [frontend-structure.md](docs/specs/frontend-structure.md) before frontend, admin UI, or frontend verification work.
+4. [frontend-architecture.md](docs/specs/frontend-architecture.md) before frontend route, loader/action, or shell work.
+5. [project-structure.md](docs/specs/project-structure.md) before backend, data, media, infra, or backend verification work.
+6. [ci-cd.md](docs/specs/ci-cd.md) before release/deployment automation or final verification.
+
+Only act on specs in `Approved` or specs explicitly assigned for authoring/review. Do not silently override locked product decisions when adapting specs to existing code.
+
+## Locked stack
+
+- **Frontend**: React 19 + Vite + TypeScript + Bun. Strict Feature-Sliced Design with layers `app`, `pages`, `widgets`, `features`, `entities`, `shared` (no `processes`). Routing uses React Router Data Mode (`createBrowserRouter` + `RouterProvider`). One app, two shells under `src/app/{public-shell,admin-shell}`.
+- **Backend**: Bun + Hono + Prisma + Postgres. Hexagonal layout: domain/application logic in `src/modules/<domain>`, technology edges in `src/adapters/{inbound,outbound}`.
+- **Deploy**: Docker on a VPS behind Caddy. `develop` deploys manually to `development.viniciuslab.dev`; production deploys only from `v*` tags pointing at commits on `main`. CI must not deploy from branch pushes.
+
+## Frontend creation workflow
+
+Before creating or materially changing frontend UI:
+
+1. Read [frontend-structure.md](docs/specs/frontend-structure.md) and [frontend-architecture.md](docs/specs/frontend-architecture.md).
+2. Use the `viniciusdev-design` skill at [.agents/skills/vinicius.dev-website-guidelines/SKILL.md](.agents/skills/vinicius.dev-website-guidelines/SKILL.md).
+3. Read the skill's [README.md](.agents/skills/vinicius.dev-website-guidelines/README.md), [GUIDELINES.md](.agents/skills/vinicius.dev-website-guidelines/GUIDELINES.md), and [colors_and_type.css](.agents/skills/vinicius.dev-website-guidelines/colors_and_type.css).
+4. Check [preview/interactive-components.html](.agents/skills/vinicius.dev-website-guidelines/preview/interactive-components.html) before implementing forms, modals, toasts, feedback, or interactive controls.
+5. Check [ui_kits/vinicius-dev/](.agents/skills/vinicius.dev-website-guidelines/ui_kits/vinicius-dev/) before building new pages, and reuse or adapt the existing `Hero`, `Nav`, `ChannelBug`, `StatusStrip`, and `Footer` patterns where they fit.
+6. Keep brand rules intact: rectangular geometry, existing tokens only, restrained neon, no emoji, no rounded UI, and reduced-motion support for animation.
+
+## Commands
+
+Run commands from each package directory unless noted.
+
+### Frontend (`cd frontend`)
+
+- `bun install`
+- `bun run dev` - Vite dev server.
+- `bun run build` - `tsc -b && vite build`.
+- `bun run lint` - ESLint over the package.
+- `bun run test` - Vitest test suite.
+- `bun run test:coverage` - report-only Vitest coverage.
+- `bun run preview` - preview the production build.
+
+### Backend (`cd backend`)
+
+- `bun install`
+- `bun run dev` - `bun --watch src/bootstrap/server.ts`.
+- `bun run start` / `bun run build`
+- `bun run typecheck` - `tsc --noEmit`.
+- `bun test` or `bun run test` - Bun test runner. Single test: `bun test <path>`.
+- `bun run test:coverage` - report-only Bun coverage.
+- `bun run test:db` - focused Prisma/Postgres contract tests; requires `DATABASE_URL`.
+- `bun run seed` - deterministic seed baseline.
+- `bun run verify` - boundary, persistence, media, selected route/integration, and deploy-readiness checks.
+- `bun run verify:boundary` - enforces hexagonal layering.
+- `bun run verify:media` - focused media/chat/photo regression checks.
+- `bun run prisma:format`, `bun run prisma:validate`, `bun run prisma:generate`, `bun run prisma:migrate:status`, `bun run prisma:check`
+- Local DB work requires `.env` with `DATABASE_URL` pointing at Postgres.
+
+### Repo-root scripts
+
+- `bun scripts/gh-project-bootstrap.ts` - bootstrap GitHub Project fields/options.
+- `bun scripts/gh-task-create.ts` - create the linked Issue + Project item from a task brief.
+- `bun scripts/gh-task-progress.ts` - update Project status or post issue comments as work moves.
+
+### CI
+
+Workflow files live under [.github/workflows/](.github/workflows/). For CI policy and intended behavior, read [docs/specs/ci-cd.md](docs/specs/ci-cd.md) and [docs/specs/ci-workflow-maintenance.md](docs/specs/ci-workflow-maintenance.md).
+
+## Architecture notes
+
+### Frontend FSD discipline
+
+- The route tree is owned only by `src/app/routes`. Other layers do not declare routes.
+- Public and admin shells live under `src/app/{public-shell,admin-shell}` and are the only places that compose route-level layout.
+- Every slice/segment must expose a public API, and external code may import only that public API.
+- Segments are purpose-driven: `ui`, `api`, `model`, `lib`, `config`. Avoid catch-all `components/`, `hooks`, and `types`.
+- Server data and mutations default to React Router loaders/actions. Local component state is the default client model; no global store by default.
+- FSD is enforced by spec and review, not a dedicated lint rule yet.
+
+### Backend hexagonal layout
+
+- `src/modules/<domain>` (admin, auth, chat, content, media, shared) holds domain/application logic and must not import from `src/adapters`.
+- `src/adapters/inbound/http/...` mounts Hono routes.
+- `src/adapters/outbound/{persistence,storage,...}` holds Prisma, filesystem, mail, and provider implementations.
+- `src/bootstrap/` wires configuration, dependency construction, and server startup.
+- Public API surface is mounted under `/api`; public photo originals use `/media/photos/:id/original`.
+- Pagination is required from day one: cursor for Thoughts and Chat; page-based for Projects and Photos.
+
+### Data model and media
+
+Read [docs/specs/data-model.md](docs/specs/data-model.md) and [docs/specs/media-storage.md](docs/specs/media-storage.md) before adding Prisma models, upload paths, media delivery, or moderation logic. Schema lives at [backend/prisma/schema.prisma](backend/prisma/schema.prisma); generated client lives at [backend/generated/prisma/](backend/generated/prisma/).
+
+## Git and GitHub workflow
+
+Full rules live in [docs/specs/git-workflow.md](docs/specs/git-workflow.md). Summary:
+
+- `main` is stable; `develop` is the integration branch. Every task gets its own branch.
+- Branch pattern: `type/TASK-ID-short-slug`. Approved prefixes: `spec/`, `frontend/`, `backend/`, `data/`, `admin/`, `infra/`, `hotfix/`.
+- Spec and implementation branches base off `develop`; hotfixes branch off `main` and merge back into both.
+- No self-merge. Every branch needs review. Use merge commits for integration, not squash/rebase.
+- Reverts revert commits or merge commits; never rewrite shared history.
+- Commit messages and PR titles must include the task ID. Commits must be signed off with `git commit -s -m "..."`.
+- Every executable task maps to one spec, one task ID, one branch, one tracker entry, and one acceptance source.
+- GitHub Issues and Project items are optional for normal task tracking unless the active task/spec explicitly requires them.
+- PR descriptions must include the source spec, acceptance source, base branch, merge target, and verification performed.
+
+## Authoring conventions
+
+- Spec docs follow the section template in [docs/specs/acceptance-criteria.md](docs/specs/acceptance-criteria.md).
+- When spec assumptions change, update [docs/specs/tracker.md](docs/specs/tracker.md) in the same task.
+- Keep doc-only changes separate from runtime code changes unless a spec explicitly ties them together.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -38,7 +38,7 @@ This harness does not contain implementation code.
 1. Read [ci-cd.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/ci-cd.md) before release automation, deployment automation, or final verification work.
 1. Work only from specs that are in `Approved` or explicitly assigned for spec authoring/review.
 1. Map each task to one spec, one task ID, one branch, one tracker entry, and one acceptance source.
-1. . For execution work, keep `tracker.md` aligned with branch, PR, and merge state.
+1. For execution work, keep `tracker.md` aligned with branch, PR, and merge state.
 
 ## Spec Lifecycle
 - `Draft`: not ready for task splitting
@@ -46,8 +46,8 @@ This harness does not contain implementation code.
 - `Approved`: ready to drive tasks
 - `Tasked`: already split into implementation work
 
-No frontend-facing spec may move to `Tasked` until [frontend-structure.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-structure.md) is approved and frontend intake is complete or explicitly marked not applicable.
-No backend-facing spec may move to `Tasked` until [project-structure.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/project-structure.md) is approved and frontend intake is complete or explicitly marked not applicable.
+No frontend-facing spec may move to `Tasked` until [frontend-structure.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-structure.md) is approved and any required frontend reconciliation is complete or explicitly marked not applicable.
+No backend-facing spec may move to `Tasked` until [project-structure.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/project-structure.md) is approved and any required frontend contract review is complete or explicitly marked not applicable.
 
 ## Canonical Files
 - [tracker.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/tracker.md)
@@ -57,6 +57,7 @@ No backend-facing spec may move to `Tasked` until [project-structure.md](/Users/
 - [github-project-execution.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/github-project-execution.md)
 - [product-scope.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/product-scope.md)
 - [design-system.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/design-system.md)
+- [agent-onboarding-refresh.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/agent-onboarding-refresh.md)
 - [frontend-structure.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-structure.md)
 - [frontend-architecture.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-architecture.md)
 - [frontend-admin-auth-integration.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-admin-auth-integration.md)
@@ -79,4 +80,4 @@ No backend-facing spec may move to `Tasked` until [project-structure.md](/Users/
 - Reference task IDs in branch names, commits, and PR titles.
 - Reference task IDs, source specs, and status updates in `tracker.md`.
 - Do not silently override locked product decisions when adapting specs to an existing frontend.
-- Update the tracker and analyzer report when spec assumptions change.
+- Update the tracker when spec assumptions change.

--- a/docs/specs/admin-cms.md
+++ b/docs/specs/admin-cms.md
@@ -82,5 +82,5 @@ Admin authentication, CRUD operations, publication controls, featured content se
 - Keep admin draft preview out of Wave 2 task definitions.
 
 ## Git Branch Implications
-- Admin work uses `admin/`, `fe/`, `be/`, or `spec/` branches depending on the change surface.
+- Admin work uses `admin/`, `frontend/`, `backend/`, or `spec/` branches depending on the change surface.
 - Do not mix admin auth tasks with unrelated public frontend work in the same branch.

--- a/docs/specs/agent-onboarding-refresh.md
+++ b/docs/specs/agent-onboarding-refresh.md
@@ -1,0 +1,69 @@
+# Agent Onboarding Docs Refresh
+
+## Purpose
+Define the documentation-only refresh that keeps `AGENTS.md` and adjacent agent onboarding references aligned with the current repository shape, spec harness, Git workflow, and Vinicius.Dev frontend design workflow.
+
+## Scope
+This spec covers repo onboarding docs, harness registry updates, stale spec dependency references, and local skill/UI-kit documentation for frontend creation.
+
+This spec does not cover runtime code, product behavior, API contracts, database schema, deployment behavior, or automated documentation tooling.
+
+## Locked Decisions
+- `AGENTS.md` is the primary repository onboarding file for coding agents.
+- Agent onboarding must describe the current repo areas: `frontend/`, `backend/`, `infra/`, `.github/workflows/`, `docs/specs/`, `.agents/skills/`, and root `scripts/`.
+- Agent onboarding must include the hard guardrails: never read `node_modules`, never run `git push origin master`, and read `docs/specs/git-workflow.md` before any Git command.
+- Frontend UI creation must start from `frontend-structure.md`, `frontend-architecture.md`, and the `viniciusdev-design` skill.
+- The canonical Vinicius.Dev brand/UI implementation source is `.agents/skills/vinicius.dev-website-guidelines/`.
+- `ui_kits/vinicius-dev/` must be checked before creating new frontend pages or page-level visual patterns.
+- Missing `design-system.md` references are resolved through a bridge spec instead of duplicating the skill content inside the harness.
+- Stale dependencies on missing frontend intake/analyzer docs must be removed or replaced with existing current specs.
+
+## Interfaces And Responsibilities
+- `AGENTS.md` owns concise, actionable agent onboarding and should point into the harness instead of restating every spec.
+- `docs/specs/design-system.md` is a bridge that points specs to the local `viniciusdev-design` skill as the canonical design source.
+- `docs/specs/README.md` owns canonical spec registration and agent workflow ordering.
+- `docs/specs/tracker.md` owns task metadata, branch names, acceptance sources, and status.
+- `.agents/skills/vinicius.dev-website-guidelines/README.md` and `ui_kits/vinicius-dev/README.md` must name actual files present in the skill directory.
+- Existing architecture specs should depend only on files that exist in `docs/specs/` unless they intentionally reference an external/local skill path.
+
+## Data/Contracts Touched
+- `AGENTS.md` onboarding contract
+- spec harness registry
+- tracker task metadata
+- design-system dependency references
+- frontend creation workflow references
+- local skill and UI-kit file inventory docs
+
+## Acceptance Checklist
+- [ ] `docs/specs/agent-onboarding-refresh.md` exists and follows the harness section template.
+- [ ] `docs/specs/README.md` registers `agent-onboarding-refresh.md`.
+- [ ] `docs/specs/tracker.md` registers `SPEC-034` and `DOCS-001` with branch names, base branch, merge target, and acceptance source.
+- [ ] `AGENTS.md` describes the current repo areas and package command surface, including frontend `test`/`test:coverage` and backend `test:coverage`/`test:db`.
+- [ ] `AGENTS.md` includes the hard guardrails for `node_modules`, `git push origin master`, and reading `git-workflow.md` before Git.
+- [ ] `AGENTS.md` documents the frontend creation workflow through the `viniciusdev-design` skill, `colors_and_type.css`, `preview/interactive-components.html`, and `ui_kits/vinicius-dev/`.
+- [ ] Missing `design-system.md` references are resolved by an existing bridge spec or by replacing the references with current docs.
+- [ ] No references to missing frontend intake/analyzer docs remain unless those files are restored in the same task.
+- [ ] Local skill/UI-kit docs no longer name absent component files.
+- [ ] Link checks confirm all touched Markdown paths point to existing files or directories.
+- [ ] Explicit non-goal: no runtime code, schema, deployment, or product behavior changes.
+
+## Dependencies
+- [README.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/README.md)
+- [tracker.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/tracker.md)
+- [acceptance-criteria.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/acceptance-criteria.md)
+- [git-workflow.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/git-workflow.md)
+- [frontend-structure.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-structure.md)
+- [frontend-architecture.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-architecture.md)
+
+## Open Questions
+- Whether a future automated Markdown link checker should enforce this contract can be decided in a separate verification task.
+
+## Task-Splitting Notes
+- `SPEC-034` covers the spec and harness registration.
+- `DOCS-001` covers the onboarding document refresh and adjacent stale-reference cleanup.
+- Keep this docs-only cluster separate from runtime frontend/backend changes.
+
+## Git Branch Implications
+- Spec work uses `spec/SPEC-034-agent-onboarding-refresh`.
+- Onboarding implementation work uses `spec/DOCS-001-agent-onboarding-docs-refresh`.
+- Both branches base from `develop`, merge to `develop`, include task IDs in commits and PR titles, and require review.

--- a/docs/specs/backend-architecture.md
+++ b/docs/specs/backend-architecture.md
@@ -91,8 +91,6 @@ Backend runtime, one application hexagon, module-first core structure, Hono inte
 - [ ] Explicit non-goal: exact file names inside each module may vary as long as the boundary rules and contracts stay intact.
 
 ## Dependencies
-- [frontend-intake.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-intake.md)
-- [frontend-analyzer.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-analyzer.md)
 - [product-scope.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/product-scope.md)
 - [frontend-architecture.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-architecture.md)
 - [project-structure.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/project-structure.md)
@@ -109,5 +107,5 @@ Backend runtime, one application hexagon, module-first core structure, Hono inte
 - Backend task briefs should name the core use case and required ports before naming concrete adapters.
 
 ## Git Branch Implications
-- Backend spec or implementation work uses `be/` or `spec/` branches with explicit task IDs.
-- Backend tasks must cite both the analyzer report revision and `project-structure.md` when frontend intake is applicable.
+- Backend spec or implementation work uses `backend/` or `spec/` branches with explicit task IDs.
+- Backend tasks must cite `project-structure.md` and the relevant frontend contract specs when frontend compatibility is applicable.

--- a/docs/specs/data-model.md
+++ b/docs/specs/data-model.md
@@ -66,8 +66,6 @@ Entity boundaries, key relationships, state fields, module ownership, and data o
 - [ ] Explicit non-goal: exhaustive schema column names are not required at this spec stage.
 
 ## Dependencies
-- [frontend-intake.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-intake.md)
-- [frontend-analyzer.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-analyzer.md)
 - [product-scope.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/product-scope.md)
 - [frontend-architecture.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-architecture.md)
 - [project-structure.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/project-structure.md)

--- a/docs/specs/design-system.md
+++ b/docs/specs/design-system.md
@@ -1,0 +1,50 @@
+# Design System
+
+## Purpose
+Bridge spec-harness design-system references to the local Vinicius.Dev brand and UI skill that contains the canonical implementation guidance.
+
+## Scope
+This file defines where agents find brand, visual, component, interaction, and frontend creation guidance for Vinicius.Dev UI work.
+
+This file does not duplicate the full design system content and does not define runtime code.
+
+## Locked Decisions
+- The canonical design source is the `viniciusdev-design` skill at `.agents/skills/vinicius.dev-website-guidelines/`.
+- Frontend UI work must read the skill manifest, brand README, full guidelines, token CSS, interactive previews, and UI kit before creating new visual patterns.
+- The active UI kit path is `.agents/skills/vinicius.dev-website-guidelines/ui_kits/vinicius-dev/`.
+- The active token source is `.agents/skills/vinicius.dev-website-guidelines/colors_and_type.css`.
+- The design language keeps rectangular geometry, restrained CRT/arcade visual references, existing tokens only, no emoji, and reduced-motion support.
+
+## Interfaces And Responsibilities
+- `.agents/skills/vinicius.dev-website-guidelines/SKILL.md` owns the agent-facing skill trigger, core rules, and quick reference.
+- `.agents/skills/vinicius.dev-website-guidelines/README.md` owns brand context and source inventory.
+- `.agents/skills/vinicius.dev-website-guidelines/GUIDELINES.md` owns the full UI/UX implementation spec.
+- `.agents/skills/vinicius.dev-website-guidelines/colors_and_type.css` owns color, type, spacing, shadow, and CRT primitive tokens.
+- `.agents/skills/vinicius.dev-website-guidelines/preview/interactive-components.html` owns interactive component reference patterns.
+- `.agents/skills/vinicius.dev-website-guidelines/ui_kits/vinicius-dev/` owns the assembled landing-page kit and reusable page patterns.
+
+## Data/Contracts Touched
+- frontend UI visual conventions
+- shared style token references
+- local skill and UI-kit file paths
+- documentation dependencies that refer to `design-system.md`
+
+## Acceptance Checklist
+- [ ] Specs that depend on `design-system.md` have an existing file to resolve.
+- [ ] The bridge points to the canonical `viniciusdev-design` skill path.
+- [ ] The bridge names the token CSS, interactive preview, and `ui_kits/vinicius-dev/` path.
+- [ ] The bridge stays documentation-only and does not duplicate the full skill content.
+
+## Dependencies
+- [frontend-structure.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-structure.md)
+- [frontend-architecture.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-architecture.md)
+
+## Open Questions
+- Whether the skill content should later be mirrored into a fully versioned spec can be decided separately.
+
+## Task-Splitting Notes
+- Design-system changes should update the skill source first, then this bridge only if canonical paths or responsibilities change.
+- Frontend implementation tasks should cite this file only as a pointer; the skill files remain the detailed acceptance source for visual behavior.
+
+## Git Branch Implications
+- Design documentation bridge changes use `spec/` branches and should not be mixed with runtime UI implementation.

--- a/docs/specs/frontend-architecture.md
+++ b/docs/specs/frontend-architecture.md
@@ -32,7 +32,7 @@ Frontend runtime, route model, migration gates, data-fetching expectations, shel
 - Define shared layout and token usage patterns.
 - Define API consumption boundaries for content, auth, chat, uploads, and status strip data.
 - Define how the frontend represents filters, featured content, and moderation/admin actions.
-- Reconcile existing frontend assumptions via the analyzer before backend tasking.
+- Reconcile existing frontend assumptions through repo review and the approved frontend specs before backend tasking.
 
 ## Data/Contracts Touched
 - route paths
@@ -55,14 +55,12 @@ Frontend runtime, route model, migration gates, data-fetching expectations, shel
 - [ ] Public and admin shells are defined inside one frontend app.
 - [ ] `frontend-structure.md` is referenced as the structural source of truth for folders, slices, and layer rules.
 - [ ] API boundaries are documented for public content, admin, auth, chat, and uploads.
-- [ ] Frontend assumptions can be reconciled to analyzer findings.
+- [ ] Frontend assumptions can be reconciled to the current implementation and approved specs.
 - [ ] Shared tokens and layout rules align with the design system.
 - [ ] Thoughts, Chat Room, and Admin exist as fully designed screens before backend tasking is considered unblocked.
 - [ ] Explicit non-goal: no frontend implementation is defined here beyond architecture and contracts.
 
 ## Dependencies
-- [frontend-intake.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-intake.md)
-- [frontend-analyzer.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-analyzer.md)
 - [product-scope.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/product-scope.md)
 - [design-system.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/design-system.md)
 - [frontend-structure.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-structure.md)
@@ -73,9 +71,9 @@ Frontend runtime, route model, migration gates, data-fetching expectations, shel
 
 ## Task-Splitting Notes
 - Reconcile imported frontend structure before splitting feature work.
-- If the imported frontend is legacy-shaped, the first frontend tasks are: archive current frontend, scaffold a clean Vite React TypeScript app, establish the `app/routes` tree and shell structure, migrate landing, migrate projects, migrate photos, implement Thoughts, implement Chat Room, implement Admin, then re-run analyzer.
+- If the imported frontend is legacy-shaped, the first frontend tasks are: archive current frontend, scaffold a clean Vite React TypeScript app, establish the `app/routes` tree and shell structure, migrate landing, migrate projects, migrate photos, implement Thoughts, implement Chat Room, implement Admin, then re-run structural review against this spec.
 - Page-level frontend tasks should depend on this spec, [frontend-structure.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-structure.md), and the relevant product or design spec.
 
 ## Git Branch Implications
-- Frontend architecture changes require `fe/` or `spec/` branches depending on whether the change is code or spec.
+- Frontend architecture changes require `frontend/` or `spec/` branches depending on whether the change is code or spec.
 - Imported frontend reconciliation should be isolated from unrelated backend tasks.

--- a/docs/specs/frontend-structure.md
+++ b/docs/specs/frontend-structure.md
@@ -139,7 +139,6 @@ frontend/
 
 ## Dependencies
 - [README.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/README.md)
-- [frontend-analyzer.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-analyzer.md)
 - [product-scope.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/product-scope.md)
 - [design-system.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/design-system.md)
 
@@ -154,5 +153,5 @@ frontend/
 - Avoid bundling broad structural refactors with visual redesign or data-contract changes in the same task.
 
 ## Git Branch Implications
-- Frontend structure changes use `fe/` or `spec/` branches depending on whether code or spec is changing.
+- Frontend structure changes use `frontend/` or `spec/` branches depending on whether code or spec is changing.
 - Tasks that reshape FSD slice boundaries or route shells must be isolated from unrelated backend or design work.

--- a/docs/specs/github-project-execution.md
+++ b/docs/specs/github-project-execution.md
@@ -61,7 +61,7 @@ Applies to task decomposition, tracker entry setup, tracker status updates, PR l
 ## Acceptance Checklist
 - [ ] `tracker.md` is the canonical execution record for `vinicius.dev` tasks.
 - [ ] Task-definition flow creates tracker entries instead of relying on GitHub Issues or Project items.
-- [ ] Frontend migration tasks are still defined before backend tasks when the analyzer still reports frontend blockers.
+- [ ] Frontend migration tasks are still defined before backend tasks when frontend contract review still reports blockers.
 - [ ] Implementation agents are required to update the tracker at start, blocker, review, and completion or handoff.
 - [ ] Tracker status flow is defined as `Spec-ready -> Todo -> In Progress -> Blocked/In Review -> Done`.
 - [ ] `In Review` includes CI validation status awareness once GitHub Actions workflows exist.
@@ -79,7 +79,7 @@ Applies to task decomposition, tracker entry setup, tracker status updates, PR l
 ## Task-Splitting Notes
 - Do not split implementation tasks until this spec is `Approved`.
 - Use tracker-first task definitions instead of external issue/project setup.
-- Use migration-first tasks when the imported frontend is legacy React: archive legacy frontend, scaffold clean typed app, migrate landing/projects/photos, implement Thoughts/Chat/Admin, rerun analyzer.
+- Use migration-first tasks when the imported frontend is legacy React: archive legacy frontend, scaffold clean typed app, migrate landing/projects/photos, implement Thoughts/Chat/Admin, then rerun structural review.
 - Changes to tracker status semantics should happen in dedicated `spec/` branches.
 
 ## Git Branch Implications

--- a/docs/specs/media-storage.md
+++ b/docs/specs/media-storage.md
@@ -89,5 +89,5 @@ Filesystem layout, path conventions, upload ownership, retention assumptions, an
 - Do not split upload behavior tasks before moderation expectations and outbound storage port ownership are approved.
 
 ## Git Branch Implications
-- Storage changes use `infra/`, `be/`, or `data/` branches depending on the layer being changed.
+- Storage changes use `infra/`, `backend/`, or `data/` branches depending on the layer being changed.
 - Because storage decisions are hard to reverse operationally, keep each storage task narrowly scoped.

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -38,6 +38,7 @@
 2. Complete reviewer validation for `CHAT-010` PR [#122](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/122).
 3. Execute `SPEC-032` testing coverage foundation tasks `QA-009` through `QA-013`.
 4. Execute `SPEC-033` photo catalog and admin upload tasks `PHOTO-001` through `PHOTO-004`.
+5. Review `SPEC-034` agent onboarding docs refresh and execute `DOCS-001`.
 
 ## Current Executable Cluster
 ### Frontend Admin API Integration
@@ -296,6 +297,30 @@ Done criteria for `PHOTO-004`:
 - admin can upload a draft photo, inspect paginated records, edit metadata, publish/unpublish, and feature/unfeature.
 - admin route/action/component tests, frontend lint, and frontend build pass.
 
+### Agent Onboarding Docs Refresh
+- Status: in progress for spec authoring and documentation cleanup.
+- Primary spec: `SPEC-034`.
+- Supporting specs: `README.md`, `git-workflow.md`, `frontend-structure.md`, `frontend-architecture.md`, and `acceptance-criteria.md`.
+- Scope: refresh `AGENTS.md`, register the onboarding docs spec, resolve stale spec/skill references discovered by repo scan, and document the Vinicius.Dev frontend creation workflow through the local design skill.
+- Non-scope: runtime code changes, product behavior changes, schemas, API contracts, deployment behavior, and automated documentation tooling.
+
+| Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| In Progress | SPEC-034 | SPEC-034 | spec | develop | `spec/SPEC-034-agent-onboarding-refresh` | develop | `docs/specs/agent-onboarding-refresh.md` | not opened | — |
+| Todo | DOCS-001 | SPEC-034 | spec | develop | `spec/DOCS-001-agent-onboarding-docs-refresh` | develop | `docs/specs/agent-onboarding-refresh.md` | not opened | — |
+
+Done criteria for `SPEC-034`:
+- `docs/specs/agent-onboarding-refresh.md` exists and follows the harness section template.
+- `docs/specs/tracker.md` and `docs/specs/README.md` register the spec and planned documentation task.
+- branch names, dependencies, acceptance source, and verification methods are defined.
+
+Done criteria for `DOCS-001`:
+- `AGENTS.md` describes current repo areas, hard guardrails, current frontend/backend command surfaces, and the Vinicius.Dev frontend creation workflow.
+- stale missing frontend intake/analyzer references are removed or replaced with existing docs.
+- `design-system.md` references resolve through an existing bridge spec or are replaced with current docs.
+- local skill/UI-kit docs no longer reference absent component files.
+- Markdown path and stale-reference checks pass.
+
 ## Spec Table
 | Spec ID | Title | Layer | Status | Depends on | Blocks | Git workflow defined | Ready for task split | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -305,11 +330,12 @@ Done criteria for `PHOTO-004`:
 | SPEC-031 | Security Hardening and Production Readiness | Cross-layer | Tasked | `frontend-structure.md`, `frontend-architecture.md`, `project-structure.md`, `backend-architecture.md`, `chat-room-live-integration.md`, `frontend-admin-auth-integration.md`, `media-storage.md`, `admin-cms.md`, `infra-deployment.md`, `verification.md`, `git-workflow.md`, `acceptance-criteria.md` | `SEC-001`, `SEC-002`, `SEC-003`, `SEC-004`, `SEC-005`, `SEC-006`, `SEC-007`, `SEC-008`, `SEC-009` | yes | yes | Approved remediation spec from the 2026-05-03 security/bug review; implementation queue is registered with first-wave critical tasks unblocked first. |
 | SPEC-032 | Testing Coverage Foundation | Cross-layer | Tasked | `verification.md`, `ci-cd.md`, `project-structure.md`, `backend-architecture.md`, `frontend-structure.md`, `frontend-architecture.md`, `git-workflow.md`, `acceptance-criteria.md` | `QA-009`, `QA-010`, `QA-011`, `QA-012`, `QA-013` | yes | yes | Adds the first cross-layer coverage baseline: backend coverage improvements, frontend Vitest coverage, focused Prisma/Postgres CI contracts, and report-only coverage commands. |
 | SPEC-033 | Photo Catalog And Admin Upload | Cross-layer | Tasked | `product-scope.md`, `frontend-structure.md`, `frontend-architecture.md`, `project-structure.md`, `backend-architecture.md`, `data-model.md`, `media-storage.md`, `admin-cms.md`, `verification.md`, `git-workflow.md`, `acceptance-criteria.md` | `PHOTO-001`, `PHOTO-002`, `PHOTO-003`, `PHOTO-004` | yes | yes | Adds draft-first admin photo original uploads, public gallery API integration with real images and facets, and admin photo management. |
+| SPEC-034 | Agent Onboarding Docs Refresh | Docs | In Progress | `README.md`, `tracker.md`, `acceptance-criteria.md`, `git-workflow.md`, `frontend-structure.md`, `frontend-architecture.md` | `DOCS-001` | yes | yes | Documentation-only onboarding refresh for `AGENTS.md`, stale spec dependencies, and local Vinicius.Dev frontend skill references. |
 
 ## Tasking Rule
 A spec may only move to `Tasked` when:
 - its status is `Approved`
 - its dependencies are `Approved`
-- frontend intake is satisfied
+- frontend structure and contract reconciliation gates are satisfied
 - branch naming is defined for resulting tasks
 - its acceptance checklist is complete

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -298,7 +298,7 @@ Done criteria for `PHOTO-004`:
 - admin route/action/component tests, frontend lint, and frontend build pass.
 
 ### Agent Onboarding Docs Refresh
-- Status: in progress for spec authoring and documentation cleanup.
+- Status: in review.
 - Primary spec: `SPEC-034`.
 - Supporting specs: `README.md`, `git-workflow.md`, `frontend-structure.md`, `frontend-architecture.md`, and `acceptance-criteria.md`.
 - Scope: refresh `AGENTS.md`, register the onboarding docs spec, resolve stale spec/skill references discovered by repo scan, and document the Vinicius.Dev frontend creation workflow through the local design skill.
@@ -306,8 +306,8 @@ Done criteria for `PHOTO-004`:
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| In Progress | SPEC-034 | SPEC-034 | spec | develop | `spec/SPEC-034-agent-onboarding-refresh` | develop | `docs/specs/agent-onboarding-refresh.md` | not opened | — |
-| Todo | DOCS-001 | SPEC-034 | spec | develop | `spec/DOCS-001-agent-onboarding-docs-refresh` | develop | `docs/specs/agent-onboarding-refresh.md` | not opened | — |
+| In Review | SPEC-034 | SPEC-034 | spec | develop | `spec/SPEC-034-agent-onboarding-refresh` | develop | `docs/specs/agent-onboarding-refresh.md` | [#151](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/151) | — |
+| In Review | DOCS-001 | SPEC-034 | spec | develop | `spec/DOCS-001-agent-onboarding-docs-refresh` | develop | `docs/specs/agent-onboarding-refresh.md` | [#151](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/151) | — |
 
 Done criteria for `SPEC-034`:
 - `docs/specs/agent-onboarding-refresh.md` exists and follows the harness section template.
@@ -330,7 +330,7 @@ Done criteria for `DOCS-001`:
 | SPEC-031 | Security Hardening and Production Readiness | Cross-layer | Tasked | `frontend-structure.md`, `frontend-architecture.md`, `project-structure.md`, `backend-architecture.md`, `chat-room-live-integration.md`, `frontend-admin-auth-integration.md`, `media-storage.md`, `admin-cms.md`, `infra-deployment.md`, `verification.md`, `git-workflow.md`, `acceptance-criteria.md` | `SEC-001`, `SEC-002`, `SEC-003`, `SEC-004`, `SEC-005`, `SEC-006`, `SEC-007`, `SEC-008`, `SEC-009` | yes | yes | Approved remediation spec from the 2026-05-03 security/bug review; implementation queue is registered with first-wave critical tasks unblocked first. |
 | SPEC-032 | Testing Coverage Foundation | Cross-layer | Tasked | `verification.md`, `ci-cd.md`, `project-structure.md`, `backend-architecture.md`, `frontend-structure.md`, `frontend-architecture.md`, `git-workflow.md`, `acceptance-criteria.md` | `QA-009`, `QA-010`, `QA-011`, `QA-012`, `QA-013` | yes | yes | Adds the first cross-layer coverage baseline: backend coverage improvements, frontend Vitest coverage, focused Prisma/Postgres CI contracts, and report-only coverage commands. |
 | SPEC-033 | Photo Catalog And Admin Upload | Cross-layer | Tasked | `product-scope.md`, `frontend-structure.md`, `frontend-architecture.md`, `project-structure.md`, `backend-architecture.md`, `data-model.md`, `media-storage.md`, `admin-cms.md`, `verification.md`, `git-workflow.md`, `acceptance-criteria.md` | `PHOTO-001`, `PHOTO-002`, `PHOTO-003`, `PHOTO-004` | yes | yes | Adds draft-first admin photo original uploads, public gallery API integration with real images and facets, and admin photo management. |
-| SPEC-034 | Agent Onboarding Docs Refresh | Docs | In Progress | `README.md`, `tracker.md`, `acceptance-criteria.md`, `git-workflow.md`, `frontend-structure.md`, `frontend-architecture.md` | `DOCS-001` | yes | yes | Documentation-only onboarding refresh for `AGENTS.md`, stale spec dependencies, and local Vinicius.Dev frontend skill references. |
+| SPEC-034 | Agent Onboarding Docs Refresh | Docs | In Review | `README.md`, `tracker.md`, `acceptance-criteria.md`, `git-workflow.md`, `frontend-structure.md`, `frontend-architecture.md` | `DOCS-001` | yes | yes | Documentation-only onboarding refresh for `AGENTS.md`, stale spec dependencies, and local Vinicius.Dev frontend skill references. |
 
 ## Tasking Rule
 A spec may only move to `Tasked` when:

--- a/docs/specs/verification.md
+++ b/docs/specs/verification.md
@@ -16,7 +16,7 @@ Spec verification, implementation verification, release gates, and cross-layer r
 
 ## Interfaces and Responsibilities
 - Validate that all spec files exist and align with the tracker.
-- Validate that frontend intake gates are respected.
+- Validate that frontend structure and contract reconciliation gates are respected.
 - Validate that `frontend-structure.md` is referenced by frontend-facing specs and task decomposition.
 - Validate that `project-structure.md` is referenced by backend-facing specs and task decomposition.
 - Validate that `ci-cd.md` is referenced by release automation and verification work.
@@ -25,12 +25,12 @@ Spec verification, implementation verification, release gates, and cross-layer r
 - Validate that tracker-based execution rules are present before implementation starts.
 - Validate that frontend structure rules cover FSD layer discipline, route tree ownership, and public/admin shell separation.
 - Validate that CI/CD rules cover PR validation, branch validation, manual development deployment, and tag-based production deployment.
-- Validate FE-010 reconciliation rules for `/api`, public DTOs, upload/media assumptions, analyzer freshness, and static route fallback.
+- Validate FE-010 reconciliation rules for `/api`, public DTOs, upload/media assumptions, and static route fallback.
 - Define cross-layer scenarios for public browsing, admin, chat, media, auth, and deployment.
 - Define frontend structural scenarios for the six route families and the three canonical frontend interaction flows.
 - Define backend architectural scenarios for `publish thought`, `post chat message`, and `admin login`.
 - Validate that the backend core is described as testable without HTTP or database.
-- Validate that frontend migration gates are respected before backend tasking begins.
+- Validate that frontend contract reconciliation gates are respected before backend tasking begins.
 
 ## Cross-Layer Scenarios
 - Public content DTOs: Thoughts, Projects, Photos, and Status Strip APIs return the migrated frontend shapes without leaking Prisma fields.
@@ -60,7 +60,7 @@ Spec verification, implementation verification, release gates, and cross-layer r
 - deployment/runtime expectations
 - FE-010 API and upload reconciliation checks
 - RSS and sitemap scenarios
-- analyzer and backend boundary validation
+- frontend contract and backend boundary validation
 
 ## Acceptance Checklist
 - [ ] Every spec referenced in the tracker exists.
@@ -69,7 +69,7 @@ Spec verification, implementation verification, release gates, and cross-layer r
 - [ ] `ci-cd.md` exists and is treated as a hard dependency for release automation and final verification.
 - [ ] `git-workflow.md` is referenced by the harness and used by task decomposition.
 - [ ] `github-project-execution.md` is referenced by the harness and used by task decomposition.
-- [ ] Frontend intake is treated as a blocking gate for backend tasking.
+- [ ] Frontend structure and contract reconciliation are treated as blocking gates for backend tasking where applicable.
 - [ ] Frontend-facing specs cannot be task-split without approved structural guidance from `frontend-structure.md`.
 - [ ] Backend-facing specs cannot be task-split without frontend review state.
 - [ ] Backend-facing specs cannot be task-split without approved structural guidance from `project-structure.md`.
@@ -77,7 +77,7 @@ Spec verification, implementation verification, release gates, and cross-layer r
 - [ ] Verification expectations include future frontend structural checks for FSD layers, page public APIs, `app/routes` ownership, shell separation, and the absence of `processes`.
 - [ ] Verification expectations include future architectural-boundary checks without selecting the tool yet.
 - [ ] Verification expectations include the CI/CD trigger matrix, the manual-development-deploy rule, and the tag-based production release rule.
-- [ ] Verification expectations include FE-010 reconciliation for `/api`, public DTOs, upload/media assumptions, analyzer freshness, and frontend static fallback.
+- [ ] Verification expectations include FE-010 reconciliation for `/api`, public DTOs, upload/media assumptions, and frontend static fallback.
 - [ ] Cross-layer scenarios cover server-side filters and pagination for Thoughts, Projects, and Photos.
 - [ ] Cross-layer scenarios cover chat join, send, upload, moderation, room-gated media, and audit retention.
 - [ ] Cross-layer scenarios cover photo original delivery through `/media/photos/:id/original`.
@@ -92,7 +92,6 @@ Spec verification, implementation verification, release gates, and cross-layer r
 
 ## Dependencies
 - [tracker.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/tracker.md)
-- [frontend-intake.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-intake.md)
 - [git-workflow.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/git-workflow.md)
 - [github-project-execution.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/github-project-execution.md)
 - [product-scope.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/product-scope.md)


### PR DESCRIPTION
## Summary

Creates the `SPEC-034` documentation contract for refreshing agent onboarding and updates the repository docs that future agents use before tasking, branching, or implementation.

## Changes

- Adds `AGENTS.md` with current repo areas, hard guardrails, command surfaces, Git workflow expectations, and the Vinicius.Dev frontend creation workflow.
- Adds `docs/specs/agent-onboarding-refresh.md` and registers `SPEC-034` / `DOCS-001` in the spec harness.
- Adds `docs/specs/design-system.md` as a bridge to the local `viniciusdev-design` skill.
- Cleans stale references to missing frontend intake/analyzer docs and updates branch-prefix wording to match the approved Git workflow.
- Adds `.agents/` to `.gitignore` so the local skill cache stays out of version control.

## Source Spec

- Primary spec: `docs/specs/agent-onboarding-refresh.md`
- Acceptance source: `docs/specs/agent-onboarding-refresh.md`
- Base branch: `develop`
- Merge target: `develop`

## Verification

- Checked touched Markdown links with a local path verifier.
- Confirmed no stale `frontend-intake.md`, `frontend-analyzer.md`, `WorkList`, or `NowPlayingStrip` references remain in the touched onboarding/spec docs.
- Confirmed remaining `design-system.md` references resolve through the new bridge spec.
- Ran `git diff --check` / staged diff check before commit.

## Notes

This is documentation-only. It does not change runtime code, product behavior, schemas, APIs, deployment behavior, or CI workflow behavior.