### PR TITLE
SPEC-035 admin photo form feedback spec

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -73,6 +73,7 @@ No backend-facing spec may move to `Tasked` until [project-structure.md](/Users/
 - [ci-workflow-maintenance.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/ci-workflow-maintenance.md)
 - [testing-coverage-foundation.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/testing-coverage-foundation.md)
 - [photo-catalog-gallery.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/photo-catalog-gallery.md)
+- [admin-photo-form-feedback.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/admin-photo-form-feedback.md)
 - [verification.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/verification.md)
 
 ## Task Authoring Rules

--- a/docs/specs/admin-photo-form-feedback.md
+++ b/docs/specs/admin-photo-form-feedback.md
@@ -1,0 +1,103 @@
+# Admin Photo Form Feedback
+
+## Purpose
+Define the admin photo form UX follow-up for branded file selection and toast-based save feedback on the photo upload and detail screens.
+
+## Scope
+This spec covers frontend-only changes for:
+- `/admin/photos/upload`
+- `/admin/photos/:id`
+- a reusable shared toast UI/provider wired through the frontend app providers
+- the upload screen's original image file chooser
+- success feedback for photo upload, metadata save, publish/unpublish, and feature/unfeature actions
+
+This spec does not cover `/admin/photos` gallery/list UI changes, public photo gallery behavior, backend API contracts, media storage behavior, schema changes, thumbnail generation, EXIF extraction, object storage, or deployment changes.
+
+## Locked Decisions
+- The visual acceptance source is the `vinicius-dev-website-guidelines` skill, especially `.agents/skills/vinicius-dev-website-guidelines/preview/interactive-components.html` for toasts and feedback.
+- Toasts appear in the bottom-right corner of the viewport.
+- Toasts auto-dismiss after `4000ms` and include a visible timer/progress bar.
+- Toasts use the design-system glyph vocabulary and semantic colors; no emoji, no rounded corners, no glassmorphism, and no new colors.
+- Toasts expose an accessible live region with `aria-live="polite"`.
+- Toast motion follows the UI kit entrance timing and respects reduced-motion preferences.
+- The shared toast implementation lives under `frontend/src/shared/ui` and is wired through `frontend/src/app/providers`.
+- The file chooser on `/admin/photos/upload` keeps the native file input accessible while replacing the visible browser-default control with a branded rectangular control.
+- The file chooser visible label is `choose file` before selection and `change file` after selection.
+- The selected file name and formatted byte size are visible after selection.
+- The upload form keeps the current accepted types: `image/jpeg`, `image/png`, and `image/webp`.
+- The upload form keeps the current required file validation and local image preview behavior.
+- A successful new photo upload keeps the current redirect behavior to `/admin/photos/:id`.
+- A successful new photo upload shows the toast on the destination detail screen after redirect.
+- Successful metadata save, publish/unpublish, and feature/unfeature actions show success toasts instead of small inline success text.
+- Error feedback remains inline near the affected form or action; this task does not convert errors to toasts.
+
+## Interfaces And Responsibilities
+- `frontend/src/shared/ui` owns the reusable toast primitives, provider, hook/API, and public exports.
+- `frontend/src/app/providers` wires the toast provider so route pages can trigger shared feedback without introducing a broader global application store.
+- `/admin/photos/upload` owns the upload-only file selection state, preview state, filename display, byte-size display, and upload form rendering.
+- `/admin/photos/:id` owns mapping photo action success states to toast messages for metadata and curation actions.
+- The upload action may pass a transient success signal to the redirected detail route, such as a route-local flash/search parameter, but must not change backend API contracts.
+- If a transient URL signal is used for upload success, the detail route must clear it with `replace` after the toast is queued so reloading/bookmarking does not replay stale feedback.
+- React Router Data Mode remains the route/action boundary for photo mutations.
+- FSD import direction remains intact: pages may import from `shared/ui`, and `shared/ui` must not import from page, feature, entity, or app slices.
+
+## Data/Contracts Touched
+- `frontend/src/shared/ui` public API for toasts
+- `frontend/src/app/providers` provider composition
+- `/admin/photos/upload` route component file input presentation and selected-file view model
+- `/admin/photos/:id` route component success-feedback presentation
+- admin photo action success view-model handling
+- frontend tests for admin photo upload/detail feedback behavior
+
+## Acceptance Checklist
+- [ ] `/admin/photos/upload` renders a branded rectangular file chooser instead of the plain browser-default visible button.
+- [ ] The upload file chooser displays `choose file` before a file is selected.
+- [ ] The upload file chooser displays `change file` after a file is selected.
+- [ ] The upload file chooser displays the selected file name and formatted size after selection.
+- [ ] The native file input remains accessible to keyboard and assistive technology users.
+- [ ] The upload file input preserves `accept="image/jpeg,image/png,image/webp"` and required-file behavior.
+- [ ] The existing local image preview behavior remains available after selecting a file.
+- [ ] Successful new photo upload still redirects to the new photo detail route.
+- [ ] Successful new photo upload shows a bottom-right success toast on the destination detail route.
+- [ ] Successful metadata save on `/admin/photos/:id` shows a bottom-right success toast.
+- [ ] Successful publish/unpublish on `/admin/photos/:id` shows a bottom-right success toast.
+- [ ] Successful feature/unfeature on `/admin/photos/:id` shows a bottom-right success toast.
+- [ ] Success messages are no longer rendered as small inline text for upload, metadata, publish/unpublish, or feature/unfeature success states.
+- [ ] Error messages remain rendered inline near the related form/action.
+- [ ] Toasts auto-dismiss after `4000ms` and include a visible timer/progress bar.
+- [ ] Toasts use `aria-live="polite"` and do not trap focus.
+- [ ] Toast styling follows the Vinicius.Dev UI kit: rectangular geometry, existing tokens, glyph-based states, no emoji, no rounded UI, and reduced-motion support.
+- [ ] `/admin/photos` gallery/list behavior is unchanged by this task.
+- [ ] No backend API, persistence, media storage, schema, or deployment behavior changes are introduced.
+- [ ] Frontend route/component tests cover the branded file chooser, selected filename/size display, upload redirect toast signal, detail success toasts, and inline error preservation.
+- [ ] Frontend `bun run test`, `bun run lint`, and `bun run build` pass.
+
+## Dependencies
+- [photo-catalog-gallery.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/photo-catalog-gallery.md)
+- [design-system.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/design-system.md)
+- [frontend-structure.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-structure.md)
+- [frontend-architecture.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/frontend-architecture.md)
+- [verification.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/verification.md)
+- [git-workflow.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/git-workflow.md)
+- [acceptance-criteria.md](/Users/vinicius/Projects/vinicius.dev/docs/specs/acceptance-criteria.md)
+
+## Open Questions
+- None. The requested behavior is locked for `PHOTO-005`.
+
+Future follow-up decisions, outside this spec, can decide whether error toasts or toast usage across other admin screens should be standardized.
+
+## Task-Splitting Notes
+- Implement as one frontend/admin task: `PHOTO-005`.
+- `PHOTO-005` should start only after the `/admin/photos/upload` and `/admin/photos/:id` routes from the photo catalog/admin upload cluster are available on the implementation base branch.
+- Keep the shared toast system intentionally small and reusable; do not introduce a broad app state manager.
+- Keep the file chooser work limited to `/admin/photos/upload`; do not change chat uploads or public photo gallery uploads.
+- Keep success-toast wiring limited to upload, metadata save, publish/unpublish, and feature/unfeature on the scoped routes.
+- The implementation agent must read the Vinicius.Dev design skill files and `preview/interactive-components.html` before writing UI code.
+
+## Git Branch Implications
+- Spec work uses `spec/SPEC-035-admin-photo-form-feedback`.
+- Implementation work uses `admin/PHOTO-005-admin-photo-form-feedback`.
+- Both branches base from `develop` and merge to `develop` after review.
+- Commit messages and PR titles must include the task ID (`SPEC-035` or `PHOTO-005`).
+- Commits must be created with `git commit -s -m "..."`.
+- The implementation PR description must include the source spec, acceptance source, base branch, merge target, and verification performed.

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -299,7 +299,7 @@ Done criteria for `PHOTO-004`:
 - admin route/action/component tests, frontend lint, and frontend build pass.
 
 ### Admin Photo Form Feedback
-- Status: spec authoring in progress; implementation is queued behind spec approval and admin photo route availability.
+- Status: in review; implementation is queued behind spec approval and admin photo route availability.
 - Primary spec: `SPEC-035`.
 - Supporting specs: `photo-catalog-gallery.md`, `design-system.md`, `frontend-structure.md`, `frontend-architecture.md`, `verification.md`, `git-workflow.md`, and `acceptance-criteria.md`.
 - Scope: shared reusable toast provider, branded `/admin/photos/upload` file chooser, selected filename/size display, and success toasts for upload, metadata save, publish/unpublish, and feature/unfeature on `/admin/photos/upload` and `/admin/photos/:id`.
@@ -307,7 +307,7 @@ Done criteria for `PHOTO-004`:
 
 | Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| In Progress | SPEC-035 | SPEC-035 | spec | develop | `spec/SPEC-035-admin-photo-form-feedback` | develop | `docs/specs/admin-photo-form-feedback.md` | not opened | — |
+| In Review | SPEC-035 | SPEC-035 | spec | develop | `spec/SPEC-035-admin-photo-form-feedback` | develop | `docs/specs/admin-photo-form-feedback.md` | [#153](https://github.com/Vinicius-Marcondes/vinicius.dev/pull/153) | — |
 | Blocked | PHOTO-005 | SPEC-035 | admin | develop | `admin/PHOTO-005-admin-photo-form-feedback` | develop | `docs/specs/admin-photo-form-feedback.md` | not opened | Pending `SPEC-035` approval and `/admin/photos/upload` plus `/admin/photos/:id` route availability from `PHOTO-004` on the base branch. |
 
 Done criteria for `SPEC-035`:

--- a/docs/specs/tracker.md
+++ b/docs/specs/tracker.md
@@ -39,6 +39,7 @@
 3. Execute `SPEC-032` testing coverage foundation tasks `QA-009` through `QA-013`.
 4. Execute `SPEC-033` photo catalog and admin upload tasks `PHOTO-001` through `PHOTO-004`.
 5. Review `SPEC-034` agent onboarding docs refresh and execute `DOCS-001`.
+6. Review `SPEC-035` admin photo form feedback and, after approval plus admin photo route availability, execute `PHOTO-005`.
 
 ## Current Executable Cluster
 ### Frontend Admin API Integration
@@ -297,6 +298,33 @@ Done criteria for `PHOTO-004`:
 - admin can upload a draft photo, inspect paginated records, edit metadata, publish/unpublish, and feature/unfeature.
 - admin route/action/component tests, frontend lint, and frontend build pass.
 
+### Admin Photo Form Feedback
+- Status: spec authoring in progress; implementation is queued behind spec approval and admin photo route availability.
+- Primary spec: `SPEC-035`.
+- Supporting specs: `photo-catalog-gallery.md`, `design-system.md`, `frontend-structure.md`, `frontend-architecture.md`, `verification.md`, `git-workflow.md`, and `acceptance-criteria.md`.
+- Scope: shared reusable toast provider, branded `/admin/photos/upload` file chooser, selected filename/size display, and success toasts for upload, metadata save, publish/unpublish, and feature/unfeature on `/admin/photos/upload` and `/admin/photos/:id`.
+- Non-scope: `/admin/photos` gallery/list UI changes, public photo gallery behavior, backend API contracts, persistence/media/schema changes, error-toast conversion, and deployment changes.
+
+| Status | Task ID | Spec ID | Layer | Base Branch | Branch Name | Merge Target | Acceptance Source | PR | Blocked Reason |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| In Progress | SPEC-035 | SPEC-035 | spec | develop | `spec/SPEC-035-admin-photo-form-feedback` | develop | `docs/specs/admin-photo-form-feedback.md` | not opened | — |
+| Blocked | PHOTO-005 | SPEC-035 | admin | develop | `admin/PHOTO-005-admin-photo-form-feedback` | develop | `docs/specs/admin-photo-form-feedback.md` | not opened | Pending `SPEC-035` approval and `/admin/photos/upload` plus `/admin/photos/:id` route availability from `PHOTO-004` on the base branch. |
+
+Done criteria for `SPEC-035`:
+- `docs/specs/admin-photo-form-feedback.md` exists and follows the harness section template.
+- `docs/specs/tracker.md` and `docs/specs/README.md` register the spec and planned implementation task.
+- branch names, dependencies, acceptance source, and verification methods are defined for `PHOTO-005`.
+- the spec records locked UX decisions from the planning conversation and the Vinicius.Dev design skill.
+
+Done criteria for `PHOTO-005`:
+- `/admin/photos/upload` renders a branded file chooser with `choose file` before selection and `change file` plus filename/size after selection.
+- the native upload input remains accessible and preserves accepted image types, required behavior, and local preview.
+- upload success keeps redirecting to `/admin/photos/:id` and shows a bottom-right 4s success toast on the destination route.
+- metadata save, publish/unpublish, and feature/unfeature successes on `/admin/photos/:id` show bottom-right 4s success toasts.
+- success messages are removed from inline text while error messages remain inline near the related form/action.
+- shared toast UI is implemented under `frontend/src/shared/ui`, wired through `frontend/src/app/providers`, and follows the Vinicius.Dev UI kit including timer/progress, `aria-live`, rectangular geometry, existing tokens, no emoji, and reduced-motion support.
+- frontend route/component tests, lint, and build pass.
+
 ### Agent Onboarding Docs Refresh
 - Status: in review.
 - Primary spec: `SPEC-034`.
@@ -331,6 +359,7 @@ Done criteria for `DOCS-001`:
 | SPEC-032 | Testing Coverage Foundation | Cross-layer | Tasked | `verification.md`, `ci-cd.md`, `project-structure.md`, `backend-architecture.md`, `frontend-structure.md`, `frontend-architecture.md`, `git-workflow.md`, `acceptance-criteria.md` | `QA-009`, `QA-010`, `QA-011`, `QA-012`, `QA-013` | yes | yes | Adds the first cross-layer coverage baseline: backend coverage improvements, frontend Vitest coverage, focused Prisma/Postgres CI contracts, and report-only coverage commands. |
 | SPEC-033 | Photo Catalog And Admin Upload | Cross-layer | Tasked | `product-scope.md`, `frontend-structure.md`, `frontend-architecture.md`, `project-structure.md`, `backend-architecture.md`, `data-model.md`, `media-storage.md`, `admin-cms.md`, `verification.md`, `git-workflow.md`, `acceptance-criteria.md` | `PHOTO-001`, `PHOTO-002`, `PHOTO-003`, `PHOTO-004` | yes | yes | Adds draft-first admin photo original uploads, public gallery API integration with real images and facets, and admin photo management. |
 | SPEC-034 | Agent Onboarding Docs Refresh | Docs | In Review | `README.md`, `tracker.md`, `acceptance-criteria.md`, `git-workflow.md`, `frontend-structure.md`, `frontend-architecture.md` | `DOCS-001` | yes | yes | Documentation-only onboarding refresh for `AGENTS.md`, stale spec dependencies, and local Vinicius.Dev frontend skill references. |
+| SPEC-035 | Admin Photo Form Feedback | Frontend/Admin | Review | `photo-catalog-gallery.md`, `design-system.md`, `frontend-structure.md`, `frontend-architecture.md`, `verification.md`, `git-workflow.md`, `acceptance-criteria.md` | `PHOTO-005` | yes | yes | Frontend-only admin photo UX follow-up for branded file selection and shared toast-based save feedback on upload/detail screens. |
 
 ## Tasking Rule
 A spec may only move to `Tasked` when:


### PR DESCRIPTION
## Source spec
- SPEC-035: docs/specs/admin-photo-form-feedback.md

## Acceptance source
- docs/specs/admin-photo-form-feedback.md

## Base branch
- develop

## Merge target
- develop

## Summary
- Adds the admin photo form feedback spec for branded file selection and toast-based save feedback.
- Registers SPEC-035 and PHOTO-005 in docs/specs/tracker.md.
- Adds the new spec to docs/specs/README.md canonical files.

## Verification performed
- git diff --check

## Notes
- Documentation/spec-only PR. No runtime code changes.
- PHOTO-005 remains blocked until SPEC-035 is approved and the admin photo upload/detail routes are available on the implementation base branch.