### PR TITLE
PRD-001: Homepage V2 reference parity refresh

### DIFF
--- a/docs/TRACKER.md
+++ b/docs/TRACKER.md
@@ -25,7 +25,7 @@
 - Merge Target: develop
 
 ## Current Task
-HOME-002
+HOME-003
 
 ## Task Index
 1. HOME-001 - Wire homepage data loader and status-strip API
@@ -36,7 +36,7 @@ HOME-002
    - Status: Accepted
 3. HOME-003 - Rebuild the homepage route for reference parity
    - Task File: docs/prds/PRD-001/tasks/HOME-003.md
-   - Status: Todo
+   - Status: Accepted
 4. HOME-004 - Polish responsive behavior and verify homepage rollout
    - Task File: docs/prds/PRD-001/tasks/HOME-004.md
    - Status: Todo
@@ -70,17 +70,22 @@ Decision Log:
 - Updated shared navigation/social/marquee config in `shared/config` to map current public routes (`/photos`, `/projects`, `/thoughts`, `/chat`) and shared footer channels.
 - Removed one-off homepage channel-bug wiring so fixed chrome behavior is shell-owned; homepage keeps only route-local hero/channel-change behavior.
 - Aligned shared tokens/motion/effects with vinicius-dev guidelines (Fira Mono body font, CRT glitch timing, and global reduced-motion collapse rule).
-Commit: Pending
+Commit: e554b31 PRD-001 HOME-002: refactor shared public chrome to v2 direction
 Blocked Reason: None
 Requested Decision: None
 
 ### HOME-003 - Rebuild the homepage route for reference parity
 Task File: docs/prds/PRD-001/tasks/HOME-003.md
-Status: Todo
+Status: Accepted
 Evidence:
-- Pending
+- `cd frontend && bun run test` -> passed (22 files, 39 tests).
+- `cd frontend && bun run build` -> passed (`tsc -b && vite build`).
 Decision Log:
-- Pending
+- Started implementation on 2026-05-09.
+- Rebuilt homepage route composition to better match the V2 reference direction while using shell-owned chrome from HOME-002.
+- Added explicit homepage route cues linking to real app routes (`/photos`, `/projects`, `/thoughts`, `/chat`).
+- Kept homepage status strip powered by loader-provided backend-wired data.
+- Added deterministic homepage rendering test covering loader-data consumption and route-cue links.
 Commit: Pending
 Blocked Reason: None
 Requested Decision: None

--- a/docs/TRACKER.md
+++ b/docs/TRACKER.md
@@ -1,0 +1,92 @@
+# TRACKER
+
+## Agent Instructions
+- Execute only the `Current Task`.
+- Use task files as stable requirements.
+- Use this tracker for execution state only.
+- Do not change task boundaries without asking Vinicius first.
+- Stop immediately on blockers.
+- Do not commit blocked work unless Vinicius explicitly asks for a checkpoint commit.
+- Commit exactly one accepted task at a time.
+- Use signed commits with `git commit -s`.
+- For `Review Mode: Human`, stop before committing and wait for Vinicius to accept.
+- For `Review Mode: Agent`, verify, accept, commit, and continue when appropriate.
+
+## PRD
+- ID: PRD-001
+- Title: Homepage V2 Reference Parity Refresh
+- Status: Active
+- PRD File: docs/prds/PRD-001/PRD-001.md
+- Summary: Refresh the public homepage to match the V2 reference look and feel inside the current React 19 + Vite + Bun app while preserving repo architecture, adapting to real routes/content, and allowing shared public chrome refactors.
+
+## Git
+- Branch: feature/PRD-001-homepage-v2-reference-refresh
+- Base: develop
+- Merge Target: develop
+
+## Current Task
+HOME-001
+
+## Task Index
+1. HOME-001 - Wire homepage data loader and status-strip API
+   - Task File: docs/prds/PRD-001/tasks/HOME-001.md
+   - Status: Accepted
+2. HOME-002 - Refactor shared public chrome to the V2 direction
+   - Task File: docs/prds/PRD-001/tasks/HOME-002.md
+   - Status: Todo
+3. HOME-003 - Rebuild the homepage route for reference parity
+   - Task File: docs/prds/PRD-001/tasks/HOME-003.md
+   - Status: Todo
+4. HOME-004 - Polish responsive behavior and verify homepage rollout
+   - Task File: docs/prds/PRD-001/tasks/HOME-004.md
+   - Status: Todo
+
+## Tasks
+
+### HOME-001 - Wire homepage data loader and status-strip API
+Task File: docs/prds/PRD-001/tasks/HOME-001.md
+Status: Accepted
+Evidence:
+- `cd frontend && bun run test` -> passed (21 files, 38 tests).
+- `cd frontend && bun run build` -> passed (`tsc -b && vite build`).
+Decision Log:
+- Started implementation on 2026-05-09.
+- Added `pages/home/route.ts` loader and wired `/` index route loader ownership in `src/app/routes/public.tsx`.
+- Added `entities/status-strip` API mapper/client for `/api/status-strip` and deterministic tests for API mapping + home loader behavior.
+- Updated `widgets/status-strip` prop typing to accept readonly arrays so loader data can flow without mutation.
+Commit: Pending
+Blocked Reason: None
+Requested Decision: None
+
+### HOME-002 - Refactor shared public chrome to the V2 direction
+Task File: docs/prds/PRD-001/tasks/HOME-002.md
+Status: Todo
+Evidence:
+- Pending
+Decision Log:
+- Pending
+Commit: Pending
+Blocked Reason: None
+Requested Decision: None
+
+### HOME-003 - Rebuild the homepage route for reference parity
+Task File: docs/prds/PRD-001/tasks/HOME-003.md
+Status: Todo
+Evidence:
+- Pending
+Decision Log:
+- Pending
+Commit: Pending
+Blocked Reason: None
+Requested Decision: None
+
+### HOME-004 - Polish responsive behavior and verify homepage rollout
+Task File: docs/prds/PRD-001/tasks/HOME-004.md
+Status: Todo
+Evidence:
+- Pending
+Decision Log:
+- Pending
+Commit: Pending
+Blocked Reason: None
+Requested Decision: None

--- a/docs/TRACKER.md
+++ b/docs/TRACKER.md
@@ -25,7 +25,7 @@
 - Merge Target: develop
 
 ## Current Task
-HOME-001
+HOME-002
 
 ## Task Index
 1. HOME-001 - Wire homepage data loader and status-strip API
@@ -33,7 +33,7 @@ HOME-001
    - Status: Accepted
 2. HOME-002 - Refactor shared public chrome to the V2 direction
    - Task File: docs/prds/PRD-001/tasks/HOME-002.md
-   - Status: Todo
+   - Status: Accepted
 3. HOME-003 - Rebuild the homepage route for reference parity
    - Task File: docs/prds/PRD-001/tasks/HOME-003.md
    - Status: Todo
@@ -54,17 +54,22 @@ Decision Log:
 - Added `pages/home/route.ts` loader and wired `/` index route loader ownership in `src/app/routes/public.tsx`.
 - Added `entities/status-strip` API mapper/client for `/api/status-strip` and deterministic tests for API mapping + home loader behavior.
 - Updated `widgets/status-strip` prop typing to accept readonly arrays so loader data can flow without mutation.
-Commit: Pending
+Commit: c81effa PRD-001 HOME-001: wire homepage loader to status-strip API
 Blocked Reason: None
 Requested Decision: None
 
 ### HOME-002 - Refactor shared public chrome to the V2 direction
 Task File: docs/prds/PRD-001/tasks/HOME-002.md
-Status: Todo
+Status: Accepted
 Evidence:
-- Pending
+- `cd frontend && bun run test` -> passed (21 files, 38 tests).
+- `cd frontend && bun run build` -> passed (`tsc -b && vite build`).
 Decision Log:
-- Pending
+- Started implementation on 2026-05-09.
+- Refactored shared public-shell chrome to reusable widgets: fixed top navigation, fixed channel bug, and fixed now-playing marquee in shell/footer/header composition.
+- Updated shared navigation/social/marquee config in `shared/config` to map current public routes (`/photos`, `/projects`, `/thoughts`, `/chat`) and shared footer channels.
+- Removed one-off homepage channel-bug wiring so fixed chrome behavior is shell-owned; homepage keeps only route-local hero/channel-change behavior.
+- Aligned shared tokens/motion/effects with vinicius-dev guidelines (Fira Mono body font, CRT glitch timing, and global reduced-motion collapse rule).
 Commit: Pending
 Blocked Reason: None
 Requested Decision: None

--- a/docs/TRACKER.md
+++ b/docs/TRACKER.md
@@ -25,7 +25,7 @@
 - Merge Target: develop
 
 ## Current Task
-HOME-003
+HOME-004
 
 ## Task Index
 1. HOME-001 - Wire homepage data loader and status-strip API
@@ -39,7 +39,7 @@ HOME-003
    - Status: Accepted
 4. HOME-004 - Polish responsive behavior and verify homepage rollout
    - Task File: docs/prds/PRD-001/tasks/HOME-004.md
-   - Status: Todo
+   - Status: Accepted
 
 ## Tasks
 
@@ -86,17 +86,23 @@ Decision Log:
 - Added explicit homepage route cues linking to real app routes (`/photos`, `/projects`, `/thoughts`, `/chat`).
 - Kept homepage status strip powered by loader-provided backend-wired data.
 - Added deterministic homepage rendering test covering loader-data consumption and route-cue links.
-Commit: Pending
+Commit: 2533e37 PRD-001 HOME-003: rebuild homepage route for reference parity
 Blocked Reason: None
 Requested Decision: None
 
 ### HOME-004 - Polish responsive behavior and verify homepage rollout
 Task File: docs/prds/PRD-001/tasks/HOME-004.md
-Status: Todo
+Status: Accepted
 Evidence:
-- Pending
+- `cd frontend && bun run test` -> passed (22 files, 39 tests).
+- `cd frontend && bun run build` -> passed (`tsc -b && vite build`).
 Decision Log:
-- Pending
-Commit: Pending
+- Started implementation on 2026-05-09.
+- Tuned responsive behavior for shell-owned fixed chrome and homepage hero/status composition at tablet/mobile breakpoints.
+- Strengthened visible focus treatment across shared chrome and homepage interactive cues using `:focus-visible` outlines.
+- Added reduced-motion overrides for scanlines, glitch hover, marquee, and pulse/blink effects to keep motion static when requested.
+- Preserved existing route structure and loader-backed homepage status-strip data path; no featured-preview/admin curation workflow was introduced.
+- Applied final homepage polish from review: full-bleed home hero, removed duplicate mid-hero route links, increased CRT scanline visibility, and adjusted top nav container background clarity toward the reference.
+Commit: PRD-001 HOME-004: polish responsive behavior and homepage rollout (see git log hash)
 Blocked Reason: None
 Requested Decision: None

--- a/frontend/src/app/public-shell/ui/PublicShell.tsx
+++ b/frontend/src/app/public-shell/ui/PublicShell.tsx
@@ -1,15 +1,16 @@
 import { Outlet } from 'react-router-dom'
 import { SiteHeader } from '../../../widgets/site-header'
-import { SiteFooter } from '../../../widgets/site-footer'
+import { NowPlayingStrip, SiteFooter } from '../../../widgets/site-footer'
 
 export function PublicShell() {
   return (
     <div className="app-shell app-shell--public fx-scanlines">
       <SiteHeader />
-      <div className="app-shell__body">
+      <div className="app-shell__body app-shell__body--public">
         <Outlet />
       </div>
       <SiteFooter />
+      <NowPlayingStrip />
     </div>
   )
 }

--- a/frontend/src/app/routes/public.tsx
+++ b/frontend/src/app/routes/public.tsx
@@ -1,6 +1,6 @@
 import type { RouteObject } from 'react-router-dom'
 import { PublicShell } from '../public-shell'
-import { HomePage } from '../../pages/home'
+import { HomePage, homeLoader } from '../../pages/home'
 import { ThoughtsFeedPage } from '../../pages/thoughts/feed'
 import { ProjectsCatalogPage } from '../../pages/projects/catalog'
 import { PhotosGalleryPage, photosGalleryLoader } from '../../pages/photos/gallery'
@@ -10,7 +10,7 @@ export const publicRoutes: RouteObject = {
   path: '/',
   element: <PublicShell />,
   children: [
-    { index: true, element: <HomePage /> },
+    { index: true, loader: homeLoader, element: <HomePage /> },
     { path: 'thoughts', element: <ThoughtsFeedPage /> },
     { path: 'projects', element: <ProjectsCatalogPage /> },
     { path: 'photos', loader: photosGalleryLoader, element: <PhotosGalleryPage /> },

--- a/frontend/src/app/styles/global.css
+++ b/frontend/src/app/styles/global.css
@@ -82,6 +82,11 @@ button {
   padding-bottom: calc(var(--spacing-8) + 48px);
 }
 
+.app-shell__body--public:has(.home-page) {
+  padding-top: 0;
+  padding-bottom: 34px;
+}
+
 .app-shell__body:has(.photo-lightbox) {
   z-index: 40;
 }
@@ -142,9 +147,10 @@ button {
   align-items: center;
   justify-content: center;
   gap: 0;
-  padding: 8px 14px;
-  border: 1px solid var(--line-2);
-  background: rgba(7, 6, 11, 0.72);
+  padding: 8px 20px;
+  border: 1px solid rgba(138, 122, 184, 0.58);
+  background: rgba(10, 8, 18, 0.64);
+  box-shadow: none;
   pointer-events: auto;
 }
 
@@ -156,7 +162,7 @@ button {
 
 .site-header__separator {
   margin: 0 2px 0 6px;
-  color: var(--fg-3);
+  color: rgba(216, 198, 255, 0.42);
 }
 
 .site-header__link,
@@ -204,6 +210,18 @@ button {
 .action-button:hover {
   border-color: var(--line-neon);
   background: rgba(255, 46, 136, 0.1);
+  color: var(--fg-0);
+}
+
+.site-header__home:focus-visible,
+.site-header__link:focus-visible,
+.site-footer__link:focus-visible,
+.home-hero__wordmark:focus-visible,
+.action-button:focus-visible,
+.signal-link:focus-visible {
+  outline: 2px solid var(--neon-cyan);
+  outline-offset: 2px;
+  border-color: var(--neon-cyan);
   color: var(--fg-0);
 }
 
@@ -1893,13 +1911,14 @@ button {
 
 .home-page {
   position: relative;
+  width: 100%;
 }
 
 .home-hero {
   position: relative;
-  min-height: calc(100vh - 116px);
+  min-height: calc(100vh - 34px);
   overflow: hidden;
-  border: 1px solid var(--surface-border-soft);
+  border: 0;
   background: rgba(6, 5, 11, 0.48);
 }
 
@@ -1913,7 +1932,7 @@ button {
 }
 
 .home-hero__sky {
-  background: linear-gradient(180deg, var(--sunset-violet) 0%, var(--sunset-magenta) 50%, var(--sunset-orange) 100%);
+  background: linear-gradient(180deg, var(--sunset-violet) 0%, var(--sunset-magenta) 40%, var(--sunset-orange) 100%);
 }
 
 .home-hero__horizon {
@@ -1977,7 +1996,7 @@ button {
   position: relative;
   z-index: 1;
   display: flex;
-  min-height: calc(100vh - 116px);
+  min-height: calc(100vh - 34px);
   flex-direction: column;
   align-items: center;
   justify-content: center;
@@ -2048,32 +2067,6 @@ button {
   letter-spacing: 0.18em;
   text-transform: uppercase;
   animation: home-prompt-in 320ms steps(4);
-}
-
-.home-hero__routes {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 18px;
-  margin: 34px 0 0;
-}
-
-.home-hero__route-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  min-height: 30px;
-  padding: 0 2px;
-  border-bottom: 1px solid var(--line-1);
-  color: var(--fg-2);
-  font-size: 11px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-}
-
-.home-hero__route-link:hover {
-  border-color: var(--neon-pink);
-  color: var(--neon-pink);
 }
 
 .home-hero__status {
@@ -2519,6 +2512,20 @@ button {
   }
 }
 
+@media (max-width: 1024px) {
+  .app-shell__body--public {
+    padding-top: 108px;
+  }
+
+  .home-hero__inner {
+    padding-top: 148px;
+  }
+
+  .home-hero__status {
+    width: min(760px, calc(100% - 40px));
+  }
+}
+
 @media (max-width: 880px) {
   .admin-shell__inner {
     grid-template-columns: 1fr;
@@ -2574,16 +2581,37 @@ button {
   }
 
   .app-shell__body--public {
-    padding-top: 116px;
+    padding-top: 126px;
     padding-bottom: calc(var(--spacing-7) + 48px);
   }
 
-  .home-hero {
-    min-height: auto;
+  .site-header__home {
+    font-size: 10px;
+    letter-spacing: 0.14em;
+  }
+
+  .site-header__nav {
+    gap: 6px;
+    padding: 6px 8px;
+  }
+
+  .site-header__item-wrap {
+    gap: 6px;
+  }
+
+  .site-header__separator {
+    display: none;
+  }
+
+  .site-header__link {
+    min-height: 30px;
+    padding: 4px 8px;
+    font-size: 10px;
+    letter-spacing: 0.12em;
   }
 
   .home-hero__inner {
-    min-height: auto;
+    min-height: calc(100vh - 34px);
     padding: 132px 18px 36px;
   }
 
@@ -2596,21 +2624,20 @@ button {
     font-size: 1.15rem;
   }
 
-  .home-hero__routes {
-    gap: 10px;
-    margin-top: 24px;
-  }
-
-  .home-hero__route-link {
-    font-size: 10px;
-  }
-
   .home-hero__status {
     width: calc(100% - 24px);
     margin-bottom: 18px;
   }
 
-  .status-strip__header,
+  .status-strip__header {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .status-strip__header-meta {
+    width: 100%;
+  }
+
   .status-strip__row {
     grid-template-columns: 1fr;
   }

--- a/frontend/src/app/styles/global.css
+++ b/frontend/src/app/styles/global.css
@@ -77,19 +77,25 @@ button {
   padding: var(--spacing-6) 0 var(--spacing-8);
 }
 
+.app-shell__body--public {
+  padding-top: 96px;
+  padding-bottom: calc(var(--spacing-8) + 48px);
+}
+
 .app-shell__body:has(.photo-lightbox) {
   z-index: 40;
 }
 
 .site-header {
-  position: sticky;
+  position: fixed;
   top: 0;
-  z-index: 30;
-  border-bottom: 1px solid var(--surface-border-soft);
-  background: rgba(5, 4, 10, 0.92);
+  left: 0;
+  right: 0;
+  z-index: 32;
+  min-height: 72px;
+  pointer-events: none;
 }
 
-.site-header__inner,
 .admin-shell__inner {
   display: grid;
   grid-template-columns: auto 1fr;
@@ -98,39 +104,26 @@ button {
   padding: 18px 0;
 }
 
-.site-header__brand {
+.site-header__home {
+  position: fixed;
+  top: 22px;
+  left: 24px;
   display: inline-flex;
   align-items: center;
-  gap: var(--spacing-3);
+  min-height: 34px;
+  padding: 8px 10px;
+  border: 1px solid var(--line-2);
+  background: rgba(7, 6, 11, 0.72);
+  color: var(--fg-1);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  pointer-events: auto;
 }
 
-.site-header__brand-mark {
-  display: grid;
-  place-items: center;
-  width: 36px;
-  height: 36px;
-  border: 1px solid var(--surface-border);
-  background: linear-gradient(180deg, rgba(255, 46, 136, 0.08), rgba(34, 227, 255, 0.08));
-}
-
-.site-header__brand-lockup {
-  display: grid;
-  gap: 6px;
-}
-
-.site-header__brand-name {
+.site-header__home:hover {
   color: var(--fg-0);
-  font-family: var(--font-display);
-  font-size: 0.88rem;
-  letter-spacing: var(--tracking-wide);
-  text-transform: uppercase;
-}
-
-.site-header__brand-caption {
-  color: var(--fg-2);
-  font-size: 10px;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
+  border-color: var(--line-neon);
 }
 
 .site-header__nav,
@@ -142,7 +135,28 @@ button {
 }
 
 .site-header__nav {
-  justify-self: end;
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  padding: 8px 14px;
+  border: 1px solid var(--line-2);
+  background: rgba(7, 6, 11, 0.72);
+  pointer-events: auto;
+}
+
+.site-header__item-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.site-header__separator {
+  margin: 0 2px 0 6px;
+  color: var(--fg-3);
 }
 
 .site-header__link,
@@ -152,10 +166,10 @@ button {
   align-items: center;
   gap: 8px;
   justify-content: center;
-  min-height: 38px;
-  padding: 8px 12px;
+  min-height: 34px;
+  padding: 6px 10px;
   border: 1px solid transparent;
-  background: rgba(255, 255, 255, 0.02);
+  background: transparent;
   color: var(--fg-1);
   font-size: 11px;
   letter-spacing: 0.14em;
@@ -163,7 +177,7 @@ button {
 }
 
 .site-header__link {
-  font-family: var(--font-display);
+  white-space: nowrap;
 }
 
 .site-header__link-cursor {
@@ -189,16 +203,59 @@ button {
 .signal-link.is-active,
 .action-button:hover {
   border-color: var(--line-neon);
-  background: linear-gradient(90deg, rgba(255, 46, 136, 0.12), rgba(34, 227, 255, 0.05));
+  background: rgba(255, 46, 136, 0.1);
   color: var(--fg-0);
+}
+
+.shell-channel-bug {
+  position: fixed;
+  top: 22px;
+  right: 24px;
+  z-index: 33;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 34px;
+  padding: 6px 10px;
+  border: 1px solid rgba(216, 198, 255, 0.4);
+  background: rgba(7, 6, 11, 0.72);
+  color: var(--fg-0);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.shell-channel-bug__channel {
+  color: var(--fg-2);
+}
+
+.shell-channel-bug__separator {
+  width: 1px;
+  height: 12px;
+  background: rgba(216, 198, 255, 0.28);
+}
+
+.shell-channel-bug__live {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--neon-pink);
+}
+
+.shell-channel-bug__pulse {
+  width: 6px;
+  height: 6px;
+  background: var(--neon-pink);
+  box-shadow: 0 0 8px var(--neon-pink);
+  animation: cursor-blink 1.6s steps(1) infinite;
 }
 
 .site-footer {
   position: relative;
   z-index: 1;
-  padding: var(--spacing-7) 0;
+  padding: var(--spacing-7) 0 calc(var(--spacing-7) + 24px);
   border-top: 1px solid var(--surface-border-soft);
-  background: linear-gradient(180deg, rgba(5, 4, 10, 0.86), rgba(5, 4, 10, 0.98));
+  background: var(--bg-0);
 }
 
 .site-footer__grid {
@@ -222,7 +279,8 @@ button {
 .site-footer__link {
   justify-content: flex-start;
   width: fit-content;
-  padding: 0;
+  min-height: 28px;
+  padding: 0 2px;
   border: 0;
   background: transparent;
 }
@@ -235,14 +293,10 @@ button {
 .site-footer__social-icon {
   display: inline-grid;
   place-items: center;
-  min-width: 20px;
-  height: 20px;
+  min-width: 16px;
+  height: 16px;
   color: var(--neon-cyan);
   font-size: 10px;
-}
-
-.site-footer__social-icon {
-  border: 1px solid var(--surface-border);
 }
 
 .site-footer__meta {
@@ -267,6 +321,49 @@ button {
 
 .site-footer__meta-copy--muted {
   color: var(--fg-2);
+}
+
+.now-playing-strip {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 34;
+  display: flex;
+  align-items: center;
+  height: 34px;
+  border-top: 1px solid var(--neon-pink);
+  background: var(--bg-1);
+  overflow: hidden;
+}
+
+.now-playing-strip__inner {
+  display: flex;
+  white-space: nowrap;
+  color: var(--fg-1);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  animation: now-playing-marquee 42s linear infinite;
+  will-change: transform;
+}
+
+.now-playing-strip__fade {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 48px;
+  pointer-events: none;
+}
+
+.now-playing-strip__fade--left {
+  left: 0;
+  background: linear-gradient(90deg, var(--bg-1), transparent);
+}
+
+.now-playing-strip__fade--right {
+  right: 0;
+  background: linear-gradient(270deg, var(--bg-1), transparent);
 }
 
 .inline-label {
@@ -2397,15 +2494,37 @@ button {
 }
 
 @media (max-width: 880px) {
-  .site-header__inner,
   .admin-shell__inner {
     grid-template-columns: 1fr;
     align-items: flex-start;
   }
 
-  .site-header__nav,
   .admin-shell__nav {
     justify-self: stretch;
+  }
+
+  .site-header__home {
+    top: 16px;
+    left: 12px;
+  }
+
+  .site-header__nav {
+    top: 60px;
+    left: 12px;
+    right: 12px;
+    transform: none;
+    justify-content: flex-start;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .site-header__nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .shell-channel-bug {
+    top: 16px;
+    right: 12px;
   }
 
   .site-footer__grid {
@@ -2426,6 +2545,11 @@ button {
   .app-shell__body,
   .site-footer {
     padding-bottom: var(--spacing-7);
+  }
+
+  .app-shell__body--public {
+    padding-top: 116px;
+    padding-bottom: calc(var(--spacing-7) + 48px);
   }
 
   .home-hero {
@@ -2454,6 +2578,10 @@ button {
   .status-strip__header,
   .status-strip__row {
     grid-template-columns: 1fr;
+  }
+
+  .shell-channel-bug {
+    display: none;
   }
 
   .channel-bug {

--- a/frontend/src/app/styles/global.css
+++ b/frontend/src/app/styles/global.css
@@ -2041,13 +2041,39 @@ button {
 
 .home-hero__prompt {
   min-height: 1.5em;
-  margin: 52px 0 0;
+  margin: 42px 0 0;
   color: var(--fg-0);
   font-family: var(--font-pixel);
   font-size: clamp(1.25rem, 2.2vw, 1.7rem);
   letter-spacing: 0.18em;
   text-transform: uppercase;
   animation: home-prompt-in 320ms steps(4);
+}
+
+.home-hero__routes {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 18px;
+  margin: 34px 0 0;
+}
+
+.home-hero__route-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 30px;
+  padding: 0 2px;
+  border-bottom: 1px solid var(--line-1);
+  color: var(--fg-2);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.home-hero__route-link:hover {
+  border-color: var(--neon-pink);
+  color: var(--neon-pink);
 }
 
 .home-hero__status {
@@ -2568,6 +2594,15 @@ button {
   .home-hero__prompt {
     margin-top: 40px;
     font-size: 1.15rem;
+  }
+
+  .home-hero__routes {
+    gap: 10px;
+    margin-top: 24px;
+  }
+
+  .home-hero__route-link {
+    font-size: 10px;
   }
 
   .home-hero__status {

--- a/frontend/src/entities/status-strip/api/list-status-strip-entries.test.ts
+++ b/frontend/src/entities/status-strip/api/list-status-strip-entries.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { listStatusStripEntries } from './list-status-strip-entries'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('status strip API helper', () => {
+  it('maps /api/status-strip payload entries and normalizes unknown accents', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          items: [
+            {
+              accent: 'pink',
+              label: 'current focus',
+              value: 'cluster 3',
+            },
+            {
+              accent: null,
+              label: 'location',
+              value: 'Sao Paulo',
+            },
+            {
+              accent: 'invalid-tone',
+              label: 'signal',
+              value: 'projects + photos',
+            },
+          ],
+        }),
+        {
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await listStatusStripEntries()
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/status-strip')
+    expect(result).toEqual({
+      items: [
+        {
+          accent: 'pink',
+          label: 'current focus',
+          value: 'cluster 3',
+        },
+        {
+          label: 'location',
+          value: 'Sao Paulo',
+        },
+        {
+          label: 'signal',
+          value: 'projects + photos',
+        },
+      ],
+    })
+  })
+})

--- a/frontend/src/entities/status-strip/api/list-status-strip-entries.ts
+++ b/frontend/src/entities/status-strip/api/list-status-strip-entries.ts
@@ -1,0 +1,8 @@
+import { getJson } from '../../../shared/api'
+import { mapStatusStripEntries, type StatusStripEntriesSnapshotDto } from '../lib/mappers'
+
+export const listStatusStripEntries = async (signal?: AbortSignal) => {
+  const response = await getJson<StatusStripEntriesSnapshotDto>('/status-strip', { signal })
+
+  return mapStatusStripEntries(response)
+}

--- a/frontend/src/entities/status-strip/index.ts
+++ b/frontend/src/entities/status-strip/index.ts
@@ -1,2 +1,3 @@
-export type { StatusStripEntry } from './model/types'
-export { toStatusStripEntry } from './lib/mappers'
+export type { StatusStripEntriesSnapshot, StatusStripEntry } from './model/types'
+export { listStatusStripEntries } from './api/list-status-strip-entries'
+export { mapStatusStripEntries, toStatusStripEntry } from './lib/mappers'

--- a/frontend/src/entities/status-strip/lib/mappers.ts
+++ b/frontend/src/entities/status-strip/lib/mappers.ts
@@ -1,5 +1,35 @@
-import type { StatusStripEntry } from '../model/types'
+import type { StatusStripEntriesSnapshot, StatusStripEntry } from '../model/types'
+
+export type StatusStripEntryDto = Readonly<{
+  accent?: string | null
+  label: string
+  value: string
+}>
+
+export type StatusStripEntriesSnapshotDto = Readonly<{
+  items: readonly StatusStripEntryDto[]
+}>
+
+const parseAccent = (value: StatusStripEntryDto['accent']): StatusStripEntry['accent'] | undefined => {
+  if (value === 'amber' || value === 'cyan' || value === 'pink') {
+    return value
+  }
+
+  return undefined
+}
 
 export function toStatusStripEntry(input: StatusStripEntry): StatusStripEntry {
   return { ...input }
+}
+
+export function mapStatusStripEntries(input: StatusStripEntriesSnapshotDto): StatusStripEntriesSnapshot {
+  return {
+    items: input.items.map((item) =>
+      toStatusStripEntry({
+        accent: parseAccent(item.accent),
+        label: item.label,
+        value: item.value,
+      }),
+    ),
+  }
 }

--- a/frontend/src/entities/status-strip/model/types.ts
+++ b/frontend/src/entities/status-strip/model/types.ts
@@ -3,3 +3,7 @@ export type StatusStripEntry = {
   label: string
   value: string
 }
+
+export type StatusStripEntriesSnapshot = Readonly<{
+  items: readonly StatusStripEntry[]
+}>

--- a/frontend/src/pages/home/index.ts
+++ b/frontend/src/pages/home/index.ts
@@ -1,1 +1,2 @@
 export { HomePage } from './ui/HomePage'
+export { homeLoader } from './route'

--- a/frontend/src/pages/home/route.test.ts
+++ b/frontend/src/pages/home/route.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { homeLoader } from './route'
+
+const mocks = vi.hoisted(() => ({
+  listStatusStripEntries: vi.fn(),
+}))
+
+vi.mock('../../entities/status-strip', () => ({
+  listStatusStripEntries: mocks.listStatusStripEntries,
+}))
+
+const loaderArgs = (request: Request): Parameters<typeof homeLoader>[0] =>
+  ({
+    params: {},
+    request,
+  }) as Parameters<typeof homeLoader>[0]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('home route', () => {
+  it('loads status-strip entries from the frontend API boundary', async () => {
+    mocks.listStatusStripEntries.mockResolvedValueOnce({
+      items: [
+        {
+          accent: 'pink',
+          label: 'current focus',
+          value: 'cluster 3',
+        },
+      ],
+    })
+
+    const request = new Request('http://localhost/')
+    const result = await homeLoader(loaderArgs(request))
+
+    expect(mocks.listStatusStripEntries).toHaveBeenCalledWith(request.signal)
+    expect(result).toEqual({
+      statusEntries: [
+        {
+          accent: 'pink',
+          label: 'current focus',
+          value: 'cluster 3',
+        },
+      ],
+    })
+  })
+
+  it('falls back to seeded entries when the API returns no status rows', async () => {
+    mocks.listStatusStripEntries.mockResolvedValueOnce({
+      items: [],
+    })
+
+    const result = await homeLoader(loaderArgs(new Request('http://localhost/')))
+
+    expect(result.statusEntries).toHaveLength(4)
+    expect(result.statusEntries[0]).toMatchObject({
+      accent: 'pink',
+      label: 'Now Building',
+    })
+  })
+})

--- a/frontend/src/pages/home/route.ts
+++ b/frontend/src/pages/home/route.ts
@@ -1,0 +1,36 @@
+import type { LoaderFunctionArgs } from 'react-router-dom'
+import { listStatusStripEntries, type StatusStripEntry } from '../../entities/status-strip'
+
+const fallbackStatusEntries: StatusStripEntry[] = [
+  {
+    accent: 'pink',
+    label: 'Now Building',
+    value: 'frontend migration wave // typed Vite shell',
+  },
+  {
+    label: 'Location',
+    value: 'sao paulo // gmt-3 // after midnight',
+  },
+  {
+    accent: 'cyan',
+    label: 'Current Focus',
+    value: 'home route, shared chrome, and neon tape deck polish',
+  },
+  {
+    accent: 'amber',
+    label: 'Signal',
+    value: 'projects, photos, thoughts, and chat room incoming',
+  },
+]
+
+export type HomeLoaderData = {
+  statusEntries: readonly StatusStripEntry[]
+}
+
+export const homeLoader = async ({ request }: LoaderFunctionArgs) => {
+  const response = await listStatusStripEntries(request.signal)
+
+  return {
+    statusEntries: response.items.length > 0 ? response.items : fallbackStatusEntries,
+  } satisfies HomeLoaderData
+}

--- a/frontend/src/pages/home/ui/HomePage.test.tsx
+++ b/frontend/src/pages/home/ui/HomePage.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+
+import { HomePage } from './HomePage'
+
+describe('home page', () => {
+  it('renders loader-provided status entries and route cues', async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/',
+          loader: () => ({
+            statusEntries: [
+              {
+                accent: 'pink',
+                label: 'current focus',
+                value: 'cluster 3',
+              },
+              {
+                label: 'location',
+                value: 'sao paulo',
+              },
+            ],
+          }),
+          element: <HomePage />,
+        },
+      ],
+      {
+        initialEntries: ['/'],
+      },
+    )
+
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByText('cluster 3')).toBeInTheDocument()
+
+    const photosLink = screen.getByRole('link', { name: /photos/i })
+    const projectsLink = screen.getByRole('link', { name: /projects/i })
+    const thoughtsLink = screen.getByRole('link', { name: /thoughts/i })
+    const chatLink = screen.getByRole('link', { name: /chat room/i })
+
+    expect(photosLink).toHaveAttribute('href', '/photos')
+    expect(projectsLink).toHaveAttribute('href', '/projects')
+    expect(thoughtsLink).toHaveAttribute('href', '/thoughts')
+    expect(chatLink).toHaveAttribute('href', '/chat')
+  })
+})

--- a/frontend/src/pages/home/ui/HomePage.test.tsx
+++ b/frontend/src/pages/home/ui/HomePage.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 import { HomePage } from './HomePage'
 
 describe('home page', () => {
-  it('renders loader-provided status entries and route cues', async () => {
+  it('renders loader-provided status entries', async () => {
     const router = createMemoryRouter(
       [
         {
@@ -35,14 +35,6 @@ describe('home page', () => {
 
     expect(await screen.findByText('cluster 3')).toBeInTheDocument()
 
-    const photosLink = screen.getByRole('link', { name: /photos/i })
-    const projectsLink = screen.getByRole('link', { name: /projects/i })
-    const thoughtsLink = screen.getByRole('link', { name: /thoughts/i })
-    const chatLink = screen.getByRole('link', { name: /chat room/i })
-
-    expect(photosLink).toHaveAttribute('href', '/photos')
-    expect(projectsLink).toHaveAttribute('href', '/projects')
-    expect(thoughtsLink).toHaveAttribute('href', '/thoughts')
-    expect(chatLink).toHaveAttribute('href', '/chat')
+    expect(screen.queryByRole('link', { name: /photos/i })).toBeNull()
   })
 })

--- a/frontend/src/pages/home/ui/HomePage.tsx
+++ b/frontend/src/pages/home/ui/HomePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useLoaderData } from 'react-router-dom'
+import { Link, useLoaderData } from 'react-router-dom'
 import { StatusStrip } from '../../../widgets/status-strip'
 import { Container } from '../../../shared/ui'
 import type { HomeLoaderData } from '../route'
@@ -9,6 +9,13 @@ const attractPrompts = [
   'press [ any key ] to enter',
   'insert coin to continue',
   'select a channel above',
+] as const
+
+const routeCues = [
+  { label: 'photos', to: '/photos' },
+  { label: 'projects', to: '/projects' },
+  { label: 'thoughts', to: '/thoughts' },
+  { label: 'chat room', to: '/chat' },
 ] as const
 
 export function HomePage() {
@@ -61,6 +68,14 @@ export function HomePage() {
             <p className="home-hero__prompt" key={attractPrompts[attractIndex]}>
               {attractPrompts[attractIndex]}
             </p>
+            <nav className="home-hero__routes" aria-label="Homepage route cues">
+              {routeCues.map((route) => (
+                <Link key={route.to} to={route.to} className="home-hero__route-link glitch-hover">
+                  <span aria-hidden="true">→</span>
+                  {route.label}
+                </Link>
+              ))}
+            </nav>
           </div>
           <StatusStrip className="home-hero__status" entries={statusEntries} />
         </section>

--- a/frontend/src/pages/home/ui/HomePage.tsx
+++ b/frontend/src/pages/home/ui/HomePage.tsx
@@ -3,7 +3,6 @@ import { useLoaderData } from 'react-router-dom'
 import { StatusStrip } from '../../../widgets/status-strip'
 import { Container } from '../../../shared/ui'
 import type { HomeLoaderData } from '../route'
-import { ChannelBug } from './ChannelBug'
 import { ChannelChangeOverlay } from './ChannelChangeOverlay'
 
 const attractPrompts = [
@@ -38,7 +37,6 @@ export function HomePage() {
             <span className="home-hero__tick home-hero__tick--bl" />
             <span className="home-hero__tick home-hero__tick--br" />
           </div>
-          <ChannelBug onOpen={() => setIsChannelChangeOpen(true)} />
           <div className="home-hero__inner">
             <p className="home-hero__caption">transmitting from sao paulo // ch.03</p>
             <h1 className="home-hero__title">

--- a/frontend/src/pages/home/ui/HomePage.tsx
+++ b/frontend/src/pages/home/ui/HomePage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
-import type { StatusStripEntry } from '../../../entities/status-strip'
+import { useLoaderData } from 'react-router-dom'
 import { StatusStrip } from '../../../widgets/status-strip'
 import { Container } from '../../../shared/ui'
+import type { HomeLoaderData } from '../route'
 import { ChannelBug } from './ChannelBug'
 import { ChannelChangeOverlay } from './ChannelChangeOverlay'
 
@@ -11,29 +12,8 @@ const attractPrompts = [
   'select a channel above',
 ] as const
 
-const homeStatusEntries: StatusStripEntry[] = [
-  {
-    accent: 'pink',
-    label: 'Now Building',
-    value: 'frontend migration wave // typed Vite shell',
-  },
-  {
-    label: 'Location',
-    value: 'sao paulo // gmt-3 // after midnight',
-  },
-  {
-    accent: 'cyan',
-    label: 'Current Focus',
-    value: 'home route, shared chrome, and neon tape deck polish',
-  },
-  {
-    accent: 'amber',
-    label: 'Signal',
-    value: 'projects, photos, thoughts, and chat room incoming',
-  },
-]
-
 export function HomePage() {
+  const { statusEntries } = useLoaderData() as HomeLoaderData
   const [attractIndex, setAttractIndex] = useState(0)
   const [isChannelChangeOpen, setIsChannelChangeOpen] = useState(false)
 
@@ -84,7 +64,7 @@ export function HomePage() {
               {attractPrompts[attractIndex]}
             </p>
           </div>
-          <StatusStrip className="home-hero__status" entries={homeStatusEntries} />
+          <StatusStrip className="home-hero__status" entries={statusEntries} />
         </section>
       </Container>
       <ChannelChangeOverlay

--- a/frontend/src/pages/home/ui/HomePage.tsx
+++ b/frontend/src/pages/home/ui/HomePage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
-import { Link, useLoaderData } from 'react-router-dom'
+import { useLoaderData } from 'react-router-dom'
 import { StatusStrip } from '../../../widgets/status-strip'
-import { Container } from '../../../shared/ui'
 import type { HomeLoaderData } from '../route'
 import { ChannelChangeOverlay } from './ChannelChangeOverlay'
 
@@ -9,13 +8,6 @@ const attractPrompts = [
   'press [ any key ] to enter',
   'insert coin to continue',
   'select a channel above',
-] as const
-
-const routeCues = [
-  { label: 'photos', to: '/photos' },
-  { label: 'projects', to: '/projects' },
-  { label: 'thoughts', to: '/thoughts' },
-  { label: 'chat room', to: '/chat' },
 ] as const
 
 export function HomePage() {
@@ -33,7 +25,7 @@ export function HomePage() {
 
   return (
     <>
-      <Container className="home-page">
+      <div className="home-page">
         <section className="home-hero fx-vignette">
           <div className="home-hero__sky" aria-hidden="true" />
           <div className="home-hero__horizon" aria-hidden="true" />
@@ -68,18 +60,10 @@ export function HomePage() {
             <p className="home-hero__prompt" key={attractPrompts[attractIndex]}>
               {attractPrompts[attractIndex]}
             </p>
-            <nav className="home-hero__routes" aria-label="Homepage route cues">
-              {routeCues.map((route) => (
-                <Link key={route.to} to={route.to} className="home-hero__route-link glitch-hover">
-                  <span aria-hidden="true">→</span>
-                  {route.label}
-                </Link>
-              ))}
-            </nav>
           </div>
           <StatusStrip className="home-hero__status" entries={statusEntries} />
         </section>
-      </Container>
+      </div>
       <ChannelChangeOverlay
         key={isChannelChangeOpen ? 'open' : 'closed'}
         open={isChannelChangeOpen}

--- a/frontend/src/shared/config/index.ts
+++ b/frontend/src/shared/config/index.ts
@@ -6,30 +6,32 @@ type NavigationItem = {
 
 type SocialItem = {
   href: string
-  icon: string
   label: string
 }
 
 export const publicNavigation: readonly NavigationItem[] = [
-  { label: 'Photos', to: '/photos' },
-  { label: 'Projects', to: '/projects' },
-  { label: 'Thoughts', to: '/thoughts' },
-  { detail: 'auth', label: 'Chat Room', to: '/chat' },
+  { label: 'photos', to: '/photos' },
+  { label: 'projects', to: '/projects' },
+  { label: 'thoughts', to: '/thoughts' },
+  { detail: 'auth', label: 'chat room', to: '/chat' },
 ] as const
 
-export const footerNavigation: readonly NavigationItem[] = [
-  { label: 'Photos', to: '/photos' },
-  { label: 'Projects', to: '/projects' },
-  { label: 'Thoughts', to: '/thoughts' },
-  { detail: 'auth', label: 'Chat Room', to: '/chat' },
-] as const
+export const footerNavigation: readonly NavigationItem[] = [...publicNavigation]
 
 export const socialNavigation: readonly SocialItem[] = [
-  { href: 'https://instagram.com', icon: 'IG', label: 'Instagram' },
-  { href: 'https://x.com', icon: 'X', label: 'X.com' },
-  { href: 'https://github.com/Vinicius-Marcondes', icon: 'GH', label: 'GitHub' },
-  { href: 'https://linkedin.com', icon: 'IN', label: 'LinkedIn' },
-  { href: 'https://reddit.com', icon: 'RD', label: 'Reddit' },
+  { href: 'https://instagram.com', label: 'instagram' },
+  { href: 'https://x.com', label: 'x.com' },
+  { href: 'https://github.com/Vinicius-Marcondes', label: 'github' },
+  { href: 'https://linkedin.com', label: 'linkedin' },
+  { href: 'https://reddit.com', label: 'reddit' },
+] as const
+
+export const nowPlayingItems = [
+  '► now playing // home route status strip online',
+  'runtime 00:24:11',
+  'sao paulo // gmt-3 // late shift',
+  'projects, photos, thoughts, and chat room',
+  'vinicius.dev // channel 03',
 ] as const
 
 export const adminNavigation = [

--- a/frontend/src/shared/styles/effects.css
+++ b/frontend/src/shared/styles/effects.css
@@ -16,7 +16,7 @@
 }
 
 .glitch-hover:hover {
-  animation: subtle-glitch 180ms steps(2) 1;
+  animation: subtle-glitch 240ms steps(4) 1;
 }
 
 .fx-crt-title {

--- a/frontend/src/shared/styles/effects.css
+++ b/frontend/src/shared/styles/effects.css
@@ -5,14 +5,10 @@
   pointer-events: none;
   z-index: 40;
   background: repeating-linear-gradient(
-    180deg,
-    rgba(255, 255, 255, 0.025) 0,
-    rgba(255, 255, 255, 0.025) 1px,
-    transparent 1px,
-    transparent 4px
+    to bottom,
+    rgba(255, 255, 255, 0.05) 0 1px,
+    transparent 1px 3px
   );
-  mix-blend-mode: screen;
-  opacity: 0.22;
 }
 
 .glitch-hover:hover {
@@ -21,8 +17,10 @@
 
 .fx-crt-title {
   text-shadow:
-    -1px 0 0 rgba(255, 46, 136, 0.9),
-    1px 0 0 rgba(34, 227, 255, 0.9);
+    -3px 0 0 rgba(255, 46, 136, 0.9),
+    3px 0 0 rgba(34, 227, 255, 0.9);
+  animation: rare-glitch 2s steps(1, end) infinite;
+  will-change: transform;
 }
 
 .fx-vignette::after {
@@ -30,5 +28,9 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(ellipse at 50% 45%, transparent 30%, rgba(0, 0, 0, 0.88) 100%);
+  background: radial-gradient(
+          ellipse at 50% 45%,
+          transparent 35%,
+          rgba(0, 0, 0, 0.82) 100%
+  );
 }

--- a/frontend/src/shared/styles/motion.css
+++ b/frontend/src/shared/styles/motion.css
@@ -4,6 +4,28 @@
   }
 }
 
+@keyframes rare-glitch {
+  /* stays still almost all the time */
+  0%, 97.8% {
+    transform: translateX(0);
+  }
+
+  /* sudden jump right */
+  98.0% {
+    transform: translateX(28px);
+  }
+
+  /* quick snap left */
+  98.2% {
+    transform: translateX(-10px);
+  }
+
+  /* back to center */
+  98.4%, 100% {
+    transform: translateX(0);
+  }
+}
+
 @keyframes subtle-glitch {
   0%,
   100% {

--- a/frontend/src/shared/styles/motion.css
+++ b/frontend/src/shared/styles/motion.css
@@ -14,3 +14,23 @@
     transform: translate(1px, -1px);
   }
 }
+
+@keyframes now-playing-marquee {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/frontend/src/shared/styles/tokens.css
+++ b/frontend/src/shared/styles/tokens.css
@@ -1,9 +1,9 @@
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Press+Start+2P&family=VT323&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&family=Fira+Mono:wght@400;500;700&display=swap');
 
 :root {
-  --bg-0: #05040a;
-  --bg-1: #0b0912;
-  --bg-2: #140f1f;
+  --bg-0: #07060b;
+  --bg-1: #0d0b14;
+  --bg-2: #151122;
   --bg-3: #1e1730;
   --fg-0: #f5ecff;
   --fg-1: #dccdff;
@@ -24,21 +24,21 @@
   --line-1: rgba(216, 198, 255, 0.14);
   --line-2: rgba(216, 198, 255, 0.28);
   --line-neon: rgba(255, 46, 136, 0.58);
-  --font-display: 'Press Start 2P', 'VT323', ui-monospace, monospace;
-  --font-pixel: 'VT323', 'Press Start 2P', ui-monospace, monospace;
-  --font-body: 'IBM Plex Mono', 'SFMono-Regular', ui-monospace, monospace;
+  --font-display: 'Press Start 2P', ui-monospace, monospace;
+  --font-pixel: 'VT323', ui-monospace, monospace;
+  --font-body: 'Fira Mono', ui-monospace, Menlo, Consolas, monospace;
   --fs-display-xl: clamp(2.8rem, 9vw, 6.25rem);
   --fs-display-lg: clamp(2rem, 6vw, 3.3rem);
   --fs-display-md: clamp(1.5rem, 4vw, 2.3rem);
   --fs-pixel-lg: clamp(1.35rem, 3vw, 2rem);
   --fs-body-lg: 18px;
-  --fs-body: 15px;
+  --fs-body: 14px;
   --fs-body-sm: 13px;
   --fs-caption: 11px;
   --lh-tight: 1.05;
   --lh-body: 1.6;
   --tracking-wide: 0.08em;
-  --tracking-caps: 0.18em;
+  --tracking-caps: 0.16em;
   --spacing-1: 4px;
   --spacing-2: 8px;
   --spacing-3: 12px;
@@ -53,7 +53,7 @@
   --surface-bg-strong: rgba(7, 6, 11, 0.94);
   --surface-border: var(--line-2);
   --surface-border-soft: var(--line-1);
-  --glow-pink: 0 0 0 1px rgba(255, 46, 136, 0.44), 0 0 26px rgba(255, 46, 136, 0.18);
-  --glow-cyan: 0 0 0 1px rgba(34, 227, 255, 0.4), 0 0 20px rgba(34, 227, 255, 0.14);
+  --glow-pink: 0 0 0 1px var(--neon-pink), 0 0 24px rgba(255, 46, 136, 0.55);
+  --glow-cyan: 0 0 0 1px var(--neon-cyan), 0 0 20px rgba(34, 227, 255, 0.45);
   --shell-max-width: 1160px;
 }

--- a/frontend/src/widgets/site-footer/index.ts
+++ b/frontend/src/widgets/site-footer/index.ts
@@ -1,1 +1,2 @@
 export { SiteFooter } from './ui/SiteFooter'
+export { NowPlayingStrip } from './ui/NowPlayingStrip'

--- a/frontend/src/widgets/site-footer/ui/NowPlayingStrip.tsx
+++ b/frontend/src/widgets/site-footer/ui/NowPlayingStrip.tsx
@@ -1,0 +1,20 @@
+import { nowPlayingItems } from '../../../shared/config'
+
+const separator = '   //   '
+
+const buildMarqueeText = (items: readonly string[]) => `${items.join(separator)}${separator}`
+
+export function NowPlayingStrip() {
+  const text = buildMarqueeText(nowPlayingItems)
+
+  return (
+    <div className="now-playing-strip" aria-label="Now playing marquee">
+      <div className="now-playing-strip__inner" aria-hidden="true">
+        <span>{text}{text}</span>
+      </div>
+      <span className="sr-only">{text}</span>
+      <div className="now-playing-strip__fade now-playing-strip__fade--left" aria-hidden="true" />
+      <div className="now-playing-strip__fade now-playing-strip__fade--right" aria-hidden="true" />
+    </div>
+  )
+}

--- a/frontend/src/widgets/site-footer/ui/SiteFooter.tsx
+++ b/frontend/src/widgets/site-footer/ui/SiteFooter.tsx
@@ -14,15 +14,15 @@ export function SiteFooter() {
                   key={item.to}
                   to={item.to}
                   className={({ isActive }) =>
-                    isActive ? 'site-footer__link site-footer__link--active' : 'site-footer__link'
+                    isActive ? 'site-footer__link site-footer__link--active glitch-hover' : 'site-footer__link glitch-hover'
                   }
                 >
                   <span className="site-footer__link-glyph" aria-hidden="true">
                     &gt;
                   </span>
                   <span>
-                    {item.label}
-                    {item.detail ? <span className="site-footer__link-detail">// {item.detail}</span> : null}
+                    [ {item.label}
+                    {item.detail ? <span className="site-footer__link-detail">// {item.detail}</span> : null} ]
                   </span>
                 </SignalLink>
               ))}
@@ -37,10 +37,10 @@ export function SiteFooter() {
                   href={item.href}
                   target="_blank"
                   rel="noreferrer"
-                  className="site-footer__link"
+                  className="site-footer__link glitch-hover"
                 >
                   <span className="site-footer__social-icon" aria-hidden="true">
-                    {item.icon}
+                    ↗
                   </span>
                   <span>{item.label}</span>
                 </SignalLink>

--- a/frontend/src/widgets/site-header/index.ts
+++ b/frontend/src/widgets/site-header/index.ts
@@ -1,1 +1,2 @@
 export { SiteHeader } from './ui/SiteHeader'
+export { ChannelBug } from './ui/ChannelBug'

--- a/frontend/src/widgets/site-header/ui/ChannelBug.tsx
+++ b/frontend/src/widgets/site-header/ui/ChannelBug.tsx
@@ -1,0 +1,16 @@
+type ChannelBugProps = {
+  channel?: number
+}
+
+export function ChannelBug({ channel = 3 }: ChannelBugProps) {
+  return (
+    <div className="shell-channel-bug" aria-label={`Live channel ${String(channel).padStart(2, '0')}`}>
+      <span className="shell-channel-bug__channel">CH.{String(channel).padStart(2, '0')}</span>
+      <span className="shell-channel-bug__separator" aria-hidden="true" />
+      <span className="shell-channel-bug__live">
+        <span className="shell-channel-bug__pulse" aria-hidden="true" />
+        live
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/widgets/site-header/ui/SiteHeader.tsx
+++ b/frontend/src/widgets/site-header/ui/SiteHeader.tsx
@@ -1,42 +1,38 @@
 import { NavLink } from 'react-router-dom'
-import logoMarkUrl from '../../../shared/assets/logo-mark.svg'
 import { publicNavigation } from '../../../shared/config'
 import { cx } from '../../../shared/lib'
-import { Container } from '../../../shared/ui'
+import { ChannelBug } from './ChannelBug'
 
 export function SiteHeader() {
   return (
-    <header className="site-header">
-      <Container>
-        <div className="site-header__inner">
-          <NavLink to="/" className="site-header__brand glitch-hover">
-            <span className="site-header__brand-mark">
-              <img src={logoMarkUrl} alt="" aria-hidden="true" width="18" height="18" />
-            </span>
-            <span className="site-header__brand-lockup">
-              <span className="site-header__brand-name">vinicius.dev</span>
-              <span className="site-header__brand-caption">late-night transmission // sao paulo</span>
-            </span>
-          </NavLink>
-          <nav className="site-header__nav" aria-label="Primary navigation">
-            {publicNavigation.map((item) => (
-              <NavLink
-                key={item.to}
-                to={item.to}
-                className={({ isActive }) => cx('site-header__link glitch-hover', isActive && 'is-active')}
-              >
-                <span className="site-header__link-cursor" aria-hidden="true">
-                  ►
-                </span>
-                <span>
-                  [ {item.label}
-                  {item.detail ? <span className="site-header__link-detail">// {item.detail}</span> : null} ]
-                </span>
-              </NavLink>
-            ))}
-          </nav>
-        </div>
-      </Container>
+    <header className="site-header" role="banner">
+      <NavLink to="/" className="site-header__home glitch-hover">
+        [ vinicius.dev ]
+      </NavLink>
+      <nav className="site-header__nav" aria-label="Primary navigation">
+        {publicNavigation.map((item, index) => (
+          <span key={item.to} className="site-header__item-wrap">
+            {index > 0 ? (
+              <span className="site-header__separator" aria-hidden="true">
+                ·
+              </span>
+            ) : null}
+            <NavLink
+              to={item.to}
+              className={({ isActive }) => cx('site-header__link glitch-hover', isActive && 'is-active')}
+            >
+              <span className="site-header__link-cursor" aria-hidden="true">
+                ►
+              </span>
+              <span>
+                [ {item.label}
+                {item.detail ? <span className="site-header__link-detail">// {item.detail}</span> : null} ]
+              </span>
+            </NavLink>
+          </span>
+        ))}
+      </nav>
+      <ChannelBug />
     </header>
   )
 }

--- a/frontend/src/widgets/status-strip/ui/StatusStrip.tsx
+++ b/frontend/src/widgets/status-strip/ui/StatusStrip.tsx
@@ -11,7 +11,7 @@ const seedEntries: StatusStripEntry[] = [
 
 type StatusStripProps = {
   className?: string
-  entries?: StatusStripEntry[]
+  entries?: readonly StatusStripEntry[]
   label?: string
 }
 


### PR DESCRIPTION
## Summary                                                                             
   Implements PRD-001 homepage refresh to match the V2 reference direction, while         
 preserving current route architecture and wired data flow.                               
                                                                                          
   ## Accepted tasks                                                                      
   - HOME-001 — Wire homepage data loader and status-strip API                            
   - HOME-002 — Refactor shared public chrome to the V2 direction                         
   - HOME-003 — Rebuild the homepage route for reference parity                           
   - HOME-004 — Polish responsive behavior and verify homepage rollout                    
                                                                                          
   ## Commits                                                                             
   - c81effa — PRD-001 HOME-001: wire homepage loader to status-strip API                 
   - e554b31 — PRD-001 HOME-002: refactor shared public chrome to v2 direction            
   - 2533e37 — PRD-001 HOME-003: rebuild homepage route for reference parity              
   - 08a220e — PRD-001 HOME-004: polish responsive behavior and homepage rollout          
                                                                                          
   ## What changed                                                                        
   - Added dedicated home loader + `/api/status-strip` frontend mapping with              
 deterministic tests.                                                                     
   - Refactored shared public shell chrome:                                               
     - fixed top nav                                                                      
     - fixed channel bug                                                                  
     - fixed now-playing bottom strip                                                     
   - Rebuilt homepage hero/composition to V2-inspired layout adapted to real              
 routes/content.                                                                          
   - Final responsive + accessibility/motion polish:                                      
     - improved breakpoints for shell/home                                                
     - visible `:focus-visible` treatment                                                 
     - reduced-motion behavior for glitch/scanline/marquee effects                        
   - Final visual tuning from review feedback:                                            
     - full-bleed hero                                                                    
     - removed duplicated mid-hero links                                                  
     - stronger CRT scanline effect                                                       
     - clearer nav container background                                                   
                                                                                          
   ## Verification                                                                        
   - `cd frontend && bun run test`                                                     
   - `cd frontend && bun run build`                                               
                                                                                          
   ## Scope notes                                                                         
   - Preserves real public routes (`/photos`, `/projects`, `/thoughts`, `/chat`).         
   - Preserves backend-wired homepage status-strip data path.                             
   - Does not introduce new featured-preview/admin curation workflows (per PRD            
 exception).