### PR TITLE
PRD-003: CI validation reliability

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  BUN_VERSION: 1.3.11
+
 concurrency:
   group: branch-validation-${{ github.ref }}
   cancel-in-progress: true
@@ -26,6 +29,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -51,6 +56,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/docs/TRACKER.md
+++ b/docs/TRACKER.md
@@ -13,94 +13,83 @@
 - For `Review Mode: Agent`, verify, accept, commit, and continue when appropriate.
 
 ## PRD
-- ID: PRD-002
-- Title: Admin Dashboard Control Deck Restyle
+- ID: PRD-003
+- Title: CI Validation Reliability
 - Status: Active
-- PRD File: docs/prds/PRD-002/PRD-002.md
-- Summary: Restyle `/admin/dashboard` to match the control-deck reference while preserving backend-connected dashboard behavior and admin photo workflows.
+- PRD File: docs/prds/PRD-003/PRD-003.md
+- Summary: Fix recurring GitHub Actions validation failures by stabilizing the frontend chat media test fixture, aligning branch validation with the pinned Bun runtime, and preserving the existing PR, branch, and tag-only production validation contract.
 
 ## Git
-- Branch: feature/PRD-002-admin-dashboard-control-deck-restyle
+- Branch: feature/PRD-003-ci-validation-reliability
 - Base: develop
 - Merge Target: develop
 
 ## Current Task
-DASH-004
+CI-001
 
 ## Task Index
-1. DASH-001 - Lock dashboard behavior tests
-   - Task File: docs/prds/PRD-002/tasks/DASH-001.md
+1. CI-001 - Repair chat media test fixture
+   - Task File: docs/prds/PRD-003/tasks/CI-001.md
    - Status: Accepted
-2. DASH-002 - Map reference structure into dashboard components
-   - Task File: docs/prds/PRD-002/tasks/DASH-002.md
-   - Status: Accepted
-3. DASH-003 - Apply control-deck visual style
-   - Task File: docs/prds/PRD-002/tasks/DASH-003.md
-   - Status: Accepted
-4. DASH-004 - Verify admin photo regressions and final rollout
-   - Task File: docs/prds/PRD-002/tasks/DASH-004.md
-   - Status: Accepted
+2. CI-002 - Pin branch validation Bun version
+   - Task File: docs/prds/PRD-003/tasks/CI-002.md
+   - Status: Todo
+3. CI-003 - Run full local validation sweep
+   - Task File: docs/prds/PRD-003/tasks/CI-003.md
+   - Status: Todo
+4. CI-004 - Confirm remote CI acceptance
+   - Task File: docs/prds/PRD-003/tasks/CI-004.md
+   - Status: Todo
 
 ## Tasks
 
-### DASH-001 - Lock dashboard behavior tests
-Task File: docs/prds/PRD-002/tasks/DASH-001.md
+### CI-001 - Repair chat media test fixture
+Task File: docs/prds/PRD-003/tasks/CI-001.md
 Status: Accepted
 Evidence:
-- 2026-05-10: `cd frontend && bun run test -- AdminDashboardPage.test.tsx route.test.ts` -> passed. Vitest reported 5 files passed, 19 tests passed, duration 797ms.
-- 2026-05-10: Coordinator rerun `cd frontend && bun run test -- AdminDashboardPage.test.tsx route.test.ts` -> passed. Vitest reported 5 files passed, 19 tests passed, duration 696ms.
+- Started CI-001 only; inspected `frontend/src/entities/chat/api/room-runtime.ts` and `frontend/src/entities/chat/api/room-runtime.test.ts`.
+- `cd frontend && bun run test -- room-runtime.test.ts` - failed once after adding a media-session-header assertion because the media request uses a plain header record instead of a `Headers` instance; adjusted the test assertion without changing runtime code.
+- `cd frontend && bun run test -- room-runtime.test.ts` - passed: 1 test file, 2 tests.
+- `cd frontend && bun run lint` - passed.
+- `cd frontend && bun run build` - passed: `tsc -b && vite build`.
+- `cd frontend && bun run test` - passed: 22 test files, 44 tests.
 Decision Log:
-- 2026-05-10: Started DASH-001 on current branch; scope limited to dashboard behavior tests and minimal accessibility/testability fixes if required.
-- 2026-05-10: Expanded dashboard page tests for backend-provided panel values, content queue rows, room access fields, generated-empty state, pending rotation, successful rotation with revoked-session count, and rotation failure feedback.
-- 2026-05-10: Split route tests so unauthorized redirect to `/admin/login` and missing room access tolerance are preserved as explicit cases.
-- 2026-05-10: No production component changes were required; current labeled fields and disabled button state supported reliable accessible tests.
+- Keep the change scoped to the chat runtime test fixture because `getChatAttachmentObjectUrl` already consumes `response.blob()` and does not require a real `Response` instance for the success path.
+- Replaced the protected-media `new Response(new Blob(...))` fixture with a runner-stable object exposing `blob()`, `headers`, `ok`, and `status`.
+- Preserved protected media URL coverage, verified the chat room session header on the media request, and verified `URL.createObjectURL` receives the returned blob while `getChatAttachmentObjectUrl` surfaces the object URL.
 Commit: Pending
 Blocked Reason: None
 Requested Decision: None
 
-### DASH-002 - Map reference structure into dashboard components
-Task File: docs/prds/PRD-002/tasks/DASH-002.md
-Status: Accepted
+### CI-002 - Pin branch validation Bun version
+Task File: docs/prds/PRD-003/tasks/CI-002.md
+Status: Todo
 Evidence:
-- 2026-05-10: `cd frontend && bun run build` -> passed. `tsc -b && vite build` completed with 132 modules transformed and production assets emitted under `dist/`.
-- 2026-05-10: `cd frontend && bun run test -- AdminDashboardPage.test.tsx route.test.ts` -> passed. Vitest reported 5 files passed, 19 tests passed, duration 1.05s.
-- 2026-05-10: `cd frontend && bun run test -- mappers.test.ts` -> passed. Vitest reported 1 file passed, 1 test passed, duration 301ms.
+- Pending
 Decision Log:
-- 2026-05-10: Started DASH-002 on current branch; scope limited to structural React mapping, stable tests, and minimal CSS scaffolding before DASH-003 visual styling.
-- 2026-05-10: Mapped the reference control-deck composition into dashboard-local React components: compact page header, stat cards, content queue panel, now-playing panel, and chat room access panel.
-- 2026-05-10: Preserved the existing `/admin/dashboard` loader/view model boundary, static fallback queue behavior, generated-empty room access state, and `rotateChatRoomPassword('night-shift', {})` mutation flow.
-- 2026-05-10: Added structured stat accent and queue action metadata in the dashboard view model so the React structure can render reference-like cards and queue rows without changing backend DTOs or route ownership.
-- 2026-05-10: Added only dashboard-scoped CSS scaffolding for the structural grid, panels, queue rows, info fields, live indicator, and rotation control; final visual parity remains DASH-003 scope.
+- Pending
 Commit: Pending
 Blocked Reason: None
 Requested Decision: None
 
-### DASH-003 - Apply control-deck visual style
-Task File: docs/prds/PRD-002/tasks/DASH-003.md
-Status: Accepted
+### CI-003 - Run full local validation sweep
+Task File: docs/prds/PRD-003/tasks/CI-003.md
+Status: Todo
 Evidence:
-- 2026-05-10: `cd frontend && bun run test -- AdminDashboardPage.test.tsx route.test.ts` -> passed. Vitest reported 5 files passed, 19 tests passed, duration 1.01s.
-- 2026-05-10: `cd frontend && bun run build` -> passed. `tsc -b && vite build` completed with 132 modules transformed and production assets emitted under `dist/`.
+- Pending
 Decision Log:
-- 2026-05-10: Started DASH-003 on current branch under the session waiver for Human review; scope is limited to final dashboard/admin shell visual treatment while preserving DASH-002 behavior.
-- 2026-05-10: Interrupted the original DASH-003 worker after its focused Vitest command appeared to stall; no lingering Vitest/Bun test process remained when checked.
-- 2026-05-10: Kept the partial visual implementation after review because the changes were coherent and scoped to admin shell/dashboard styling.
-- 2026-05-10: Applied the session-only human-review waiver from Vinicius and accepted DASH-003 after coordinator verification passed.
+- Pending
 Commit: Pending
 Blocked Reason: None
 Requested Decision: None
 
-### DASH-004 - Verify admin photo regressions and final rollout
-Task File: docs/prds/PRD-002/tasks/DASH-004.md
-Status: Accepted
+### CI-004 - Confirm remote CI acceptance
+Task File: docs/prds/PRD-003/tasks/CI-004.md
+Status: Todo
 Evidence:
-- 2026-05-10: `cd frontend && bun run test -- AdminDashboardPage.test.tsx route.test.ts AdminPhotosGalleryPage.test.tsx` -> passed. Vitest reported 6 files passed, 22 tests passed, duration 768ms.
-- 2026-05-10: `cd frontend && bun run lint` -> passed. ESLint completed with exit code 0 and no diagnostics.
-- 2026-05-10: `cd frontend && bun run build` -> passed. `tsc -b && vite build` completed with 132 modules transformed and production assets emitted under `dist/`.
+- Pending
 Decision Log:
-- 2026-05-10: Started DASH-004 on current branch; scope limited to admin photo regression verification, dashboard regression coverage, frontend lint/build, and small fixes only if current behavior regressed.
-- 2026-05-10: Existing admin photo tests already covered private gallery cards, upload navigation, protected originals, upload accepted MIME types, upload draft action, detail metadata editor, publish/draft controls, feature/unfeature controls, route filters, pagination input, upload redirect, and detail metadata/curation actions.
-- 2026-05-10: No test maintenance or style regression fixes were required, and no backend, schema, media storage, auth, or deployment files were changed.
+- Pending
 Commit: Pending
 Blocked Reason: None
 Requested Decision: None

--- a/docs/TRACKER.md
+++ b/docs/TRACKER.md
@@ -25,7 +25,7 @@
 - Merge Target: develop
 
 ## Current Task
-CI-003
+CI-004
 
 ## Task Index
 1. CI-001 - Repair chat media test fixture
@@ -39,7 +39,7 @@ CI-003
    - Status: Accepted
 4. CI-004 - Confirm remote CI acceptance
    - Task File: docs/prds/PRD-003/tasks/CI-004.md
-   - Status: Todo
+   - Status: Blocked
 
 ## Tasks
 
@@ -57,7 +57,7 @@ Decision Log:
 - Keep the change scoped to the chat runtime test fixture because `getChatAttachmentObjectUrl` already consumes `response.blob()` and does not require a real `Response` instance for the success path.
 - Replaced the protected-media `new Response(new Blob(...))` fixture with a runner-stable object exposing `blob()`, `headers`, `ok`, and `status`.
 - Preserved protected media URL coverage, verified the chat room session header on the media request, and verified `URL.createObjectURL` receives the returned blob while `getChatAttachmentObjectUrl` surfaces the object URL.
-Commit: Pending
+Commit: a911fd1 PRD-003 CI-001: repair chat media test fixture
 Blocked Reason: None
 Requested Decision: None
 
@@ -81,7 +81,7 @@ Decision Log:
 - Added workflow-level `BUN_VERSION: 1.3.11` to `.github/workflows/branch-validation.yml` to match PR validation style and frontend package metadata.
 - Applied the pin to both branch-validation `oven-sh/setup-bun@v2` steps without changing branch triggers or validation commands.
 - Treated the backend sandbox `EADDRINUSE` failures as environment-specific local server binding failures because the same required commands passed outside the sandbox and PRD-003 already documents this backend test behavior.
-Commit: Pending
+Commit: 2bab514 PRD-003 CI-002: pin branch validation Bun version
 Blocked Reason: None
 Requested Decision: None
 
@@ -102,17 +102,25 @@ Decision Log:
 - No validation command was weakened, removed, or replaced to make the local sweep pass.
 - Treated the backend sandbox failures as environment-specific local server/database access limitations because the same required backend commands passed outside the sandbox and no implementation files changed.
 - CI-003 acceptance is based on the deterministic required command sequence passing locally with the documented sandbox reruns; CI-004 remains Todo and was not started.
-Commit: Pending
+Commit: 324ff10 PRD-003 CI-003: record local validation sweep
 Blocked Reason: None
 Requested Decision: None
 
 ### CI-004 - Confirm remote CI acceptance
 Task File: docs/prds/PRD-003/tasks/CI-004.md
-Status: Todo
+Status: Blocked
 Evidence:
-- Pending
+- Started CI-004 only; Review Mode is Human and this task is stopped uncommitted for coordinator/Vinicius review.
+- Current local branch confirmed as `feature/PRD-003-ci-validation-reliability`; local HEAD is `324ff10`.
+- `gh pr list --state all --head feature/PRD-003-ci-validation-reliability --json number,url,state,headRefName,baseRefName,title,updatedAt,isDraft,statusCheckRollup` - returned `[]`; no GitHub PR exists for this branch in open, closed, or merged state.
+- `gh api repos/Vinicius-Marcondes/vinicius.dev/git/ref/heads/feature%2FPRD-003-ci-validation-reliability --jq '{ref: .ref, sha: .object.sha, url: .url}'` - failed with `HTTP 404 Not Found`; the PRD branch is not present as a remote GitHub branch ref.
+- `gh run list --workflow pr-validation.yml --branch feature/PRD-003-ci-validation-reliability --limit 10 --json databaseId,displayTitle,event,headBranch,headSha,status,conclusion,createdAt,updatedAt,url,workflowName` - returned `[]`; no remote `pr-validation` run exists for the PRD branch.
+- Inspected `.github/workflows/production-deploy.yml`: production deployment triggers are limited to `push` tags matching `v*` and `workflow_dispatch` with a required `tag` input; both `preflight` and `deploy-production` jobs also guard execution to pushed `refs/tags/v*` or manual dispatch. Normal branch pushes do not trigger production deployment.
+- Post-merge `branch-validation` on `develop` was not marked complete because there is no PRD branch PR, no remote branch ref, and no PRD merge to `develop`; the relevant post-merge `develop` run does not exist yet.
 Decision Log:
-- Pending
+- Remote PR validation acceptance cannot proceed in the current state because CI-004 is not allowed to push the branch or open a PR, and GitHub has no remote branch ref, PR, or `pr-validation` run to inspect.
+- Production deployment trigger policy is confirmed as tag-only plus manual dispatch; no workflow change was needed.
+- Develop branch-validation acceptance remains pending post-merge by task rule and was not treated as complete.
 Commit: Pending
-Blocked Reason: None
-Requested Decision: None
+Blocked Reason: No pushed PRD branch, PR, or remote `pr-validation` run exists for `feature/PRD-003-ci-validation-reliability`, so the required GitHub PR validation evidence cannot be confirmed inside CI-004 without performing excluded push/PR actions.
+Requested Decision: Vinicius/coordinator should decide whether to separately push/open the PRD branch and rerun CI-004 after GitHub Actions completes, or explicitly accept the documented pending remote PR/develop validation state as an exception.

--- a/docs/TRACKER.md
+++ b/docs/TRACKER.md
@@ -25,7 +25,7 @@
 - Merge Target: develop
 
 ## Current Task
-CI-001
+CI-002
 
 ## Task Index
 1. CI-001 - Repair chat media test fixture
@@ -33,7 +33,7 @@ CI-001
    - Status: Accepted
 2. CI-002 - Pin branch validation Bun version
    - Task File: docs/prds/PRD-003/tasks/CI-002.md
-   - Status: Todo
+   - Status: Accepted
 3. CI-003 - Run full local validation sweep
    - Task File: docs/prds/PRD-003/tasks/CI-003.md
    - Status: Todo
@@ -63,11 +63,24 @@ Requested Decision: None
 
 ### CI-002 - Pin branch validation Bun version
 Task File: docs/prds/PRD-003/tasks/CI-002.md
-Status: Todo
+Status: Accepted
 Evidence:
-- Pending
+- Started CI-002 only; confirmed `.github/workflows/pr-validation.yml` declares `BUN_VERSION: 1.3.11` and `frontend/package.json` declares `packageManager: bun@1.3.11`.
+- Inspected `.github/workflows/branch-validation.yml`: trigger remains `push` to `develop` and `main`; workflow now declares `BUN_VERSION: 1.3.11`; both frontend and backend `oven-sh/setup-bun@v2` steps use `bun-version: ${{ env.BUN_VERSION }}`.
+- Inspected `.github/workflows/branch-validation.yml`: frontend command coverage remains `bun install --frozen-lockfile`, `bun run lint`, `bun run build`, and `bun run test`.
+- Inspected `.github/workflows/branch-validation.yml`: backend command coverage remains `bun install --frozen-lockfile`, `bun run prisma:generate`, `bun run typecheck`, `bun run test`, and `bun run verify`.
+- `cd frontend && bun run lint` - passed.
+- `cd frontend && bun run build` - passed: `tsc -b && vite build`.
+- `cd frontend && bun run test` - passed: 22 test files, 44 tests.
+- `cd backend && bun run typecheck` - passed.
+- `cd backend && bun run test` - sandbox run failed on two WebSocket route tests with `EADDRINUSE` while `Bun.serve` tried to bind local test ports 38711 and 38712.
+- `cd backend && bun run test` - unsandboxed rerun passed: 225 tests, 0 failed.
+- `cd backend && bun run verify` - sandbox run reached media verification but failed on the same WebSocket local-port binding issue.
+- `cd backend && bun run verify` - unsandboxed rerun passed, including persistence, media, public route/content, admin/auth/chat/media integration, and deploy/readiness checks.
 Decision Log:
-- Pending
+- Added workflow-level `BUN_VERSION: 1.3.11` to `.github/workflows/branch-validation.yml` to match PR validation style and frontend package metadata.
+- Applied the pin to both branch-validation `oven-sh/setup-bun@v2` steps without changing branch triggers or validation commands.
+- Treated the backend sandbox `EADDRINUSE` failures as environment-specific local server binding failures because the same required commands passed outside the sandbox and PRD-003 already documents this backend test behavior.
 Commit: Pending
 Blocked Reason: None
 Requested Decision: None

--- a/docs/TRACKER.md
+++ b/docs/TRACKER.md
@@ -25,7 +25,7 @@
 - Merge Target: develop
 
 ## Current Task
-CI-002
+CI-003
 
 ## Task Index
 1. CI-001 - Repair chat media test fixture
@@ -36,7 +36,7 @@ CI-002
    - Status: Accepted
 3. CI-003 - Run full local validation sweep
    - Task File: docs/prds/PRD-003/tasks/CI-003.md
-   - Status: Todo
+   - Status: Accepted
 4. CI-004 - Confirm remote CI acceptance
    - Task File: docs/prds/PRD-003/tasks/CI-004.md
    - Status: Todo
@@ -87,11 +87,21 @@ Requested Decision: None
 
 ### CI-003 - Run full local validation sweep
 Task File: docs/prds/PRD-003/tasks/CI-003.md
-Status: Todo
+Status: Accepted
 Evidence:
-- Pending
+- Started CI-003 only; updated `Current Task` from CI-002 to CI-003 and kept CI-004 Todo.
+- `cd frontend && bun run lint` - passed.
+- `cd frontend && bun run build` - passed: `tsc -b && vite build`, 132 modules transformed, production build completed.
+- `cd frontend && bun run test` - passed: 22 test files, 44 tests.
+- `cd backend && bun run typecheck` - passed.
+- `cd backend && bun run test` - sandbox run failed only on the two WebSocket route tests when `Bun.serve` could not bind local test ports 38711 and 38712, both reporting `EADDRINUSE`.
+- `cd backend && bun run test` - unsandboxed rerun passed: 225 tests, 0 failed, 667 expectations.
+- `cd backend && bun run verify` - sandbox run reached persistence verification; Prisma migration status could not reach the configured local Postgres database from the sandbox and was skipped by the script, then media verification failed on the same WebSocket `Bun.serve` local-port binding issue for ports 38711 and 38712.
+- `cd backend && bun run verify` - unsandboxed rerun passed: persistence verification, media verification, public routes/content verification, admin/auth/chat/media integration verification, and deploy/readiness checks.
 Decision Log:
-- Pending
+- No validation command was weakened, removed, or replaced to make the local sweep pass.
+- Treated the backend sandbox failures as environment-specific local server/database access limitations because the same required backend commands passed outside the sandbox and no implementation files changed.
+- CI-003 acceptance is based on the deterministic required command sequence passing locally with the documented sandbox reruns; CI-004 remains Todo and was not started.
 Commit: Pending
 Blocked Reason: None
 Requested Decision: None

--- a/frontend/src/entities/chat/api/room-runtime.test.ts
+++ b/frontend/src/entities/chat/api/room-runtime.test.ts
@@ -28,8 +28,18 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
+const getRequestHeader = (headers: HeadersInit | undefined, name: string) =>
+  headers instanceof Headers ? headers.get(name) : (headers as Record<string, string> | undefined)?.[name]
+
 describe('chat runtime API helpers', () => {
   it('builds participant, message, send, and protected media requests', async () => {
+    const protectedMediaBlob = new Blob(['image'], { type: 'image/png' })
+    const protectedMediaResponse = {
+      blob: vi.fn(async () => protectedMediaBlob),
+      headers: new Headers(),
+      ok: true,
+      status: 200,
+    } satisfies Pick<Response, 'blob' | 'headers' | 'ok' | 'status'>
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ items: [] }), {
@@ -49,11 +59,7 @@ describe('chat runtime API helpers', () => {
           status: 200,
         }),
       )
-      .mockResolvedValueOnce(
-        new Response(new Blob(['image']), {
-          status: 200,
-        }),
-      )
+      .mockResolvedValueOnce(protectedMediaResponse)
     const createObjectUrl = vi.fn(() => 'blob:chat-image')
     vi.stubGlobal('fetch', fetchMock)
     vi.stubGlobal('URL', {
@@ -72,8 +78,9 @@ describe('chat runtime API helpers', () => {
       '/api/chat/rooms/night-shift/messages',
       '/api/chat/uploads/upload_1/media',
     ])
-    expect((fetchMock.mock.calls[0]?.[1]?.headers as Headers).get('x-chat-room-session-id')).toBe('session_1')
-    expect(createObjectUrl).toHaveBeenCalled()
+    expect(getRequestHeader(fetchMock.mock.calls[0]?.[1]?.headers, 'x-chat-room-session-id')).toBe('session_1')
+    expect(getRequestHeader(fetchMock.mock.calls[3]?.[1]?.headers, 'x-chat-room-session-id')).toBe('session_1')
+    expect(createObjectUrl).toHaveBeenCalledWith(protectedMediaBlob)
   })
 
   it('opens live sockets with the approved subprotocol auth contract', () => {


### PR DESCRIPTION
## Summary

Implements PRD-003 to stabilize CI validation reliability without changing product behavior or deployment scope.

## Changes

- Repaired the frontend chat media runtime test fixture so it no longer constructs a mocked response with `new Response(new Blob(...))` on GitHub Actions.
- Pinned branch validation to Bun `1.3.11`, matching PR validation and frontend package metadata.
- Preserved branch-validation triggers for pushes to `develop` and `main` only.
- Confirmed production deployment remains tag-only via `v*` pushes plus manual dispatch.

## Accepted Tasks

- `a911fd1 PRD-003 CI-001: repair chat media test fixture`
- `2bab514 PRD-003 CI-002: pin branch validation Bun version`
- `324ff10 PRD-003 CI-003: record local validation sweep`

## Check Evidence

- `cd frontend && bun run test -- room-runtime.test.ts` passed.
- `cd frontend && bun run lint` passed.
- `cd frontend && bun run build` passed.
- `cd frontend && bun run test` passed: 22 files, 44 tests.
- `cd backend && bun run typecheck` passed.
- `cd backend && bun run test` passed unsandboxed: 225 tests.
- `cd backend && bun run verify` passed unsandboxed.

## Known Limitations

- CI-004 remains blocked in `docs/TRACKER.md` until this PR's remote GitHub Actions evidence exists.
- Local sandboxed backend test/verify runs hit known local server/database binding limitations; the same backend commands passed outside the sandbox.
- Post-merge branch validation on `develop` is still pending by definition until this PR is merged.
