### PR TITLE
PRD-004 Admin Gallery Reference Restyle

### DIFF
--- a/docs/TRACKER.md
+++ b/docs/TRACKER.md
@@ -25,7 +25,7 @@
 - Merge Target: develop
 
 ## Current Task
-GAL-001
+GAL-002
 
 ## Task Index
 1. GAL-001 - Rebuild Admin Gallery Frame
@@ -33,7 +33,7 @@ GAL-001
    - Status: Accepted
 2. GAL-002 - Restyle Gallery Cards And Presentation Controls
    - Task File: docs/prds/PRD-004/tasks/GAL-002.md
-   - Status: Todo
+   - Status: Accepted
 3. GAL-003 - Preserve Photo Admin Workflow Regressions
    - Task File: docs/prds/PRD-004/tasks/GAL-003.md
    - Status: Todo
@@ -59,17 +59,26 @@ Decision Log:
 - Omitted reference-only view toggle, hover overlays, fake mutations, delete, and client-side filtering because they are explicitly outside GAL-001 scope.
 - Kept the upload action implemented through existing `ActionButton` and `/admin/photos/upload` navigation.
 - Human review completed and GAL-001 accepted by Vinicius before starting GAL-002.
-Commit: 1e42be3 PRD-004 GAL-001: rebuild admin gallery frame
+Commit: e673f27 PRD-004 GAL-001: rebuild admin gallery frame
 Blocked Reason: None
 Requested Decision: None
 
 ### GAL-002 - Restyle Gallery Cards And Presentation Controls
 Task File: docs/prds/PRD-004/tasks/GAL-002.md
-Status: Todo
+Status: Accepted
 Evidence:
-- Pending
+- Started GAL-002 after Vinicius accepted GAL-001 and GAL-001 was committed.
+- Updated `frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.tsx` to restyle loader-backed records as reference-style cards with rectangular image frames, CRT hover overlay, title/meta blocks, status badges, optional featured badge, file-size display, and a local presentation-only grid/list toggle.
+- Preserved `useLoaderData`, URL-backed filter/pagination helpers, `getAdminPhotoOriginalUrl(photo.id)`, upload navigation to `/admin/photos/upload`, and detail navigation to `/admin/photos/:id` with `state.from`.
+- Updated `frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.test.tsx` to assert protected original URLs, upload/detail navigation, `state.from`, local grid/list toggle state, unchanged query state, URL-backed filters, and pagination behavior.
+- Updated `frontend/src/app/styles/global.css` with scoped admin gallery card, badge, hover overlay, empty-state, pagination, and grid/list presentation styles.
+- `cd frontend && bun run test -- AdminPhotosGalleryPage.test.tsx` passed: 1 test file passed, 5 tests passed.
+- `cd frontend && bun run lint` passed with exit code 0.
+- Vinicius accepted GAL-002 after review: "GAl-002 is fine, continue with GAL-003".
 Decision Log:
-- Pending
+- Added a grid/list toggle as local React state only; it does not persist, mutate query params, or change the backend/API contract.
+- Kept the hover overlay honest by making the card itself the only action path to the existing detail/edit route; no delete, inline feature, inline edit, bulk action, fake mutation, or client-side filtering was added.
+- Human review completed and GAL-002 accepted by Vinicius before starting GAL-003.
 Commit: Pending
 Blocked Reason: None
 Requested Decision: None

--- a/docs/TRACKER.md
+++ b/docs/TRACKER.md
@@ -13,114 +13,85 @@
 - For `Review Mode: Agent`, verify, accept, commit, and continue when appropriate.
 
 ## PRD
-- ID: PRD-003
-- Title: CI Validation Reliability
+- ID: PRD-004
+- Title: Admin Gallery Reference Restyle
 - Status: Active
-- PRD File: docs/prds/PRD-003/PRD-003.md
-- Summary: Fix recurring GitHub Actions validation failures by stabilizing the frontend chat media test fixture, aligning branch validation with the pinned Bun runtime, and preserving the existing PR, branch, and tag-only production validation contract.
+- PRD File: docs/prds/PRD-004/PRD-004.md
+- Summary: Restyle `/admin/photos` to match `references/vinicius.dev.v2/gallery.html` while preserving backend-connected listing, filtering, pagination, protected originals, upload navigation, and existing detail/edit workflows.
 
 ## Git
-- Branch: feature/PRD-003-ci-validation-reliability
+- Branch: feature/PRD-004-admin-gallery-reference-restyle
 - Base: develop
 - Merge Target: develop
 
 ## Current Task
-CI-004
+GAL-001
 
 ## Task Index
-1. CI-001 - Repair chat media test fixture
-   - Task File: docs/prds/PRD-003/tasks/CI-001.md
+1. GAL-001 - Rebuild Admin Gallery Frame
+   - Task File: docs/prds/PRD-004/tasks/GAL-001.md
    - Status: Accepted
-2. CI-002 - Pin branch validation Bun version
-   - Task File: docs/prds/PRD-003/tasks/CI-002.md
-   - Status: Accepted
-3. CI-003 - Run full local validation sweep
-   - Task File: docs/prds/PRD-003/tasks/CI-003.md
-   - Status: Accepted
-4. CI-004 - Confirm remote CI acceptance
-   - Task File: docs/prds/PRD-003/tasks/CI-004.md
-   - Status: Blocked
+2. GAL-002 - Restyle Gallery Cards And Presentation Controls
+   - Task File: docs/prds/PRD-004/tasks/GAL-002.md
+   - Status: Todo
+3. GAL-003 - Preserve Photo Admin Workflow Regressions
+   - Task File: docs/prds/PRD-004/tasks/GAL-003.md
+   - Status: Todo
+4. GAL-004 - Final Gallery Visual Acceptance
+   - Task File: docs/prds/PRD-004/tasks/GAL-004.md
+   - Status: Todo
 
 ## Tasks
 
-### CI-001 - Repair chat media test fixture
-Task File: docs/prds/PRD-003/tasks/CI-001.md
+### GAL-001 - Rebuild Admin Gallery Frame
+Task File: docs/prds/PRD-004/tasks/GAL-001.md
 Status: Accepted
 Evidence:
-- Started CI-001 only; inspected `frontend/src/entities/chat/api/room-runtime.ts` and `frontend/src/entities/chat/api/room-runtime.test.ts`.
-- `cd frontend && bun run test -- room-runtime.test.ts` - failed once after adding a media-session-header assertion because the media request uses a plain header record instead of a `Headers` instance; adjusted the test assertion without changing runtime code.
-- `cd frontend && bun run test -- room-runtime.test.ts` - passed: 1 test file, 2 tests.
-- `cd frontend && bun run lint` - passed.
-- `cd frontend && bun run build` - passed: `tsc -b && vite build`.
-- `cd frontend && bun run test` - passed: 22 test files, 44 tests.
+- Started GAL-001 after reading required repo rules, task file, PRD, tracker, reference HTML, and design-system skill files.
+- Updated `frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.tsx` to match the reference page frame while preserving `useLoaderData`, `useSearchParams`, `updateQuery`, `goToPage`, upload navigation, loader-provided records, and backend URL-driven controls.
+- Updated `frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.test.tsx` to verify loader-backed rendering, upload/detail navigation, query-backed filters resetting `page=1`, and pagination query behavior.
+- Updated `frontend/src/app/styles/global.css` with scoped admin gallery frame styles for the header, upload action, filters bar, records panel, empty state, and pagination.
+- `cd frontend && bun run test -- AdminPhotosGalleryPage.test.tsx` passed: 1 test file passed, 5 tests passed.
+- `cd frontend && bun run lint` passed with exit code 0.
+- Vinicius accepted GAL-001 after review: "looks like it is still working fine, GAL-001 Accepted".
 Decision Log:
-- Keep the change scoped to the chat runtime test fixture because `getChatAttachmentObjectUrl` already consumes `response.blob()` and does not require a real `Response` instance for the success path.
-- Replaced the protected-media `new Response(new Blob(...))` fixture with a runner-stable object exposing `blob()`, `headers`, `ok`, and `status`.
-- Preserved protected media URL coverage, verified the chat room session header on the media request, and verified `URL.createObjectURL` receives the returned blob while `getChatAttachmentObjectUrl` surfaces the object URL.
-Commit: a911fd1 PRD-003 CI-001: repair chat media test fixture
+- Scope held to GAL-001 page frame only: header, upload action, filters bar, and records panel. Card presentation remains limited to preserving existing backend-connected gallery rendering for GAL-002.
+- Omitted reference-only view toggle, hover overlays, fake mutations, delete, and client-side filtering because they are explicitly outside GAL-001 scope.
+- Kept the upload action implemented through existing `ActionButton` and `/admin/photos/upload` navigation.
+- Human review completed and GAL-001 accepted by Vinicius before starting GAL-002.
+Commit: 1e42be3 PRD-004 GAL-001: rebuild admin gallery frame
 Blocked Reason: None
 Requested Decision: None
 
-### CI-002 - Pin branch validation Bun version
-Task File: docs/prds/PRD-003/tasks/CI-002.md
-Status: Accepted
+### GAL-002 - Restyle Gallery Cards And Presentation Controls
+Task File: docs/prds/PRD-004/tasks/GAL-002.md
+Status: Todo
 Evidence:
-- Started CI-002 only; confirmed `.github/workflows/pr-validation.yml` declares `BUN_VERSION: 1.3.11` and `frontend/package.json` declares `packageManager: bun@1.3.11`.
-- Inspected `.github/workflows/branch-validation.yml`: trigger remains `push` to `develop` and `main`; workflow now declares `BUN_VERSION: 1.3.11`; both frontend and backend `oven-sh/setup-bun@v2` steps use `bun-version: ${{ env.BUN_VERSION }}`.
-- Inspected `.github/workflows/branch-validation.yml`: frontend command coverage remains `bun install --frozen-lockfile`, `bun run lint`, `bun run build`, and `bun run test`.
-- Inspected `.github/workflows/branch-validation.yml`: backend command coverage remains `bun install --frozen-lockfile`, `bun run prisma:generate`, `bun run typecheck`, `bun run test`, and `bun run verify`.
-- `cd frontend && bun run lint` - passed.
-- `cd frontend && bun run build` - passed: `tsc -b && vite build`.
-- `cd frontend && bun run test` - passed: 22 test files, 44 tests.
-- `cd backend && bun run typecheck` - passed.
-- `cd backend && bun run test` - sandbox run failed on two WebSocket route tests with `EADDRINUSE` while `Bun.serve` tried to bind local test ports 38711 and 38712.
-- `cd backend && bun run test` - unsandboxed rerun passed: 225 tests, 0 failed.
-- `cd backend && bun run verify` - sandbox run reached media verification but failed on the same WebSocket local-port binding issue.
-- `cd backend && bun run verify` - unsandboxed rerun passed, including persistence, media, public route/content, admin/auth/chat/media integration, and deploy/readiness checks.
+- Pending
 Decision Log:
-- Added workflow-level `BUN_VERSION: 1.3.11` to `.github/workflows/branch-validation.yml` to match PR validation style and frontend package metadata.
-- Applied the pin to both branch-validation `oven-sh/setup-bun@v2` steps without changing branch triggers or validation commands.
-- Treated the backend sandbox `EADDRINUSE` failures as environment-specific local server binding failures because the same required commands passed outside the sandbox and PRD-003 already documents this backend test behavior.
-Commit: 2bab514 PRD-003 CI-002: pin branch validation Bun version
-Blocked Reason: None
-Requested Decision: None
-
-### CI-003 - Run full local validation sweep
-Task File: docs/prds/PRD-003/tasks/CI-003.md
-Status: Accepted
-Evidence:
-- Started CI-003 only; updated `Current Task` from CI-002 to CI-003 and kept CI-004 Todo.
-- `cd frontend && bun run lint` - passed.
-- `cd frontend && bun run build` - passed: `tsc -b && vite build`, 132 modules transformed, production build completed.
-- `cd frontend && bun run test` - passed: 22 test files, 44 tests.
-- `cd backend && bun run typecheck` - passed.
-- `cd backend && bun run test` - sandbox run failed only on the two WebSocket route tests when `Bun.serve` could not bind local test ports 38711 and 38712, both reporting `EADDRINUSE`.
-- `cd backend && bun run test` - unsandboxed rerun passed: 225 tests, 0 failed, 667 expectations.
-- `cd backend && bun run verify` - sandbox run reached persistence verification; Prisma migration status could not reach the configured local Postgres database from the sandbox and was skipped by the script, then media verification failed on the same WebSocket `Bun.serve` local-port binding issue for ports 38711 and 38712.
-- `cd backend && bun run verify` - unsandboxed rerun passed: persistence verification, media verification, public routes/content verification, admin/auth/chat/media integration verification, and deploy/readiness checks.
-Decision Log:
-- No validation command was weakened, removed, or replaced to make the local sweep pass.
-- Treated the backend sandbox failures as environment-specific local server/database access limitations because the same required backend commands passed outside the sandbox and no implementation files changed.
-- CI-003 acceptance is based on the deterministic required command sequence passing locally with the documented sandbox reruns; CI-004 remains Todo and was not started.
-Commit: 324ff10 PRD-003 CI-003: record local validation sweep
-Blocked Reason: None
-Requested Decision: None
-
-### CI-004 - Confirm remote CI acceptance
-Task File: docs/prds/PRD-003/tasks/CI-004.md
-Status: Blocked
-Evidence:
-- Started CI-004 only; Review Mode is Human and this task is stopped uncommitted for coordinator/Vinicius review.
-- Current local branch confirmed as `feature/PRD-003-ci-validation-reliability`; local HEAD is `324ff10`.
-- `gh pr list --state all --head feature/PRD-003-ci-validation-reliability --json number,url,state,headRefName,baseRefName,title,updatedAt,isDraft,statusCheckRollup` - returned `[]`; no GitHub PR exists for this branch in open, closed, or merged state.
-- `gh api repos/Vinicius-Marcondes/vinicius.dev/git/ref/heads/feature%2FPRD-003-ci-validation-reliability --jq '{ref: .ref, sha: .object.sha, url: .url}'` - failed with `HTTP 404 Not Found`; the PRD branch is not present as a remote GitHub branch ref.
-- `gh run list --workflow pr-validation.yml --branch feature/PRD-003-ci-validation-reliability --limit 10 --json databaseId,displayTitle,event,headBranch,headSha,status,conclusion,createdAt,updatedAt,url,workflowName` - returned `[]`; no remote `pr-validation` run exists for the PRD branch.
-- Inspected `.github/workflows/production-deploy.yml`: production deployment triggers are limited to `push` tags matching `v*` and `workflow_dispatch` with a required `tag` input; both `preflight` and `deploy-production` jobs also guard execution to pushed `refs/tags/v*` or manual dispatch. Normal branch pushes do not trigger production deployment.
-- Post-merge `branch-validation` on `develop` was not marked complete because there is no PRD branch PR, no remote branch ref, and no PRD merge to `develop`; the relevant post-merge `develop` run does not exist yet.
-Decision Log:
-- Remote PR validation acceptance cannot proceed in the current state because CI-004 is not allowed to push the branch or open a PR, and GitHub has no remote branch ref, PR, or `pr-validation` run to inspect.
-- Production deployment trigger policy is confirmed as tag-only plus manual dispatch; no workflow change was needed.
-- Develop branch-validation acceptance remains pending post-merge by task rule and was not treated as complete.
+- Pending
 Commit: Pending
-Blocked Reason: No pushed PRD branch, PR, or remote `pr-validation` run exists for `feature/PRD-003-ci-validation-reliability`, so the required GitHub PR validation evidence cannot be confirmed inside CI-004 without performing excluded push/PR actions.
-Requested Decision: Vinicius/coordinator should decide whether to separately push/open the PRD branch and rerun CI-004 after GitHub Actions completes, or explicitly accept the documented pending remote PR/develop validation state as an exception.
+Blocked Reason: None
+Requested Decision: None
+
+### GAL-003 - Preserve Photo Admin Workflow Regressions
+Task File: docs/prds/PRD-004/tasks/GAL-003.md
+Status: Todo
+Evidence:
+- Pending
+Decision Log:
+- Pending
+Commit: Pending
+Blocked Reason: None
+Requested Decision: None
+
+### GAL-004 - Final Gallery Visual Acceptance
+Task File: docs/prds/PRD-004/tasks/GAL-004.md
+Status: Todo
+Evidence:
+- Pending
+Decision Log:
+- Pending
+Commit: Pending
+Blocked Reason: None
+Requested Decision: None

--- a/docs/TRACKER.md
+++ b/docs/TRACKER.md
@@ -25,7 +25,7 @@
 - Merge Target: develop
 
 ## Current Task
-GAL-002
+GAL-003
 
 ## Task Index
 1. GAL-001 - Rebuild Admin Gallery Frame
@@ -36,7 +36,7 @@ GAL-002
    - Status: Accepted
 3. GAL-003 - Preserve Photo Admin Workflow Regressions
    - Task File: docs/prds/PRD-004/tasks/GAL-003.md
-   - Status: Todo
+   - Status: Active
 4. GAL-004 - Final Gallery Visual Acceptance
    - Task File: docs/prds/PRD-004/tasks/GAL-004.md
    - Status: Todo
@@ -79,17 +79,26 @@ Decision Log:
 - Added a grid/list toggle as local React state only; it does not persist, mutate query params, or change the backend/API contract.
 - Kept the hover overlay honest by making the card itself the only action path to the existing detail/edit route; no delete, inline feature, inline edit, bulk action, fake mutation, or client-side filtering was added.
 - Human review completed and GAL-002 accepted by Vinicius before starting GAL-003.
-Commit: Pending
+Commit: 540d6d0 PRD-004 GAL-002: restyle gallery cards
 Blocked Reason: None
 Requested Decision: None
 
 ### GAL-003 - Preserve Photo Admin Workflow Regressions
 Task File: docs/prds/PRD-004/tasks/GAL-003.md
-Status: Todo
+Status: Accepted
 Evidence:
-- Pending
+- Started GAL-003 after Vinicius accepted GAL-002 and GAL-002 was committed.
+- Updated `frontend/src/pages/admin/photos/route.test.ts` to harden deterministic workflow coverage for admin photo query parsing into `listAdminPhotos`, including `search`, `status`, `featured=featured`, `featured=not_featured`, and `page`.
+- Added route coverage for unauthorized `/admin/photos` gallery loader redirects to `/admin/login`, preserving the existing detail unauthorized redirect coverage.
+- Expanded upload action assertions to verify `uploadAdminPhoto` receives the existing upload payload shape before redirecting to `/admin/photos/photo_1`.
+- Expanded detail action assertions to verify metadata edits call `updateAdminPhotoMetadata` with parsed tags and existing metadata fields, and curation edits call `updateAdminPhotoCuration` for publish and feature updates.
+- Preserved gallery/detail protected original URL coverage in `frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.test.tsx`.
+- No upload/detail UI redesign or shared style changes were needed.
+- `cd frontend && bun run test -- AdminPhotosGalleryPage.test.tsx route.test.ts` passed after changes: 5 test files passed, 20 tests passed.
+- `cd frontend && bun run lint` passed with exit code 0.
 Decision Log:
-- Pending
+- Kept GAL-003 scoped to deterministic route/action test hardening because the existing upload and detail screens remained compatible with the GAL-001/GAL-002 gallery restyle.
+- Did not change backend contracts, entity API helper semantics, upload validation, auth behavior, media delivery, or gallery visual features.
 Commit: Pending
 Blocked Reason: None
 Requested Decision: None

--- a/docs/TRACKER.md
+++ b/docs/TRACKER.md
@@ -25,7 +25,7 @@
 - Merge Target: develop
 
 ## Current Task
-GAL-003
+GAL-004
 
 ## Task Index
 1. GAL-001 - Rebuild Admin Gallery Frame
@@ -36,10 +36,10 @@ GAL-003
    - Status: Accepted
 3. GAL-003 - Preserve Photo Admin Workflow Regressions
    - Task File: docs/prds/PRD-004/tasks/GAL-003.md
-   - Status: Active
+   - Status: Accepted
 4. GAL-004 - Final Gallery Visual Acceptance
    - Task File: docs/prds/PRD-004/tasks/GAL-004.md
-   - Status: Todo
+   - Status: Accepted
 
 ## Tasks
 
@@ -99,17 +99,39 @@ Evidence:
 Decision Log:
 - Kept GAL-003 scoped to deterministic route/action test hardening because the existing upload and detail screens remained compatible with the GAL-001/GAL-002 gallery restyle.
 - Did not change backend contracts, entity API helper semantics, upload validation, auth behavior, media delivery, or gallery visual features.
-Commit: Pending
+Commit: be56609 PRD-004 GAL-003: harden admin photo regressions
 Blocked Reason: None
 Requested Decision: None
 
 ### GAL-004 - Final Gallery Visual Acceptance
 Task File: docs/prds/PRD-004/tasks/GAL-004.md
-Status: Todo
+Status: Accepted
 Evidence:
-- Pending
+- Started GAL-004 after GAL-003 was accepted and committed.
+- Read `docs/rules/AGENTS.md`, `supervised-workflow.md`, `prd-and-tracker.md`, `architecture.md`, `product-and-platform.md`, PRD-004, GAL-004, the active tracker, `references/vinicius.dev.v2/gallery.html`, and the Vinicius.Dev design-system skill files before reviewing the final UI.
+- Reviewed `frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.tsx` and the scoped admin gallery CSS in `frontend/src/app/styles/global.css` for backend-connected behavior, reference parity, focus states, rectangular geometry, no emoji, no glassmorphism, approved token usage, and no fake production actions.
+- Added the required `prefers-reduced-motion: reduce` rule to `frontend/src/app/styles/global.css` so animations/transitions collapse for reduced-motion users.
+- Desktop visual pass completed in Chrome at `localhost:5173/admin/photos` against the reference: admin shell, header/upload action, filters, records panel, grid cards, list mode, badges, protected original images, and pagination matched the intended reference structure closely enough for human review.
+- Keyboard focus spot-check completed in Chrome: upload navigation, search input, status select, featured select, grid/list controls, and photo links showed visible cyan focus treatment.
+- Responsive CSS reviewed for the existing `1024px`, `880px`, `760px`, and `520px` breakpoints covering two-column/one-column gallery, stacked header, stacked filters, stacked records header, and list-card mobile layout.
+- `cd frontend && bun run test -- AdminPhotosGalleryPage.test.tsx route.test.ts` passed: 5 test files passed, 20 tests passed.
+- `cd frontend && bun run test` passed: 22 test files passed, 48 tests passed.
+- `cd frontend && bun run lint` passed with exit code 0.
+- `cd frontend && bun run build` passed: `tsc -b && vite build`, 132 modules transformed.
+- Vinicius provided screenshot feedback that the actual gallery top area still had an extra outer frame and spacing compared with the target reference.
+- Updated `frontend/src/app/styles/global.css` so the admin shell `ScreenFrame` that contains `.admin-photo-gallery` becomes transparent and unframed, matching the reference where only the filters and records panels are boxed.
+- Updated `.admin-photo-gallery` to use a `1408px` content band so the header, upload action, filters, and records panels align more closely with the target screenshot.
+- Reran `cd frontend && bun run test -- AdminPhotosGalleryPage.test.tsx route.test.ts`: 5 test files passed, 20 tests passed.
+- Reran `cd frontend && bun run lint`: passed with exit code 0.
+- Reran `cd frontend && bun run test`: 22 test files passed, 48 tests passed.
+- Reran `cd frontend && bun run build`: `tsc -b && vite build`, 132 modules transformed.
+- Vinicius accepted GAL-004 after screenshot-driven layout correction: "that is fine, task accepted".
 Decision Log:
-- Pending
-Commit: Pending
+- Kept runtime scope to the final acceptance pass; no backend, route, schema, upload, or detail redesign changes were made.
+- Did not change `AdminPhotosGalleryPage.tsx` because the current markup already preserved loader data, URL-backed filters/pagination, protected originals, upload navigation, detail navigation, and presentation-only grid/list state.
+- Used a global reduced-motion rule because the Vinicius.Dev design system requires the sitewide motion collapse pattern and the GAL-004 acceptance criteria explicitly include reduced-motion behavior.
+- Treated the screenshot mismatch as a shell/layout issue rather than a gallery behavior issue; fixed it with a gallery-specific `:has(.admin-photo-gallery)` shell-frame override so dashboard and other admin screens keep their existing shell framing.
+- Human review completed and GAL-004 accepted by Vinicius.
+Commit: ec618c4 PRD-004 GAL-004: finalize gallery visual acceptance
 Blocked Reason: None
 Requested Decision: None

--- a/docs/prds/PRD-004/PRD-004.md
+++ b/docs/prds/PRD-004/PRD-004.md
@@ -1,0 +1,66 @@
+# PRD-004 - Admin Gallery Reference Restyle
+
+## Status
+Ready
+
+## Summary
+Restyle the existing admin gallery screen at `/admin/photos` so it matches the layout, CRT effects, interaction language, and visual density of `references/vinicius.dev.v2/gallery.html`, while preserving the current backend-connected photo listing, filtering, pagination, upload navigation, and edit-entry flow.
+
+## Goals
+- Make `/admin/photos` visually match the private gallery reference: sticky admin shell treatment, channel bug, compact header, upload action, filters bar, records panel, photo card grid/list presentation, badges, hover overlay feel, empty state, pagination, scanlines, glitch hover, and restrained neon states.
+- Preserve all existing production data flow for admin photos, including React Router loader query parsing, `listAdminPhotos`, protected original image URLs, filters, pagination, and links into photo detail editing.
+- Keep the existing upload and detail/edit screens working, including upload, metadata editing, publish/unpublish, feature/unfeature, protected original display, and auth redirect behavior.
+- Use the Vinicius.Dev design system and already-developed admin/dashboard styling where it matches the requested reference style.
+- Restrict implementation to the admin gallery screen, except for tightly scoped global/shared React components or CSS primitives needed to reuse existing admin style and keep screens consistent.
+
+## Non-Goals
+- Do not change backend APIs, database schema, Prisma models, auth behavior, media storage, protected media routes, upload validation, or deployment configuration.
+- Do not redesign public pages.
+- Do not redesign `/admin/photos/upload` or `/admin/photos/:id` beyond incidental shared-component/global CSS changes needed to preserve compatibility with the gallery restyle.
+- Do not add new photo management capabilities such as delete, inline metadata editing, bulk actions, or new curation states.
+- Do not replace the existing backend-connected filtering and pagination with prototype-only client-side filtering.
+- Do not introduce a new UI framework, global store, broad visual regression system, or unrelated frontend architecture change.
+
+## Context
+The current admin gallery at `/admin/photos` is functional. It loads admin photo records from the backend through the existing React Router loader, renders protected original image URLs, supports URL-backed `search`, `status`, `featured`, and `page` filters, paginates through backend results, links to `/admin/photos/:id` for editing, and links to `/admin/photos/upload` for uploads.
+
+The desired visual target is `references/vinicius.dev.v2/gallery.html`. That reference is a static prototype, so production implementation must translate its appearance and effects without copying prototype-only behavior that would break existing backend connections. The reference includes local JavaScript filtering, local sample data, a local-only grid/list toggle, overlay actions, and an unwired delete toast. These may guide visual treatment, but production behavior must remain backed by the existing application APIs and routes.
+
+The canonical design source remains `.agents/skills/vinicius-dev-website-guidelines/`. If the reference HTML conflicts with the design system, keep the reference intent while following the design system unless Vinicius explicitly approves an exception. Important constraints include rectangular geometry, near-black surfaces, the three-font stack, restrained neon usage, CRT scanlines, glitch hover, visible focus states, no emoji, no glassmorphism, no unsupported colors, and reduced-motion support.
+
+## Requirements
+- `/admin/photos` must keep using the existing React Router loader data and existing `listAdminPhotos` API path.
+- Existing URL-backed filters must remain functional: search, status, featured, and page.
+- Existing pagination must remain backend-connected and preserve the current query string behavior.
+- Photo cards must continue using `getAdminPhotoOriginalUrl(photo.id)` for protected original image rendering.
+- Each photo must still provide a clear navigation path to `/admin/photos/:id` so metadata and curation editing remain available.
+- The upload action must continue navigating to `/admin/photos/upload`.
+- The gallery screen must adopt the reference visual structure: compact page header, primary upload button, rectangular filters bar, records panel, photo cards, status/featured badges, empty state, pagination area, CRT scanlines, glitch hover, and responsive card/list density.
+- Reference-only controls may be adapted only when they do not alter backend contracts. For example, a local grid/list view toggle is allowed if it only changes presentation and preserves accessibility, loader data, links, filters, and pagination.
+- Overlay affordances may be used for visual parity only if they route to existing production flows or are omitted. Do not ship unwired delete, fake feature, or fake edit behavior.
+- Styling must use the Vinicius.Dev tokens and rules: `Press Start 2P` only for wordmark/control branding, `VT323` for headings/counters, `Fira Mono` for body/UI, zero border radius, hard borders, approved glow/block shadows, no broad gradients on panels/cards, and no emoji.
+- The implementation may update shared admin shell, shared UI primitives, or global CSS only when the change is necessary for the gallery reference style or to reuse already-developed admin/dashboard components.
+- Any shared/global styling change must preserve `/admin/dashboard`, `/admin/photos/upload`, `/admin/photos/:id`, and `/admin/login` behavior.
+- Existing frontend tests around admin photo routes and pages must be preserved or updated to verify the backend-connected behavior after the restyle.
+
+## Implementation Overview
+First, compare `references/vinicius.dev.v2/gallery.html` against the current `/admin/photos` React screen and identify which parts are visual-only, which parts map to existing production behavior, and which prototype actions must be omitted or rerouted. Then update the admin gallery markup and CSS to match the reference composition while keeping loader data, query updates, protected image URLs, upload navigation, and detail navigation intact. Reuse shared admin/dashboard primitives or global styles only where they reduce duplication and do not broaden scope. Finally, verify the admin photo route tests, gallery/detail/upload page tests, lint, build, responsive behavior, keyboard focus, and reduced-motion handling.
+
+## Acceptance Criteria
+- [ ] `/admin/photos` visually follows `references/vinicius.dev.v2/gallery.html` for layout, density, typography, panel hierarchy, photo card treatment, badges, filters, pagination, CRT scanlines, glitch hover, hover states, and responsive behavior.
+- [ ] `/admin/photos` still loads records through the existing `listAdminPhotos` loader/API flow.
+- [ ] Search, status, featured, and page controls still update the URL query and preserve backend-connected filtering/pagination.
+- [ ] Photo cards still render protected originals through `getAdminPhotoOriginalUrl(photo.id)`.
+- [ ] Photo cards or their visible actions still navigate to the existing detail/edit route for the selected photo.
+- [ ] The upload control still navigates to `/admin/photos/upload`.
+- [ ] `/admin/photos/:id` still displays the protected original image, saves metadata, publishes/unpublishes, and features/unfeatures through existing actions.
+- [ ] `/admin/photos/upload` still uploads accepted image types through the existing action and redirects to the created detail page.
+- [ ] No new backend API, Prisma, storage, auth, or media-delivery changes are required.
+- [ ] Prototype-only reference behavior is not shipped as fake production behavior; especially unwired delete and sample-data-only mutations are omitted or replaced by existing production routes.
+- [ ] Any shared React component or global CSS change is necessary for the gallery restyle or reuse of existing matching admin style, and does not redesign unrelated screens.
+- [ ] The implementation follows the Vinicius.Dev design system: no rounded UI, no emoji, no glassmorphism, no unsupported fonts, no unapproved colors, visible focus states, and reduced-motion handling.
+- [ ] Focus and keyboard navigation remain usable for admin nav links, upload navigation, filter fields, view controls if added, photo cards/actions, and pagination buttons.
+- [ ] Frontend verification passes at minimum for admin photo route tests, admin photo page tests, lint, and build.
+
+## Open Questions
+- None. For task splitting, the grid/list toggle is allowed only as presentation-only local state, and hover overlay actions may only route to existing production edit/detail navigation.

--- a/docs/prds/PRD-004/tasks/GAL-001.md
+++ b/docs/prds/PRD-004/tasks/GAL-001.md
@@ -1,0 +1,53 @@
+# GAL-001 - Rebuild Admin Gallery Frame
+
+## Metadata
+- PRD: PRD-004
+- Review Mode: Human
+- Dependencies: None
+- Files Expected To Change:
+  - `frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.tsx`
+  - `frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.test.tsx`
+  - `frontend/src/app/styles/global.css`
+  - `docs/TRACKER.md`
+
+## Goal
+Rework the `/admin/photos` page frame so the header, upload action, filters bar, and records panel match the structure and tone of `references/vinicius.dev.v2/gallery.html` while preserving current loader data, URL-backed filters, upload navigation, and pagination entry points.
+
+## Scope
+- Read `.agents/skills/vinicius-dev-website-guidelines/SKILL.md`, `README.md`, `GUIDELINES.md`, `colors_and_type.css`, and `preview/interactive-components.html` before changing UI.
+- Map the reference page header, `// photo catalog` labeling, upload button treatment, rectangular filters panel, and records panel header into the existing React screen.
+- Preserve `useLoaderData`, `useSearchParams`, `updateQuery`, `goToPage`, `ActionButton` upload navigation, and backend-provided `pageInfo`.
+- Keep filters server-backed through query string updates for `search`, `status`, and `featured`.
+- Update focused component tests to keep asserting upload navigation and backend-connected gallery rendering.
+- Use existing shared admin shell/shared UI components where they already match the requested style.
+
+## Non-Scope
+- Do not restyle photo cards beyond what is required to keep the records panel coherent; photo card visual parity belongs to GAL-002.
+- Do not add grid/list view state, hover overlays, fake edit actions, fake feature actions, delete actions, or client-side filtering.
+- Do not change backend APIs, route loaders, actions, entities, Prisma, media delivery, or auth behavior.
+- Do not redesign `/admin/photos/upload`, `/admin/photos/:id`, public pages, or unrelated admin screens.
+
+## Implementation Plan
+1. Compare the current `AdminPhotosGalleryPage` markup with the reference header, filters, and records panel.
+2. Adjust gallery-level JSX class names and structure so the page header, upload action, filters, and records header can be styled like the reference.
+3. Update `global.css` with scoped admin-gallery frame styles using existing Vinicius.Dev tokens and approved effects only.
+4. Keep all filter controls bound to existing loader data and query updates.
+5. Update tests only where accessible names or structure changed, preserving behavior assertions.
+
+## Acceptance Criteria
+- [ ] `/admin/photos` keeps rendering loader-provided photo data.
+- [ ] The upload control still links to `/admin/photos/upload`.
+- [ ] Search, status, and featured filters still update query string state and reset page to `1`.
+- [ ] Pagination controls still use existing `goToPage` behavior.
+- [ ] The page header, upload action, filters bar, and records panel visually follow the reference frame and design-system rules.
+- [ ] No prototype-only local data or fake mutations are introduced.
+- [ ] Existing gallery behavior tests are preserved or updated.
+
+## Verification Strategy
+- `cd frontend && bun run test -- AdminPhotosGalleryPage.test.tsx` should pass.
+- `cd frontend && bun run lint` should pass.
+
+## Human Review Needs
+- Inspect `/admin/photos` and confirm the page frame, header, upload action, filters, and records panel are close to `references/vinicius.dev.v2/gallery.html` before accepting.
+- Confirm the page still feels like the Vinicius.Dev admin shell and does not introduce rounded UI, emoji, glassmorphism, or unsupported colors.
+

--- a/docs/prds/PRD-004/tasks/GAL-002.md
+++ b/docs/prds/PRD-004/tasks/GAL-002.md
@@ -1,0 +1,54 @@
+# GAL-002 - Restyle Gallery Cards And Presentation Controls
+
+## Metadata
+- PRD: PRD-004
+- Review Mode: Human
+- Dependencies: GAL-001
+- Files Expected To Change:
+  - `frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.tsx`
+  - `frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.test.tsx`
+  - `frontend/src/app/styles/global.css`
+  - `docs/TRACKER.md`
+
+## Goal
+Restyle the admin photo records area so photo cards, badges, hover states, empty state, pagination, and optional presentation-only grid/list view match the gallery reference without changing backend-connected behavior.
+
+## Scope
+- Implement reference-inspired photo cards with rectangular image frames, title/meta blocks, status badges, featured badges when applicable, file-size display, and restrained hover treatment.
+- Add a presentation-only grid/list toggle if it can be done with local component state and no backend contract changes.
+- If hover overlays are used, limit them to existing production navigation such as opening the detail/edit route for the selected photo.
+- Preserve the whole-card or visible-action path to `/admin/photos/:id` with the existing `state.from` return behavior.
+- Preserve `getAdminPhotoOriginalUrl(photo.id)` for protected original images.
+- Restyle the empty state and pagination area to match the reference while keeping current pagination logic.
+- Update component tests to assert protected image URLs, detail navigation, and presentation controls if added.
+
+## Non-Scope
+- Do not add delete, inline feature/unfeature, inline metadata editing, bulk actions, or any fake sample-data mutation.
+- Do not replace server-backed filtering/pagination with local filtering/pagination.
+- Do not change upload/detail route behavior, backend API helpers, route loaders, or actions.
+- Do not introduce persistent user preferences for grid/list view.
+
+## Implementation Plan
+1. Rework photo card JSX to expose the visual pieces needed by the reference: image frame, optional overlay affordance, title, metadata, badges, and size.
+2. Add local presentation state for grid/list view only if it remains fully client-local and accessible.
+3. Update scoped CSS for card grid, list mode, badges, hover states, empty state, and pagination using approved tokens and effects.
+4. Keep links, image URLs, pagination buttons, and accessible labels deterministic.
+5. Update tests for card navigation, protected original URLs, and any new presentation-only controls.
+
+## Acceptance Criteria
+- [ ] Photo cards visually follow the reference card treatment in grid mode.
+- [ ] List mode is available only as presentation-only local state if implemented.
+- [ ] Card images still use `getAdminPhotoOriginalUrl(photo.id)`.
+- [ ] Each photo still has a clear accessible path to `/admin/photos/:id`.
+- [ ] Status and featured state are represented as badges without adding new curation behavior.
+- [ ] Empty and pagination states visually match the reference and keep current behavior.
+- [ ] No fake delete, fake feature, sample-data mutation, or client-only filtering is shipped.
+
+## Verification Strategy
+- `cd frontend && bun run test -- AdminPhotosGalleryPage.test.tsx` should pass.
+- `cd frontend && bun run lint` should pass.
+
+## Human Review Needs
+- Inspect `/admin/photos` in populated and empty states and confirm cards, badges, hover treatment, pagination, and optional list mode match the reference closely enough.
+- Confirm any overlay action is honest production navigation and not fake or misleading.
+

--- a/docs/prds/PRD-004/tasks/GAL-003.md
+++ b/docs/prds/PRD-004/tasks/GAL-003.md
@@ -1,0 +1,51 @@
+# GAL-003 - Preserve Photo Admin Workflow Regressions
+
+## Metadata
+- PRD: PRD-004
+- Review Mode: Agent
+- Review Reason: This task is focused on deterministic behavior preservation through route and component tests.
+- Dependencies: GAL-002
+- Files Expected To Change:
+  - `frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.test.tsx`
+  - `frontend/src/pages/admin/photos/route.test.ts`
+  - `frontend/src/pages/admin/photos/ui/AdminPhotoDetailPage.tsx`
+  - `frontend/src/pages/admin/photos/ui/AdminPhotoUploadPage.tsx`
+  - `frontend/src/app/styles/global.css`
+  - `docs/TRACKER.md`
+
+## Goal
+Verify and harden the existing admin photo workflows after the gallery restyle so listing, filtering, pagination, upload, detail display, metadata editing, and curation editing remain backend-connected.
+
+## Scope
+- Preserve or expand tests for `adminPhotosLoader` query parsing and calls to `listAdminPhotos`.
+- Preserve or expand tests for unauthorized admin photo loader redirects.
+- Preserve or expand tests for protected original URLs on gallery and detail screens.
+- Preserve or expand tests for upload, metadata edit, and curation edit actions.
+- Make only incidental UI/style adjustments to upload/detail screens if shared/global gallery styles caused regressions.
+- Keep changes within frontend admin photo route/page tests and tightly related UI compatibility fixes.
+
+## Non-Scope
+- Do not materially redesign upload or detail screens.
+- Do not change backend contracts, entity API helpers, action semantics, upload validation, auth behavior, or media delivery.
+- Do not add new visual features to the gallery beyond what GAL-001 and GAL-002 already scoped.
+- Do not broaden testing into unrelated admin/public areas unless a regression from shared styles is discovered.
+
+## Implementation Plan
+1. Review existing admin photo route and page tests after GAL-001 and GAL-002.
+2. Add focused assertions for any behavior that could have been weakened by the restyle, especially query filters, protected images, detail links, and upload/detail actions.
+3. Fix only frontend UI or scoped CSS regressions caused by shared/global style changes.
+4. Run focused admin photo tests and frontend lint.
+
+## Acceptance Criteria
+- [ ] `adminPhotosLoader` still maps `search`, `status`, `featured`, and `page` query values into `listAdminPhotos`.
+- [ ] Unauthorized loader behavior still redirects to `/admin/login`.
+- [ ] Gallery and detail screens still render protected original URLs.
+- [ ] Upload action still calls the existing upload API path and redirects to the created detail route.
+- [ ] Metadata and curation actions still submit through existing action handlers.
+- [ ] Upload/detail screen behavior is not materially redesigned.
+- [ ] Focused frontend tests cover the preserved workflows.
+
+## Verification Strategy
+- `cd frontend && bun run test -- AdminPhotosGalleryPage.test.tsx route.test.ts` should pass.
+- `cd frontend && bun run lint` should pass.
+

--- a/docs/prds/PRD-004/tasks/GAL-004.md
+++ b/docs/prds/PRD-004/tasks/GAL-004.md
@@ -1,0 +1,57 @@
+# GAL-004 - Final Gallery Visual Acceptance
+
+## Metadata
+- PRD: PRD-004
+- Review Mode: Human
+- Dependencies: GAL-003
+- Files Expected To Change:
+  - `frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.tsx`
+  - `frontend/src/app/styles/global.css`
+  - `docs/TRACKER.md`
+
+## Goal
+Perform the final responsive, accessibility, reduced-motion, and visual acceptance pass for the admin gallery restyle against `references/vinicius.dev.v2/gallery.html` and the Vinicius.Dev design system.
+
+## Scope
+- Run the full frontend verification commands required by the PRD.
+- Inspect `/admin/photos` across desktop and mobile widths.
+- Verify keyboard focus is visible for admin nav links, upload navigation, filters, presentation controls if added, photo links/actions, and pagination.
+- Verify reduced-motion behavior collapses animations gracefully.
+- Confirm the final gallery does not introduce rounded UI, emoji, glassmorphism, unsupported fonts, unapproved colors, unapproved soft shadows, or fake production behavior.
+- Make only final polish fixes needed to satisfy visual acceptance and verification.
+
+## Non-Scope
+- Do not add new features, backend changes, schema changes, or route changes.
+- Do not redesign upload/detail screens beyond fixing regressions caused by shared/global style changes.
+- Do not broaden the PRD into public pages or unrelated admin surfaces.
+- Do not skip failed acceptance criteria without explicit Vinicius approval.
+
+## Implementation Plan
+1. Run focused admin photo tests, full frontend tests, lint, and build.
+2. Start the frontend locally if visual inspection needs a running app.
+3. Inspect `/admin/photos` against the reference on desktop and mobile widths, including empty/populated states where viable.
+4. Check keyboard focus and reduced-motion behavior.
+5. Apply only tightly scoped final fixes required for acceptance.
+6. Record final evidence in `docs/TRACKER.md`.
+
+## Acceptance Criteria
+- [ ] `/admin/photos` matches the reference closely enough for human visual acceptance.
+- [ ] The final screen follows the Vinicius.Dev design system constraints.
+- [ ] Desktop and mobile layouts remain usable and visually aligned with the reference.
+- [ ] Keyboard focus is visible and usable across gallery controls.
+- [ ] Reduced-motion behavior is present for animations.
+- [ ] No fake production behavior from the static reference is shipped.
+- [ ] Focused admin photo tests pass.
+- [ ] Frontend lint passes.
+- [ ] Frontend build passes.
+
+## Verification Strategy
+- `cd frontend && bun run test -- AdminPhotosGalleryPage.test.tsx route.test.ts` should pass.
+- `cd frontend && bun run test` should pass.
+- `cd frontend && bun run lint` should pass.
+- `cd frontend && bun run build` should pass.
+
+## Human Review Needs
+- Compare `/admin/photos` with `references/vinicius.dev.v2/gallery.html` and approve whether the visual parity, interaction feel, responsive behavior, and design-system compliance are acceptable.
+- Confirm any unresolved visual differences are acceptable before marking the PRD implementation accepted.
+

--- a/frontend/src/app/styles/global.css
+++ b/frontend/src/app/styles/global.css
@@ -2869,6 +2869,242 @@ button {
   grid-template-columns: minmax(220px, 1fr) repeat(2, minmax(150px, 0.35fr));
 }
 
+.admin-photo-gallery {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+.admin-photo-gallery__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-6);
+  margin-bottom: var(--spacing-4);
+}
+
+.admin-photo-gallery__eyebrow {
+  display: block;
+  margin-bottom: 10px;
+  color: var(--fg-3);
+}
+
+.admin-photo-gallery__title {
+  margin: 0 0 10px;
+  color: var(--fg-0);
+  font-family: var(--font-pixel);
+  font-size: 40px;
+  letter-spacing: 0;
+  line-height: 1;
+  text-transform: lowercase;
+}
+
+.admin-photo-gallery__subtitle {
+  max-width: 480px;
+  margin: 0;
+  color: var(--fg-2);
+  font-size: 12px;
+}
+
+.app-shell--admin .admin-photo-gallery__upload.action-button {
+  flex-shrink: 0;
+  min-height: 42px;
+  margin-top: 4px;
+  padding: 11px 22px;
+  border-color: var(--neon-pink);
+  background: var(--bg-1);
+  box-shadow: 4px 4px 0 0 var(--neon-pink);
+  color: var(--fg-0);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  white-space: nowrap;
+}
+
+.app-shell--admin .admin-photo-gallery__upload.action-button:hover {
+  border-color: var(--neon-pink);
+  background: var(--neon-pink);
+  box-shadow: 4px 4px 0 0 var(--neon-pink);
+  color: var(--bg-0);
+}
+
+.app-shell--admin .admin-photo-gallery__upload.action-button:active {
+  box-shadow: none;
+  transform: translate(4px, 4px);
+}
+
+.admin-photo-gallery__filters.screen-frame,
+.admin-photo-gallery__records.screen-frame {
+  overflow: visible;
+  border-color: var(--line-2);
+  background: var(--bg-1);
+}
+
+.admin-photo-gallery__filters.screen-frame::before,
+.admin-photo-gallery__records.screen-frame::before {
+  content: none;
+}
+
+.admin-photo-gallery__filters {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-3);
+  padding: 20px 24px;
+}
+
+.admin-photo-gallery__records.screen-frame {
+  padding: 0;
+}
+
+.admin-photo-gallery__panel-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--fg-3);
+  letter-spacing: 0.2em;
+}
+
+.admin-photo-gallery__panel-label::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--line-1);
+}
+
+.admin-photo-gallery__records-header .admin-photo-gallery__panel-label::after {
+  content: none;
+}
+
+.admin-photo-gallery__filters-row {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) repeat(2, minmax(150px, 180px));
+  gap: var(--spacing-3);
+  align-items: end;
+}
+
+.admin-photo-gallery__filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.admin-photo-gallery__filter-field label {
+  color: var(--fg-2);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.admin-photo-gallery__input-wrap {
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--line-2);
+  background: var(--bg-0);
+  transition:
+    border-color 120ms steps(1),
+    box-shadow 120ms steps(1);
+}
+
+.admin-photo-gallery__input-wrap:focus-within {
+  border-color: var(--neon-cyan);
+  box-shadow: var(--glow-cyan);
+}
+
+.admin-photo-gallery__input-prompt {
+  flex-shrink: 0;
+  padding: 0 8px 0 12px;
+  color: var(--fg-3);
+  font-size: 13px;
+  pointer-events: none;
+}
+
+.admin-photo-gallery__input-wrap:focus-within .admin-photo-gallery__input-prompt {
+  color: var(--neon-cyan);
+}
+
+.admin-photo-gallery__input-wrap input,
+.admin-photo-gallery__select-wrap select {
+  width: 100%;
+  min-height: 36px;
+  border: 0;
+  background: transparent;
+  color: var(--fg-0);
+  font-size: 13px;
+  outline: none;
+}
+
+.admin-photo-gallery__input-wrap input {
+  padding: 9px 12px 9px 0;
+}
+
+.admin-photo-gallery__input-wrap input::placeholder {
+  color: var(--fg-3);
+}
+
+.admin-photo-gallery__select-wrap {
+  position: relative;
+  border: 1px solid var(--line-2);
+  background: var(--bg-0);
+  transition:
+    border-color 120ms steps(1),
+    box-shadow 120ms steps(1);
+}
+
+.admin-photo-gallery__select-wrap::after {
+  content: '▾';
+  position: absolute;
+  top: 50%;
+  right: 12px;
+  color: var(--fg-3);
+  font-size: 12px;
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
+.admin-photo-gallery__select-wrap:focus-within {
+  border-color: var(--neon-cyan);
+  box-shadow: var(--glow-cyan);
+}
+
+.admin-photo-gallery__input-wrap input:focus-visible,
+.admin-photo-gallery__select-wrap select:focus-visible,
+.admin-photo-pagination button:focus-visible {
+  outline: 2px solid var(--neon-cyan);
+  outline-offset: 2px;
+}
+
+.admin-photo-gallery__select-wrap select {
+  padding: 9px 32px 9px 12px;
+  appearance: none;
+  color-scheme: dark;
+  cursor: pointer;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+}
+
+.admin-photo-gallery__records {
+  display: grid;
+}
+
+.admin-photo-gallery__records-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--line-1);
+}
+
+.admin-photo-gallery__records-count {
+  color: var(--fg-3);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.admin-photo-gallery__records-count span {
+  color: var(--fg-2);
+}
+
 .admin-photo-toolbar,
 .admin-photo-pagination,
 .admin-photo-empty,
@@ -2881,26 +3117,32 @@ button {
 
 .admin-photo-grid {
   display: grid;
-  gap: var(--spacing-3);
-  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  gap: var(--spacing-4);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding: 20px;
 }
 
 .admin-photo-card {
   display: grid;
   overflow: hidden;
-  border: 1px solid var(--surface-border-soft);
+  border: 1px solid var(--line-2);
+  background: var(--bg-1);
   color: inherit;
   text-decoration: none;
+  transition:
+    background-color 80ms steps(1),
+    border-color 120ms steps(1);
 }
 
 .admin-photo-card:hover {
-  border-color: var(--neon-cyan);
+  border-color: var(--line-2);
+  background: var(--bg-2);
 }
 
 .admin-photo-card__image {
   display: block;
   aspect-ratio: 4 / 3;
-  background: var(--bg-0);
+  background: var(--bg-2);
 }
 
 .admin-photo-card__image img,
@@ -2914,11 +3156,11 @@ button {
 
 .admin-photo-card__body {
   display: grid;
-  gap: 6px;
-  padding: 12px;
-  color: var(--fg-2);
-  font-size: 10px;
-  letter-spacing: 0.12em;
+  gap: 5px;
+  padding: 14px 16px;
+  color: var(--fg-3);
+  font-size: 11px;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
@@ -2930,9 +3172,19 @@ button {
 
 .admin-photo-empty {
   display: grid;
-  gap: 8px;
-  border: 1px dashed var(--surface-border);
-  padding: var(--spacing-4);
+  justify-items: center;
+  gap: var(--spacing-3);
+  min-height: 220px;
+  padding: var(--spacing-8) var(--spacing-5);
+  border-bottom: 1px solid var(--line-1);
+  text-align: center;
+}
+
+.admin-photo-empty__glyph {
+  color: var(--fg-3);
+  font-family: var(--font-pixel);
+  font-size: 64px;
+  line-height: 1;
 }
 
 .admin-photo-pagination button,
@@ -2962,7 +3214,7 @@ button {
 .admin-photo-upload button:disabled,
 .admin-photo-detail button:disabled {
   cursor: not-allowed;
-  opacity: 0.5;
+  opacity: 0.35;
 }
 
 .admin-photo-detail {
@@ -3037,6 +3289,10 @@ button {
     padding-top: 108px;
   }
 
+  .admin-photo-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .admin-dashboard-page__stats {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -3055,6 +3311,23 @@ button {
 }
 
 @media (max-width: 880px) {
+  .admin-photo-gallery__header {
+    flex-direction: column;
+    gap: var(--spacing-4);
+  }
+
+  .app-shell--admin .admin-photo-gallery__upload.action-button {
+    align-self: flex-start;
+  }
+
+  .admin-photo-gallery__filters-row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .admin-photo-gallery__filter-field:first-child {
+    grid-column: 1 / -1;
+  }
+
   .admin-shell__inner {
     grid-template-columns: 1fr;
     align-items: flex-start;
@@ -3112,6 +3385,26 @@ button {
 @media (max-width: 760px) {
   .layout-container {
     width: min(calc(100% - 20px), var(--shell-max-width));
+  }
+
+  .admin-photo-gallery__filters-row,
+  .admin-photo-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-photo-gallery__filters.screen-frame {
+    padding: 16px;
+  }
+
+  .admin-photo-gallery__records-header,
+  .admin-photo-pagination {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .admin-photo-grid {
+    gap: var(--spacing-3);
+    padding: 12px;
   }
 
   .app-shell__body,

--- a/frontend/src/app/styles/global.css
+++ b/frontend/src/app/styles/global.css
@@ -3105,6 +3105,44 @@ button {
   color: var(--fg-2);
 }
 
+.admin-photo-gallery__records-tools {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+}
+
+.admin-photo-view-toggle {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.admin-photo-view-toggle button {
+  display: inline-grid;
+  place-items: center;
+  min-width: 34px;
+  min-height: 32px;
+  border: 1px solid var(--line-2);
+  background: var(--bg-0);
+  color: var(--fg-3);
+  cursor: pointer;
+  font-size: 12px;
+  transition:
+    border-color 80ms steps(1),
+    color 80ms steps(1);
+}
+
+.admin-photo-view-toggle button:hover,
+.admin-photo-view-toggle button.is-active {
+  border-color: var(--neon-cyan);
+  color: var(--neon-cyan);
+}
+
+.admin-photo-view-toggle button:focus-visible,
+.admin-photo-card:focus-visible {
+  outline: 2px solid var(--neon-cyan);
+  outline-offset: 2px;
+}
+
 .admin-photo-toolbar,
 .admin-photo-pagination,
 .admin-photo-empty,
@@ -3123,7 +3161,9 @@ button {
 }
 
 .admin-photo-card {
-  display: grid;
+  position: relative;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
   border: 1px solid var(--line-2);
   background: var(--bg-1);
@@ -3131,18 +3171,23 @@ button {
   text-decoration: none;
   transition:
     background-color 80ms steps(1),
-    border-color 120ms steps(1);
+    border-color 120ms steps(1),
+    transform 120ms steps(2);
 }
 
 .admin-photo-card:hover {
   border-color: var(--line-2);
   background: var(--bg-2);
+  transform: translate(-1px, -1px);
 }
 
 .admin-photo-card__image {
+  position: relative;
   display: block;
   aspect-ratio: 4 / 3;
+  overflow: hidden;
   background: var(--bg-2);
+  border-bottom: 1px solid var(--line-1);
 }
 
 .admin-photo-card__image img,
@@ -3154,29 +3199,162 @@ button {
   object-fit: cover;
 }
 
-.admin-photo-card__body {
+.admin-photo-card__image::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(to bottom, rgba(255, 255, 255, 0.045) 0 1px, transparent 1px 3px),
+    radial-gradient(ellipse at center, transparent 52%, rgba(0, 0, 0, 0.34) 100%);
+  opacity: 0.65;
+}
+
+.admin-photo-card__overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  background: rgba(7, 6, 11, 0.72);
+  color: var(--neon-cyan);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  opacity: 0;
+  text-transform: uppercase;
+  transition: opacity 150ms steps(2);
+}
+
+.admin-photo-card:hover .admin-photo-card__overlay,
+.admin-photo-card:focus-visible .admin-photo-card__overlay {
+  opacity: 1;
+}
+
+.admin-photo-card__info {
   display: grid;
   gap: 5px;
   padding: 14px 16px;
+}
+
+.admin-photo-card__title {
+  color: var(--fg-0);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+}
+
+.admin-photo-card__meta {
   color: var(--fg-3);
   font-size: 11px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
-.admin-photo-card__body strong,
+.admin-photo-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  margin-top: auto;
+  padding: 0 16px 14px;
+}
+
+.admin-photo-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.admin-photo-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid;
+  padding: 2px 8px;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.admin-photo-badge--draft {
+  border-color: rgba(255, 231, 76, 0.42);
+  color: var(--neon-yellow);
+}
+
+.admin-photo-badge--published {
+  border-color: rgba(182, 255, 60, 0.42);
+  color: var(--neon-lime);
+}
+
+.admin-photo-badge--featured {
+  border-color: rgba(34, 227, 255, 0.42);
+  color: var(--neon-cyan);
+}
+
+.admin-photo-badge__dot {
+  width: 5px;
+  height: 5px;
+  background: currentColor;
+}
+
+.admin-photo-card__size {
+  color: var(--fg-3);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.admin-photo-grid--list {
+  grid-template-columns: 1fr;
+}
+
+.admin-photo-grid--list .admin-photo-card {
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr) auto;
+  align-items: stretch;
+}
+
+.admin-photo-grid--list .admin-photo-card__image {
+  aspect-ratio: auto;
+  height: 92px;
+  border-right: 1px solid var(--line-1);
+  border-bottom: 0;
+}
+
+.admin-photo-grid--list .admin-photo-card__overlay {
+  display: none;
+}
+
+.admin-photo-grid--list .admin-photo-card__info {
+  align-content: center;
+  padding: 12px 16px;
+}
+
+.admin-photo-grid--list .admin-photo-card__footer {
+  align-content: center;
+  align-items: center;
+  margin-top: 0;
+  padding: 12px 16px;
+}
+
 .admin-photo-empty strong {
   color: var(--fg-0);
   font-weight: 500;
 }
 
 .admin-photo-empty {
-  display: grid;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   justify-items: center;
   gap: var(--spacing-3);
   min-height: 220px;
   padding: var(--spacing-8) var(--spacing-5);
   border-bottom: 1px solid var(--line-1);
+  background-image: radial-gradient(rgba(216, 198, 255, 0.16) 1px, transparent 1px);
+  background-size: 8px 8px;
   text-align: center;
 }
 
@@ -3192,13 +3370,26 @@ button {
 .admin-photo-upload button,
 .admin-photo-detail button {
   min-height: 38px;
-  border: 1px solid var(--surface-border);
+  border: 1px solid var(--line-2);
   background: transparent;
   color: var(--fg-1);
   padding: 10px 12px;
   font-size: 10px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
+}
+
+.admin-photo-pagination {
+  padding: 16px 20px;
+  border-top: 1px solid var(--line-1);
+}
+
+.admin-photo-pagination span {
+  color: var(--fg-2);
+}
+
+.admin-photo-pagination button {
+  background: var(--bg-0);
 }
 
 .admin-photo-pagination button:hover:not(:disabled),
@@ -3402,9 +3593,30 @@ button {
     flex-direction: column;
   }
 
+  .admin-photo-gallery__records-tools {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--spacing-2);
+  }
+
   .admin-photo-grid {
     gap: var(--spacing-3);
     padding: 12px;
+  }
+
+  .admin-photo-grid--list .admin-photo-card {
+    grid-template-columns: 96px minmax(0, 1fr);
+  }
+
+  .admin-photo-grid--list .admin-photo-card__image {
+    height: 100%;
+    min-height: 104px;
+  }
+
+  .admin-photo-grid--list .admin-photo-card__footer {
+    grid-column: 1 / -1;
+    justify-content: space-between;
+    padding-top: 0;
   }
 
   .app-shell__body,

--- a/frontend/src/app/styles/global.css
+++ b/frontend/src/app/styles/global.css
@@ -2253,6 +2253,17 @@ button {
   content: none;
 }
 
+.app-shell--admin .screen-frame:has(.admin-photo-gallery) {
+  overflow: visible;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.app-shell--admin .screen-frame:has(.admin-photo-gallery)::before {
+  content: none;
+}
+
 .app-shell--admin .signal-link,
 .app-shell--admin .action-button {
   min-height: 30px;
@@ -2870,7 +2881,7 @@ button {
 }
 
 .admin-photo-gallery {
-  max-width: 1120px;
+  width: min(100%, 1408px);
   margin: 0 auto;
 }
 
@@ -3729,5 +3740,16 @@ button {
 
   .admin-shell__channel-bug {
     right: 12px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/frontend/src/pages/admin/photos/route.test.ts
+++ b/frontend/src/pages/admin/photos/route.test.ts
@@ -58,21 +58,23 @@ const photoItem = {
   updatedAt: '2026-04-28T12:00:00.000Z',
 } as const
 
+const listResponse = {
+  items: [photoItem],
+  pageInfo: {
+    page: 2,
+    pageSize: 20,
+    totalItems: 21,
+    totalPages: 2,
+  },
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
 })
 
 describe('admin photo routes', () => {
-  it('loads private gallery filters from the URL', async () => {
-    mocks.listAdminPhotos.mockResolvedValueOnce({
-      items: [photoItem],
-      pageInfo: {
-        page: 2,
-        pageSize: 20,
-        totalItems: 21,
-        totalPages: 2,
-      },
-    })
+  it('maps private gallery query values into listAdminPhotos', async () => {
+    mocks.listAdminPhotos.mockResolvedValueOnce(listResponse)
 
     const result = await adminPhotosLoader(
       routeArgs(new Request('http://localhost/admin/photos?status=draft&featured=featured&search=night&page=2')),
@@ -95,6 +97,40 @@ describe('admin photo routes', () => {
       },
       items: [photoItem],
     })
+
+    mocks.listAdminPhotos.mockResolvedValueOnce(listResponse)
+
+    const hiddenResult = await adminPhotosLoader(
+      routeArgs(
+        new Request('http://localhost/admin/photos?status=published&featured=not_featured&search=%20street%20&page=3'),
+      ),
+    )
+
+    expect(mocks.listAdminPhotos).toHaveBeenLastCalledWith(
+      {
+        featured: false,
+        page: 3,
+        search: 'street',
+        status: 'published',
+      },
+      expect.any(AbortSignal),
+    )
+    expect(hiddenResult).toMatchObject({
+      filters: {
+        featured: 'not_featured',
+        search: 'street',
+        status: 'published',
+      },
+      items: [photoItem],
+    })
+  })
+
+  it('redirects unauthorized gallery loads to admin login', async () => {
+    mocks.listAdminPhotos.mockRejectedValueOnce(new ApiRequestError(401, { error: 'denied' }))
+
+    const result = await adminPhotosLoader(routeArgs(new Request('http://localhost/admin/photos')))
+
+    expect((result as Response).headers.get('location')).toBe('/admin/login')
   })
 
   it('loads a private photo detail and protected original URL', async () => {
@@ -144,10 +180,22 @@ describe('admin photo routes', () => {
       } as unknown as Request),
     )
 
+    expect(mocks.uploadAdminPhoto).toHaveBeenCalledWith({
+      camera: undefined,
+      caption: undefined,
+      date: photoItem.date,
+      file,
+      film: undefined,
+      frame: photoItem.frame,
+      location: photoItem.location,
+      tags: [],
+      title: photoItem.title,
+      tone: photoItem.tone,
+    })
     expect((result as Response).headers.get('location')).toBe('/admin/photos/photo_1')
   })
 
-  it('submits detail metadata and curation actions', async () => {
+  it('submits detail metadata actions through the existing handler', async () => {
     mocks.updateAdminPhotoMetadata.mockResolvedValueOnce({ item: photoItem })
     const metadata = new FormData()
     metadata.set('intent', 'update_metadata')
@@ -157,6 +205,10 @@ describe('admin photo routes', () => {
     metadata.set('date', photoItem.date)
     metadata.set('location', photoItem.location)
     metadata.set('tone', photoItem.tone)
+    metadata.set('tags', 'night, street, ')
+    metadata.set('caption', photoItem.caption)
+    metadata.set('camera', photoItem.camera)
+    metadata.set('film', photoItem.film)
 
     await expect(
       adminPhotoDetailAction(
@@ -173,6 +225,21 @@ describe('admin photo routes', () => {
       status: 'success',
     })
 
+    expect(mocks.updateAdminPhotoMetadata).toHaveBeenCalledWith({
+      camera: photoItem.camera,
+      caption: photoItem.caption,
+      date: photoItem.date,
+      film: photoItem.film,
+      frame: photoItem.frame,
+      id: photoItem.id,
+      location: photoItem.location,
+      tags: ['night', 'street'],
+      title: photoItem.title,
+      tone: photoItem.tone,
+    })
+  })
+
+  it('submits detail curation actions through the existing handler', async () => {
     mocks.updateAdminPhotoCuration.mockResolvedValueOnce({ item: photoItem })
     const curation = new FormData()
     curation.set('intent', 'update_curation')
@@ -192,6 +259,39 @@ describe('admin photo routes', () => {
     ).resolves.toMatchObject({
       intent: 'update_curation',
       status: 'success',
+    })
+
+    expect(mocks.updateAdminPhotoCuration).toHaveBeenLastCalledWith({
+      featured: undefined,
+      id: photoItem.id,
+      status: 'published',
+    })
+
+    mocks.updateAdminPhotoCuration.mockResolvedValueOnce({ item: photoItem })
+    const feature = new FormData()
+    feature.set('intent', 'update_curation')
+    feature.set('photoId', photoItem.id)
+    feature.set('featured', 'true')
+
+    await expect(
+      adminPhotoDetailAction(
+        routeArgs(
+          new Request('http://localhost/admin/photos/photo_1', {
+            body: feature,
+            method: 'POST',
+          }),
+          { id: photoItem.id },
+        ),
+      ),
+    ).resolves.toMatchObject({
+      intent: 'update_curation',
+      status: 'success',
+    })
+
+    expect(mocks.updateAdminPhotoCuration).toHaveBeenLastCalledWith({
+      featured: true,
+      id: photoItem.id,
+      status: undefined,
     })
   })
 })

--- a/frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.test.tsx
+++ b/frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.test.tsx
@@ -53,22 +53,44 @@ afterEach(() => {
 
 describe('admin photo split screens', () => {
   it('renders private gallery cards and upload navigation', async () => {
+    const user = userEvent.setup()
     const router = createMemoryRouter([
       {
         element: <AdminPhotosGalleryPage />,
         loader: ({ request }) => createGalleryLoaderData(request),
         path: '/admin/photos',
       },
+      {
+        element: <div>photo detail route</div>,
+        path: '/admin/photos/:id',
+      },
     ], {
-      initialEntries: ['/admin/photos'],
+      initialEntries: ['/admin/photos?page=2&status=draft'],
     })
 
     render(<RouterProvider router={router} />)
 
     expect(await screen.findByRole('heading', { name: 'private gallery' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /upload photo/i })).toHaveAttribute('href', '/admin/photos/upload')
-    expect(screen.getByRole('link', { name: /paulista at 02:14/i })).toHaveAttribute('href', '/admin/photos/photo_1')
+    const photoLink = screen.getByRole('link', { name: /paulista at 02:14/i })
+    expect(photoLink).toHaveAttribute('href', '/admin/photos/photo_1')
     expect(screen.getByAltText('paulista at 02:14')).toHaveAttribute('src', '/api/admin/photos/photo_1/original')
+
+    const gridView = screen.getByRole('button', { name: /grid view/i })
+    const listView = screen.getByRole('button', { name: /list view/i })
+    expect(gridView).toHaveAttribute('aria-pressed', 'true')
+    expect(listView).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(listView)
+
+    expect(gridView).toHaveAttribute('aria-pressed', 'false')
+    expect(listView).toHaveAttribute('aria-pressed', 'true')
+    expect(router.state.location.search).toBe('?page=2&status=draft')
+
+    await user.click(photoLink)
+
+    expect(router.state.location.pathname).toBe('/admin/photos/photo_1')
+    expect(router.state.location.state).toEqual({ from: '/admin/photos?page=2&status=draft' })
   })
 
   it('keeps filters backed by query string state and resets page', async () => {

--- a/frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.test.tsx
+++ b/frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it } from 'vitest'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 
@@ -27,6 +28,25 @@ const photoItem = {
   updatedAt: '2026-04-28T12:00:00.000Z',
 } as const
 
+const createGalleryLoaderData = (request: Request) => {
+  const url = new URL(request.url)
+
+  return {
+    filters: {
+      featured: url.searchParams.get('featured') ?? 'all',
+      search: url.searchParams.get('search') ?? '',
+      status: url.searchParams.get('status') ?? 'all',
+    },
+    items: [photoItem],
+    pageInfo: {
+      page: Number(url.searchParams.get('page') ?? '1'),
+      pageSize: 20,
+      totalItems: 42,
+      totalPages: 3,
+    },
+  }
+}
+
 afterEach(() => {
   cleanup()
 })
@@ -36,20 +56,7 @@ describe('admin photo split screens', () => {
     const router = createMemoryRouter([
       {
         element: <AdminPhotosGalleryPage />,
-        loader: () => ({
-          filters: {
-            featured: 'all',
-            search: '',
-            status: 'all',
-          },
-          items: [photoItem],
-          pageInfo: {
-            page: 1,
-            pageSize: 20,
-            totalItems: 1,
-            totalPages: 1,
-          },
-        }),
+        loader: ({ request }) => createGalleryLoaderData(request),
         path: '/admin/photos',
       },
     ], {
@@ -59,9 +66,65 @@ describe('admin photo split screens', () => {
     render(<RouterProvider router={router} />)
 
     expect(await screen.findByRole('heading', { name: 'private gallery' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'upload photo' })).toHaveAttribute('href', '/admin/photos/upload')
+    expect(screen.getByRole('link', { name: /upload photo/i })).toHaveAttribute('href', '/admin/photos/upload')
     expect(screen.getByRole('link', { name: /paulista at 02:14/i })).toHaveAttribute('href', '/admin/photos/photo_1')
     expect(screen.getByAltText('paulista at 02:14')).toHaveAttribute('src', '/api/admin/photos/photo_1/original')
+  })
+
+  it('keeps filters backed by query string state and resets page', async () => {
+    const user = userEvent.setup()
+    const router = createMemoryRouter([
+      {
+        element: <AdminPhotosGalleryPage />,
+        loader: ({ request }) => createGalleryLoaderData(request),
+        path: '/admin/photos',
+      },
+    ], {
+      initialEntries: ['/admin/photos?page=3'],
+    })
+
+    render(<RouterProvider router={router} />)
+
+    await user.type(await screen.findByLabelText('search'), 'neon')
+
+    expect(router.state.location.search).toContain('search=neon')
+    expect(router.state.location.search).toContain('page=1')
+
+    await user.selectOptions(screen.getByLabelText('status'), 'published')
+
+    expect(router.state.location.search).toContain('status=published')
+    expect(router.state.location.search).toContain('page=1')
+
+    await user.selectOptions(screen.getByLabelText('featured'), 'featured')
+
+    expect(router.state.location.search).toContain('featured=featured')
+    expect(router.state.location.search).toContain('page=1')
+  })
+
+  it('keeps pagination backed by existing page query behavior', async () => {
+    const user = userEvent.setup()
+    const router = createMemoryRouter([
+      {
+        element: <AdminPhotosGalleryPage />,
+        loader: ({ request }) => createGalleryLoaderData(request),
+        path: '/admin/photos',
+      },
+    ], {
+      initialEntries: ['/admin/photos?page=2&status=draft'],
+    })
+
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findAllByText('page 2 / 3')).toHaveLength(2)
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    expect(router.state.location.search).toContain('page=3')
+    expect(router.state.location.search).toContain('status=draft')
+
+    await user.click(screen.getByRole('button', { name: /previous/i }))
+
+    expect(router.state.location.search).toContain('page=2')
+    expect(router.state.location.search).toContain('status=draft')
   })
 
   it('renders the upload form as its own screen', async () => {

--- a/frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.tsx
+++ b/frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.tsx
@@ -46,51 +46,77 @@ export function AdminPhotosGalleryPage() {
   }
 
   return (
-    <Stack gap={20}>
-      <div className="admin-photo-header">
+    <Stack className="admin-photo-gallery" gap={16}>
+      <div className="admin-photo-gallery__header">
         <div>
-          <InlineLabel>photo catalog</InlineLabel>
-          <h2 className="page-heading fx-crt-title">private gallery</h2>
-          <p className="page-copy">Browse drafts and published originals before opening a frame for curation.</p>
+          <InlineLabel className="admin-photo-gallery__eyebrow">// photo catalog</InlineLabel>
+          <h2 className="admin-photo-gallery__title">private gallery</h2>
+          <p className="admin-photo-gallery__subtitle">
+            Browse drafts and published originals before opening a frame for curation.
+          </p>
         </div>
-        <ActionButton to="/admin/photos/upload">upload photo</ActionButton>
+        <ActionButton className="admin-photo-gallery__upload glitch-hover" to="/admin/photos/upload">
+          <span aria-hidden="true">►</span>
+          upload photo
+        </ActionButton>
       </div>
 
-      <ScreenFrame className="admin-panel">
-        <InlineLabel>filters</InlineLabel>
-        <div className="admin-status-editor admin-photo-filters">
-          <label className="admin-field">
-            <span>search</span>
-            <input
-              value={data.filters.search}
-              onChange={(event) => updateQuery({ search: event.target.value })}
-              placeholder="title, frame, location"
-            />
-          </label>
-          <label className="admin-field">
-            <span>status</span>
-            <select value={data.filters.status} onChange={(event) => updateQuery({ status: event.target.value })}>
-              <option value="all">all</option>
-              <option value="draft">draft</option>
-              <option value="published">published</option>
-            </select>
-          </label>
-          <label className="admin-field">
-            <span>featured</span>
-            <select value={data.filters.featured} onChange={(event) => updateQuery({ featured: event.target.value })}>
-              <option value="all">all</option>
-              <option value="featured">featured</option>
-              <option value="not_featured">not featured</option>
-            </select>
-          </label>
+      <ScreenFrame className="admin-panel admin-photo-gallery__filters">
+        <InlineLabel className="admin-photo-gallery__panel-label">// filters</InlineLabel>
+        <div className="admin-photo-gallery__filters-row">
+          <div className="admin-photo-gallery__filter-field">
+            <label htmlFor="admin-photo-search">search</label>
+            <div className="admin-photo-gallery__input-wrap">
+              <span aria-hidden="true" className="admin-photo-gallery__input-prompt">
+                &gt;
+              </span>
+              <input
+                id="admin-photo-search"
+                value={data.filters.search}
+                onChange={(event) => updateQuery({ search: event.target.value })}
+                placeholder="title, frame, location"
+              />
+            </div>
+          </div>
+          <div className="admin-photo-gallery__filter-field">
+            <label htmlFor="admin-photo-status">status</label>
+            <div className="admin-photo-gallery__select-wrap">
+              <select
+                id="admin-photo-status"
+                value={data.filters.status}
+                onChange={(event) => updateQuery({ status: event.target.value })}
+              >
+                <option value="all">all</option>
+                <option value="draft">draft</option>
+                <option value="published">published</option>
+              </select>
+            </div>
+          </div>
+          <div className="admin-photo-gallery__filter-field">
+            <label htmlFor="admin-photo-featured">featured</label>
+            <div className="admin-photo-gallery__select-wrap">
+              <select
+                id="admin-photo-featured"
+                value={data.filters.featured}
+                onChange={(event) => updateQuery({ featured: event.target.value })}
+              >
+                <option value="all">all</option>
+                <option value="featured">featured</option>
+                <option value="not_featured">not featured</option>
+              </select>
+            </div>
+          </div>
         </div>
       </ScreenFrame>
 
-      <ScreenFrame className="admin-panel">
-        <div className="admin-photo-toolbar">
-          <InlineLabel>records</InlineLabel>
-          <span>
-            page {data.pageInfo.page} / {data.pageInfo.totalPages} // {data.pageInfo.totalItems} total
+      <ScreenFrame className="admin-panel admin-photo-gallery__records">
+        <div className="admin-photo-gallery__records-header">
+          <InlineLabel className="admin-photo-gallery__panel-label">// records</InlineLabel>
+          <span className="admin-photo-gallery__records-count">
+            <span>
+              page {data.pageInfo.page} / {data.pageInfo.totalPages}
+            </span>{' '}
+            // <span>{data.pageInfo.totalItems}</span> total
           </span>
         </div>
 
@@ -121,14 +147,17 @@ export function AdminPhotosGalleryPage() {
           </div>
         ) : (
           <div className="admin-photo-empty">
-            <strong>no photos found</strong>
+            <span className="admin-photo-empty__glyph" aria-hidden="true">
+              ░
+            </span>
+            <strong>no records match filters</strong>
             <span>Adjust the filters or upload a new draft.</span>
           </div>
         )}
 
         <nav className="admin-photo-pagination" aria-label="Admin photos pagination">
           <button type="button" disabled={data.pageInfo.page <= 1} onClick={() => goToPage(data.pageInfo.page - 1)}>
-            previous
+            ← previous
           </button>
           <span aria-live="polite">
             page {data.pageInfo.page} / {data.pageInfo.totalPages}
@@ -138,7 +167,7 @@ export function AdminPhotosGalleryPage() {
             disabled={data.pageInfo.page >= data.pageInfo.totalPages}
             onClick={() => goToPage(data.pageInfo.page + 1)}
           >
-            next
+            next →
           </button>
         </nav>
       </ScreenFrame>

--- a/frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.tsx
+++ b/frontend/src/pages/admin/photos/ui/AdminPhotosGalleryPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { Link, useLoaderData, useLocation, useSearchParams } from 'react-router-dom'
 import { getAdminPhotoOriginalUrl } from '../../../../entities/photo'
 import { ActionButton, InlineLabel, ScreenFrame, Stack } from '../../../../shared/ui'
@@ -19,6 +20,7 @@ export function AdminPhotosGalleryPage() {
   const data = useLoaderData() as AdminPhotosLoaderData
   const location = useLocation()
   const [searchParams, setSearchParams] = useSearchParams()
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid')
 
   const updateQuery = (patch: Record<string, string>) => {
     const next = new URLSearchParams(searchParams)
@@ -112,35 +114,71 @@ export function AdminPhotosGalleryPage() {
       <ScreenFrame className="admin-panel admin-photo-gallery__records">
         <div className="admin-photo-gallery__records-header">
           <InlineLabel className="admin-photo-gallery__panel-label">// records</InlineLabel>
-          <span className="admin-photo-gallery__records-count">
-            <span>
-              page {data.pageInfo.page} / {data.pageInfo.totalPages}
-            </span>{' '}
-            // <span>{data.pageInfo.totalItems}</span> total
-          </span>
+          <div className="admin-photo-gallery__records-tools">
+            <span className="admin-photo-gallery__records-count">
+              <span>
+                page {data.pageInfo.page} / {data.pageInfo.totalPages}
+              </span>{' '}
+              // <span>{data.pageInfo.totalItems}</span> total
+            </span>
+            <div className="admin-photo-view-toggle" role="group" aria-label="Photo presentation view">
+              <button
+                type="button"
+                className={viewMode === 'grid' ? 'is-active' : undefined}
+                aria-pressed={viewMode === 'grid'}
+                onClick={() => setViewMode('grid')}
+              >
+                ▦
+                <span className="sr-only">grid view</span>
+              </button>
+              <button
+                type="button"
+                className={viewMode === 'list' ? 'is-active' : undefined}
+                aria-pressed={viewMode === 'list'}
+                onClick={() => setViewMode('list')}
+              >
+                ☰
+                <span className="sr-only">list view</span>
+              </button>
+            </div>
+          </div>
         </div>
 
         {data.items.length > 0 ? (
-          <div className="admin-photo-grid">
+          <div className={`admin-photo-grid admin-photo-grid--${viewMode}`}>
             {data.items.map((photo) => (
               <Link
                 key={photo.id}
-                className="admin-photo-card"
+                className="admin-photo-card glitch-hover"
                 to={`/admin/photos/${encodeURIComponent(photo.id)}`}
                 state={{ from: `${location.pathname}${location.search}` }}
               >
                 <span className="admin-photo-card__image">
                   <img src={getAdminPhotoOriginalUrl(photo.id)} alt={photo.title} loading="lazy" />
+                  <span className="admin-photo-card__overlay" aria-hidden="true">
+                    open/edit →
+                  </span>
                 </span>
-                <span className="admin-photo-card__body">
-                  <strong>{photo.title}</strong>
-                  <span>
+                <span className="admin-photo-card__info">
+                  <span className="admin-photo-card__title">{photo.title}</span>
+                  <span className="admin-photo-card__meta">
                     {photo.frame} // {photo.location}
                   </span>
-                  <span>
-                    {photo.status} // {photo.featured ? 'featured' : 'not featured'}
+                </span>
+                <span className="admin-photo-card__footer">
+                  <span className="admin-photo-card__badges">
+                    <span className={`admin-photo-badge admin-photo-badge--${photo.status}`}>
+                      <span className="admin-photo-badge__dot" aria-hidden="true" />
+                      {photo.status}
+                    </span>
+                    {photo.featured ? (
+                      <span className="admin-photo-badge admin-photo-badge--featured">
+                        <span aria-hidden="true">◆</span>
+                        featured
+                      </span>
+                    ) : null}
                   </span>
-                  <span>{formatBytes(photo.original.byteSize)}</span>
+                  <span className="admin-photo-card__size">{formatBytes(photo.original.byteSize)}</span>
                 </span>
               </Link>
             ))}


### PR DESCRIPTION
## Summary

Restyles the admin gallery screen at `/admin/photos` to match `references/vinicius.dev.v2/gallery.html` while preserving the existing backend-connected photo workflows.

## Accepted tasks

- `GAL-001` - Rebuilt the admin gallery frame: header, upload action, filters bar, records panel, and tracker/PRD setup.
- `GAL-002` - Restyled gallery cards, badges, hover affordance, empty/pagination states, and added a local-only grid/list presentation toggle.
- `GAL-003` - Hardened admin photo regression coverage for loader query parsing, unauthorized redirects, upload, metadata, and curation actions.
- `GAL-004` - Completed final visual/accessibility/reduced-motion pass and corrected the top layout to remove the extra outer gallery frame.

## Commits

- `e673f27` `PRD-004 GAL-001: rebuild admin gallery frame`
- `540d6d0` `PRD-004 GAL-002: restyle gallery cards`
- `be56609` `PRD-004 GAL-003: harden admin photo regressions`
- `16ea3bf` `PRD-004 GAL-004: finalize gallery visual acceptance`

## Verification

- `cd frontend && bun run test -- AdminPhotosGalleryPage.test.tsx route.test.ts` passed.
- `cd frontend && bun run test` passed.
- `cd frontend && bun run lint` passed.
- `cd frontend && bun run build` passed.

## Notes

- Backend APIs, Prisma schema, auth, media delivery, upload validation, and route contracts were not changed.
- Grid/list mode is local presentation state only and does not mutate query params or backend contracts.
- Hover/card action remains honest navigation to the existing detail/edit route; no fake delete, fake feature, inline edit, bulk action, or client-side filtering was added.
- One unrelated local `.gitignore` modification remains uncommitted and is not part of this PR.